### PR TITLE
Fix issue with MVAPICH2 compiler wrappers when used in the build stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 .coverage
+Dockerfile*
+Singularity*

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -15,13 +15,13 @@ specifying the `--format` command line option.
 
 ```python
 # OpenMPI 3.0.0, with InfiniBand and CUDA enabled, using the latest
-# PGI community edition compiler (17.10)
+# PGI community edition compiler (18.4)
 Stage0.baseimage('nvidia/cuda:9.0-devel')
 
 ospackages = ['make', 'wget']
 Stage0 += apt_get(ospackages=ospackages)
 
-p = pgi(eula=True, version='17.10')
+p = pgi(eula=True, version='18.4')
 Stage0 += p
 
 # Use the PGI toolchain to build OpenMPI                                
@@ -652,7 +652,7 @@ Parameters:
 - `version`: The version of the PGI compiler to use.  Note this value
   is currently only used when setting the environment and does not
   control the version of the compiler downloaded.  The default value
-  is `17.10`.
+  is `18.4`.
 
 Methods:
 
@@ -662,7 +662,7 @@ Methods:
 Examples:
 
 ```python
-pgi(eula=True, version='2017')
+pgi(eula=True, version='18.4')
 ```
 
 ```python

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -212,6 +212,37 @@ Example:
 apt_get(ospackages=['make', 'wget'])
 ```
 
+### cmake
+
+The `cmake` building block downloads and installs the
+[CMake](https://cmake.org) component.
+
+Parameters:
+
+- `eula`: By setting this value to `True`, you agree to the [CMake
+  End-User License
+  Agreement](https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt).
+  The default value is `False`.
+
+- `ospackages`: List of OS packages to install prior to installing.
+  The default value is `wget`.
+
+- `prefix`: The top level install location.  The default value is
+  `/usr/local`.
+
+- `version`: The version of CMake to download.  The default value is
+  `3.11.1`.
+
+Examples:
+
+```python
+cmake(eula=True)
+```
+
+```python
+cmake(eula=True, version='3.10.3')
+```
+
 ### fftw
 
 The `fftw` building block downloads, configures, builds, and installs

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -724,6 +724,41 @@ Stage1 += p.runtime()
 pgi(eula=True, tarball='pgilinux-2017-1710-x86_64.tar.gz')
 ```
 
+### python
+
+The `python` building block installs Python from the upstream Linux
+distribution.
+
+Parameters:
+
+- `python2`: Boolean flag to specify whether to install Python version
+  2.  The default is True.
+
+- `python3`: Boolean flag to specify whether to install Python version
+  3.  The default is True.
+
+Methods:
+
+- `runtime(_from='...')`: Generate the set of instructions to install
+  the runtime specific components from a build in a previous stage.
+
+Examples:
+
+```python
+python()
+```
+
+```python
+p = python()
+Stage0 += p
+...
+Stage1 += p.runtime()
+```
+
+```python
+python(python3=False)
+```
+
 ## Templates
 
 Templates are abstractions of common operations, such as downloading

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -214,10 +214,10 @@ apt_get(ospackages=['make', 'wget'])
 
 ### fftw
 
-The `fftw` building block down configures, builds, and installs the
-[FFTW](http://www.fftw.org) component.  Depending on the parameters,
-the source will be downloaded from the web (default) or copied from a
-source directory in the local build context.
+The `fftw` building block downloads, configures, builds, and installs
+the [FFTW](http://www.fftw.org) component.  Depending on the
+parameters, the source will be downloaded from the web (default) or
+copied from a source directory in the local build context.
 
 As a side effect, this building block modifies `LD_LIBRARY_PATH` to
 include the FFTW build.
@@ -283,8 +283,8 @@ Stage1 += f.runtime()
 
 ### hdf5
 
-The `hdf5` building block down configures, builds, and installs the
-[HDF5](http://www.hdfgroup.org) component.  Depending on the
+The `hdf5` building block downloads, configures, builds, and installs
+the [HDF5](http://www.hdfgroup.org) component.  Depending on the
 parameters, the source will be downloaded from the web (default) or
 copied from a source directory in the local build context.
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -312,6 +312,54 @@ Stage0 += f
 Stage1 += f.runtime()
 ```
 
+### gnu
+
+The `gnu` building block installs the GNU compilers from the upstream
+Linux distribution.
+
+As a side effect, a toolchain is created containing the GNU compilers.
+The toolchain can be passed to other operations that want to build
+using the GNU compilers.
+
+```python
+g = gnu()
+
+operation(..., toolchain=g.toolchain, ...)
+```
+
+Parameters:
+
+- `cc`: Boolean flag to specify whether to install `gcc`.  The default
+  is True.
+
+- `cxx`: Boolean flag to specify whether to install `g++`.  The
+  default is True.
+
+- `fortran`: Boolean flag to specify whether to install `gfortran`.
+  The default is True.
+
+Methods:
+
+- `runtime(_from='...')`: Generate the set of instructions to install
+  the runtime specific components from a build in a previous stage.
+
+Examples:
+
+```python
+gnu()
+```
+
+```python
+g = gnu()
+Stage0 += g
+...
+Stage1 += g.runtime()
+```
+
+```python
+gnu(fortran=False)
+```
+
 ### hdf5
 
 The `hdf5` building block downloads, configures, builds, and installs

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -442,8 +442,8 @@ Parameters:
   `libnuma1`, and `wget`.
 
 - `packages`: List of packages to install from Mellanox OFED.  The
-  default values are `libibverbs1`, `libibverbs-dev`, `libmlx5-1`, and
-  `ibverbs-utils`.
+  default values are `libibverbs1`, `libibverbs-dev`, `libibumad`,
+  `libibmad`, `libmlx5-1`, and `ibverbs-utils`.
 
 - `version`: The version of Mellanox OFED to download.  The default
   value is `3.4-1.0.0.0`.  Only versions that provide an Ubuntu 16.04
@@ -550,6 +550,85 @@ mvapich2(configure_opts=['--disable-fortran', '--disable-mcast'],
 
 ```python
 mv2 = mvapich2()
+Stage0 += mv2
+...
+Stage1 += mv2.runtime()
+```
+
+### mvapich2_gdr
+
+The `mvapich2_gdr` building blocks installs the
+[MVAPICH2-GDR](http://mvapich.cse.ohio-state.edu) component.
+Depending on the parameters, the package will be downloaded from the
+web (default) or copied from the local build context.
+
+MVAPICH2-GDR is distributed as a binary package, so certain
+dependencies need to be met and only certain combinations of recipe
+components are supported; please refer to the MVAPICH2-GDR
+documentation for more information.
+
+The [GNU compiler](#gnu) building block should be installed prior to
+this building block.
+
+The [Mellanox OFED](#mlnx_ofed) building block should be installed
+prior to this building block.
+
+As a side effect, this building block modifies `PATH` and
+`LD_LIBRARY_PATH` to include the MVAPICH2-GDR build.
+
+As a side effect, a toolchain is created containing the MPI compiler
+wrappers.  The toolchain can be passed to other operations that want
+to build using the MPI compiler wrappers.
+
+```python
+mv2 = mvapich2_gdr()
+
+operation(..., toolchain=mv2.toolchain, ...)
+```
+
+Parameters:
+
+- `cuda_version`: The version of CUDA the MVAPICH2-GDR package was
+  built against.  The version string format is X.Y.  The version
+  should match the version of CUDA provided by the base image.  This
+  value is ignored if `package` is set.  The default value is `9.0`.
+
+- `mlnx_ofed_version`: The version of Mellanox OFED the MVAPICH2-GDR
+  package was built against.  The version string format is X.Y.  The
+  version should match the version of Mellanox OFED installed by the
+  `mlnx_ofed` building block.  This value is ignored if `package` is
+  set.  The default value is `3.4`.
+
+- `ospackages`: List of OS packages to install prior to installation.
+  The default values are `openssh-client` and `wget`.
+
+- `package`: Path to the package file relative to the local build
+  context.  The default value is empty.  If this is defined, the
+  package in the local build context will be used rather than
+  downloading the package from the web.  The package should correspond
+  to the other recipe components (e.g., compiler version, CUDA
+  version, Mellanox OFED version).
+
+- `version`: The version of MVAPICH2-GDR to download.  The value is
+  ignored if `package` is set.  The default value is `2.3a`.
+
+Methods:
+
+- `runtime(_from='...')`: Generate the set of instructions to install
+  the runtime specific components from a build in a previous stage.
+
+Examples:
+
+```python
+mvapich2_gdr(version='2.3a')
+```
+
+```python
+mvapich2_gdr(package='mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb')
+```
+
+```python
+mv2 = mvapich2_gdr()
 Stage0 += mv2
 ...
 Stage1 += mv2.runtime()

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -480,6 +480,16 @@ OFED](#mlnx_ofed)) should be installed prior to this building block.
 As a side effect, this building block modifies `PATH` and
 `LD_LIBRARY_PATH` to include the MVAPICH2 build.
 
+As a side effect, a toolchain is created containing the MPI compiler
+wrappers.  The tool can be passed to other operations that want to
+build using the MPI compiler wrappers.
+
+```python
+mv2 = mvapich2()
+
+operation(..., toolchain=mv2.toolchain, ...)
+```
+
 Parameters:
 
 - `check`: Boolean flag to specify whether the `make check` step
@@ -586,6 +596,16 @@ copied from a source directory in the local build context.
 
 As a side effect, this building block modifies `PATH` and
 `LD_LIBRARY_PATH` to include the OpenMPI build.
+
+As a side effect, a toolchain is created containing the MPI compiler
+wrappers.  The tool can be passed to other operations that want to
+build using the MPI compiler wrappers.
+
+```python
+ompi = openmpi()
+
+operation(..., toolchain=ompi.toolchain, ...)
+```
 
 Parameters:
 

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -658,6 +658,8 @@ Templates are not automatically included in the recipe namespace.  The
 
 - `git`: Clone git repositories
 
+- `sed`: Modify files
+
 - `tar`: Work with tarball files
 
 - `toolchain`: Development toolchain environment

--- a/hpccm/Stage.py
+++ b/hpccm/Stage.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Container stage"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -24,39 +24,33 @@ import logging # pylint: disable=unused-import
 from .baseimage import baseimage
 
 class Stage(object):
-    """Documentation TBD"""
+    """Class for the container stage.  Docker may have one or more stages,
+       Singularity will always have a single stage."""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize stage"""
 
         self.__layers = []
         self.name = kwargs.get('name', '')
         self.__separator = kwargs.get('separator', '\n\n')
 
     def __iadd__(self, layer):
-        """Documentation TBD"""
+        """Add the layer to the stage.  Allows "+=" syntax."""
         if isinstance(layer, list):
             self.__layers.extend(layer)
         else:
             self.__layers.append(layer)
         return self
 
+    def __str__(self):
+        """String representation of the stage"""
+        return self.__separator.join(str(x) for x in self.__layers)
+
     def baseimage(self, image):
-        """Documentation TBD"""
+        """Insert the baseimage as the first layer"""
         if image:
             self.__layers.insert(0, baseimage(image=image, _as=self.name))
 
     def is_defined(self):
-        """Documentation TBD"""
-        if self.__layers:
-            return True
-        else:
-            return False
-
-    def toString(self, ctype):
-        """Documentation TBD"""
-        l = []
-        for layer in self.__layers:
-            l.append(layer.toString(ctype))
-
-        return self.__separator.join(l)
+        """Return True if any layers have been defined, otherwise False"""
+        return bool(self.__layers)

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -38,6 +38,7 @@ from .mvapich2 import mvapich2
 from .ofed import ofed
 from .openmpi import openmpi
 from .pgi import pgi
+from .python import python
 from .raw import raw
 from .recipe import recipe
 from .sed import sed

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -24,6 +24,7 @@ from .Stage import Stage
 from .apt_get import apt_get
 from .baseimage import baseimage
 from .blob import blob
+from .cmake import cmake
 from .comment import comment
 from .copy import copy
 from .environment import environment

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -30,6 +30,7 @@ from .copy import copy
 from .environment import environment
 from .fftw import fftw
 from .git import git
+from .gnu import gnu
 from .hdf5 import hdf5
 from .label import label
 from .mlnx_ofed import mlnx_ofed

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -35,6 +35,7 @@ from .hdf5 import hdf5
 from .label import label
 from .mlnx_ofed import mlnx_ofed
 from .mvapich2 import mvapich2
+from .mvapich2_gdr import mvapich2_gdr
 from .ofed import ofed
 from .openmpi import openmpi
 from .pgi import pgi

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -38,6 +38,7 @@ from .openmpi import openmpi
 from .pgi import pgi
 from .raw import raw
 from .recipe import recipe
+from .sed import sed
 from .shell import shell
 from .tar import tar
 from .toolchain import toolchain

--- a/hpccm/apt_get.py
+++ b/hpccm/apt_get.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""apt-get building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -24,18 +24,26 @@ import logging # pylint: disable=unused-import
 from .shell import shell
 
 class apt_get(object):
-    """Documentation TBD"""
+    """apt-get building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         #super(apt_get, self).__init__()
 
         self.__commands = []
         self.ospackages = kwargs.get('ospackages', [])
 
+        # Construct the series of commands that form the building
+        # block
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+        return str(shell(commands=self.__commands))
+
     def __setup(self):
-        """Documentation TBD"""
+        """Construct the series of commands to execute"""
 
         self.__commands.append('apt-get update -y')
         if self.ospackages:
@@ -46,10 +54,3 @@ class apt_get(object):
             install = install + ' \\\n'.join(packages)
             self.__commands.append(install)
         self.__commands.append('rm -rf /var/lib/apt/lists/*')
-
-    def toString(self, ctype):
-        """Documentation TBD"""
-
-        self.__setup()
-        s = shell(commands=self.__commands)
-        return s.toString(ctype)

--- a/hpccm/baseimage.py
+++ b/hpccm/baseimage.py
@@ -14,39 +14,39 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Base image primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class baseimage(object):
-    """Documentation TBD"""
+    """Base image primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize the primitive"""
 
         #super(baseimage, self).__init__()
 
         self.__as = kwargs.get('AS', '') # Docker specific
         self.__as = kwargs.get('_as', self.__as) # Docker specific
-        self.image = kwargs.get('image', 'nvcr.io/nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04')
+        self.image = kwargs.get('image', 'nvidia/cuda:9.0-devel-ubuntu16.04')
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
-        if ctype == container_type.DOCKER:
+    def __str__(self):
+        """String representation of the primitive"""
+        if hpccm.config.g_ctype == container_type.DOCKER:
             image = 'FROM {}'.format(self.image)
 
             if self.__as:
                 image = image + ' AS {}'.format(self.__as)
 
             return image
-        elif ctype == container_type.SINGULARITY:
+        elif hpccm.config.g_ctype == container_type.SINGULARITY:
             return 'BootStrap: docker\nFrom: {}'.format(self.image)
         else:
-            logging.error('Unknown container type')
-            return ''
+            raise RuntimeError('Unknown container type')

--- a/hpccm/blob.py
+++ b/hpccm/blob.py
@@ -14,48 +14,49 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Blob primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class blob(object):
-    """Documentation TBD"""
+    """Blob primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(blob, self).__init__()
 
-        self.docker = kwargs.get('docker', {}) # Docker specific
-        self.singularity = kwargs.get('singularity', {}) # Singularity specific
+        self.__docker = kwargs.get('docker', {}) # Docker specific
+        self.__singularity = kwargs.get('singularity', {}) # Singularity
+                                                           # specific
+
+    def __str__(self):
+        """String representation of the primitive"""
+        if hpccm.config.g_ctype == container_type.DOCKER:
+            return self.__read_blob(self.__docker)
+        if hpccm.config.g_ctype == container_type.SINGULARITY:
+            return self.__read_blob(self.__singularity)
+        else:
+            raise RuntimeError('Unknown container type')
 
     def __read_blob(self, path):
-        """Documentation TBD"""
+        """Read the blob from a file"""
 
-        blob = ''
+        b = ''
         try:
             if path:
                 with open(path, 'r') as f:
-                    blob = f.read()
+                    b = f.read()
             else:
                 logging.warning('Blob file not specified')
         except:
             logging.error('Error opening blob {}'.format(path))
 
-        return blob
-
-    def toString(self, ctype):
-        """Documentation TBD"""
-
-        if ctype == container_type.DOCKER:
-            return self.__read_blob(self.docker)
-        if ctype == container_type.SINGULARITY:
-            return self.__read_blob(self.singularity)
-        else:
-            logging.error('Unknown container type')
-            return ''
+        return b

--- a/hpccm/cmake.py
+++ b/hpccm/cmake.py
@@ -1,0 +1,123 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""CMake building block"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+import re
+
+from .apt_get import apt_get
+from .comment import comment
+from .environment import environment
+from .shell import shell
+from .wget import wget
+
+class cmake(wget):
+    """CMake building block"""
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        # Trouble getting MRO with kwargs working correctly, so just call
+        # the parent class constructors manually for now.
+        #super(cmake, self).__init__(**kwargs)
+        wget.__init__(self, **kwargs)
+
+        self.__baseurl = kwargs.get('baseurl', 'https://cmake.org/files')
+
+        # By setting this value to True, you agree to the CMake
+        # End-User License Agreement
+        # (https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt)
+        self.__eula = kwargs.get('eula', False)
+
+        self.__ospackages = kwargs.get('ospackages', ['wget'])
+        self.__prefix = kwargs.get('prefix', '/usr/local')
+        self.__version = kwargs.get('version', '3.11.1')
+
+        self.__commands = [] # Filled in by __setup()
+        self.__wd = '/tmp' # working directory
+
+    def cleanup_step(self, items=None):
+        """Cleanup temporary files"""
+
+        if not items: # pragma: no cover
+            logging.warning('items are not defined')
+            return ''
+
+        return 'rm -rf {}'.format(' '.join(items))
+
+    def __setup(self):
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
+
+        # Check to see if the setup has already been performed
+        if self.__commands: # pragma: no cover
+            return
+
+        # The download URL has the format contains vMAJOR.MINOR in the
+        # path and the runfile contains MAJOR.MINOR.REVISION, so pull
+        # apart the full version to get the MAJOR and MINOR
+        # components.
+        match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)', self.__version)
+        major_minor = '{0}.{1}'.format(match.groupdict()['major'],
+                                        match.groupdict()['minor'])
+        runfile = 'cmake-{}-Linux-x86_64.sh'.format(self.__version)
+        url = '{0}/v{1}/{2}'.format(self.__baseurl, major_minor, runfile)
+
+        # Download source from web
+        self.__commands.append(self.download_step(url=url,
+                                                  directory=self.__wd))
+
+        # Run the runfile
+        if self.__eula:
+            self.__commands.append(
+                '/bin/sh {0} --prefix={1} --skip-license'.format(
+                    os.path.join(self.__wd, runfile), self.__prefix))
+        else:
+            # This will fail when building the container
+            logging.warning('CMake EULA was not accepted')
+            self.__commands.append(
+                '/bin/sh {0} --prefix={1}'.format(
+                    os.path.join(self.__wd, runfile), self.__prefix))
+
+        # Cleanup runfile
+        self.__commands.append(self.cleanup_step(
+            items=[os.path.join(self.__wd, runfile)]))
+
+    def runtime(self, _from='0'):
+        """Install the runtime from a full build in a previous stage.  In this
+           case there is no difference between the runtime and the
+           full build."""
+        return self
+
+    def toString(self, ctype):
+        """Building block container specification"""
+
+        self.__setup()
+
+        instructions = []
+        instructions.append(comment(
+            'CMake version {}'.format(self.__version)).toString(ctype))
+        instructions.append(apt_get(
+            ospackages=self.__ospackages).toString(ctype))
+        instructions.append(shell(commands=self.__commands).toString(ctype))
+
+        return '\n'.join(instructions)

--- a/hpccm/comment.py
+++ b/hpccm/comment.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Comment primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -23,13 +23,11 @@ import logging  # pylint: disable=unused-import
 import re
 import textwrap
 
-from .common import container_type
-
 class comment(object):
-    """Documentation TBD"""
+    """Comment primitive"""
 
     def __init__(self, *args, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(comment, self).__init__()
 
@@ -40,9 +38,8 @@ class comment(object):
 
         self.__reformat = kwargs.get('reformat', True)
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
+    def __str__(self):
+        """String representation of the primitive"""
         if self.__string:
             # Comments are universal (so far...)
             if self.__reformat:

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+"""Global configuration
 
-"""Common stuff used by multiple parts of HPC Container Maker"""
+Import this as
+import hpccm.config
 
-from enum import Enum
+And access variables as
+hpccm.config.var
+"""
 
-class container_type(Enum):
-    """Supported container types"""
-    DOCKER = 1
-    SINGULARITY = 2
+from hpccm.common import container_type
+
+# Global variables
+g_ctype = container_type.DOCKER  # Container type

--- a/hpccm/environment.py
+++ b/hpccm/environment.py
@@ -14,20 +14,22 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Environment primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class environment(object):
-    """Documentation TBD"""
+    """Environment primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(environment, self).__init__()
 
@@ -37,17 +39,16 @@ class environment(object):
         # this variable is True, then also generate a '%post' section
         # to set the variables for the build context.
         self.__export = kwargs.get('_export', True) # Singularity specific
-        self.variables = kwargs.get('variables', {})
+        self.__variables = kwargs.get('variables', {})
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
-        if self.variables:
+    def __str__(self):
+        """String representation of the primitive"""
+        if self.__variables:
             keyvals = []
-            for key, val in sorted(self.variables.items()):
+            for key, val in sorted(self.__variables.items()):
                 keyvals.append('{0}={1}'.format(key, val))
 
-            if ctype == container_type.DOCKER:
+            if hpccm.config.g_ctype == container_type.DOCKER:
                 # Format:
                 # ENV K1=V1 \
                 #     K2=V2 \
@@ -55,7 +56,7 @@ class environment(object):
                 environ = ['ENV {}'.format(keyvals[0])]
                 environ.extend(['    {}'.format(x) for x in keyvals[1:]])
                 return ' \\\n'.join(environ)
-            elif ctype == container_type.SINGULARITY:
+            elif hpccm.config.g_ctype == container_type.SINGULARITY:
                 # Format:
                 # %environment
                 #     export K1=V1
@@ -70,10 +71,10 @@ class environment(object):
 
                 if self.__export:
                     environ.extend(['%post'])
-                    environ.extend(['    export {}'.format(x) for x in keyvals])
+                    environ.extend(['    export {}'.format(x)
+                                    for x in keyvals])
                 return '\n'.join(environ)
             else:
-                logging.error('Unknown container type')
-                return ''
+                raise RuntimeError('Unknown container type')
         else:
             return ''

--- a/hpccm/fftw.py
+++ b/hpccm/fftw.py
@@ -64,6 +64,30 @@ class fftw(ConfigureMake, tar, wget):
             '{}:$LD_LIBRARY_PATH'.format(os.path.join(self.prefix, 'lib'))}
         self.__wd = '/tmp' # working directory
 
+        # Construct series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+        instructions = []
+        if self.__directory:
+            instructions.append(comment('FFTW'))
+        else:
+            instructions.append(
+                comment('FFTW version {}'.format(self.__version)))
+        instructions.append(apt_get(ospackages=self.__ospackages))
+        if self.__directory:
+            # Use source from local build context
+            instructions.append(
+                copy(src=self.__directory,
+                     dest=os.path.join(self.__wd,
+                                       self.__directory)))
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(
+            environment(variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
     def cleanup_step(self, items=None):
         """Cleanup temporary files"""
 
@@ -100,7 +124,7 @@ class fftw(ConfigureMake, tar, wget):
 
         # Check the build
         if self.__check:
-            # PGI compiler needs a larger stack size 
+            # PGI compiler needs a larger stack size
             self.__commands.append('ulimit -s unlimited')
             self.__commands.append(self.check_step())
 
@@ -126,28 +150,3 @@ class fftw(ConfigureMake, tar, wget):
         instructions.append(environment(
             variables=self.__environment_variables))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        self.__setup()
-
-        instructions = []
-        if self.__directory:
-            instructions.append(comment('FFTW').toString(ctype))
-        else:
-            instructions.append(comment(
-                'FFTW version {}'.format(self.__version)).toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.__ospackages).toString(ctype))
-        if self.__directory:
-            # Use source from local build context
-            instructions.append(
-                copy(src=self.__directory,
-                     dest=os.path.join(self.__wd,
-                                       self.__directory)).toString(ctype))
-        instructions.append(shell(commands=self.__commands).toString(ctype))
-        instructions.append(environment(
-            variables=self.__environment_variables).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/fftw.py
+++ b/hpccm/fftw.py
@@ -15,7 +15,7 @@
 # pylint: disable=invalid-name, too-few-public-methods
 # pylint: disable=too-many-instance-attributes
 
-"""Documentation TBD"""
+"""FFTW building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -34,10 +34,10 @@ from .toolchain import toolchain
 from .wget import wget
 
 class fftw(ConfigureMake, tar, wget):
-    """Documentation TBD"""
+    """FFTW building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         # Trouble getting MRO with kwargs working correctly, so just call
         # the parent class constructors manually for now.
@@ -65,16 +65,17 @@ class fftw(ConfigureMake, tar, wget):
         self.__wd = '/tmp' # working directory
 
     def cleanup_step(self, items=None):
-        """Documentation TBD"""
+        """Cleanup temporary files"""
 
-        if not items:
+        if not items: # pragma: no cover
             logging.warning('items are not defined')
             return ''
 
         return 'rm -rf {}'.format(' '.join(items))
 
     def __setup(self):
-        """Documentation TBD"""
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
 
         tarball = 'fftw-{}.tar.gz'.format(self.__version)
         url = '{0}/{1}'.format(self.__baseurl, tarball)
@@ -117,7 +118,7 @@ class fftw(ConfigureMake, tar, wget):
                                     'fftw-{}'.format(self.__version))]))
 
     def runtime(self, _from='0'):
-        """Documentation TBD"""
+        """Install the runtime from a full build in a previous stage"""
         instructions = []
         instructions.append(comment('FFTW'))
         instructions.append(copy(_from=_from, src=self.prefix,
@@ -127,7 +128,7 @@ class fftw(ConfigureMake, tar, wget):
         return instructions
 
     def toString(self, ctype):
-        """Documentation TBD"""
+        """Building block container specification"""
 
         self.__setup()
 

--- a/hpccm/gnu.py
+++ b/hpccm/gnu.py
@@ -60,19 +60,16 @@ class gnu(object):
             self.toolchain.F90 = 'gfortran'
             self.toolchain.FC = 'gfortran'
 
+    def __str__(self):
+        """String representation of the building block"""
+        instructions = []
+        instructions.append(comment('GNU compiler'))
+        instructions.append(apt_get(ospackages=self.__compiler_packages))
+        return '\n'.join(str(x) for x in instructions)
+
     def runtime(self, _from='0'):
         """Runtime specification"""
         instructions = []
         instructions.append(comment('GNU compiler runtime'))
         instructions.append(apt_get(ospackages=self.__runtime_packages))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        instructions = []
-        instructions.append(comment('GNU compiler').toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.__compiler_packages).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/gnu.py
+++ b/hpccm/gnu.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""GNU compiler building block"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+from .apt_get import apt_get
+from .comment import comment
+from .toolchain import toolchain
+
+class gnu(object):
+    """GNU compiler building block"""
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        # Trouble getting MRO with kwargs working correctly, so just call
+        # the parent class constructors manually for now.
+        #super(gnu, self).__init__(**kwargs)
+
+        self.__cc = kwargs.get('cc', True)
+        self.__cxx = kwargs.get('cxx', True)
+        self.__fortran = kwargs.get('fortran', True)
+
+        self.__compiler_packages = [] # Filled in below
+        self.__runtime_packages = ['libgomp1']
+
+        # Output toolchain
+        self.toolchain = toolchain()
+
+        if self.__cc:
+            self.__compiler_packages.append('gcc')
+            self.toolchain.CC = 'gcc'
+
+        if self.__cxx:
+            self.__compiler_packages.append('g++')
+            self.toolchain.CXX = 'g++'
+
+        if self.__fortran:
+            self.__compiler_packages.append('gfortran')
+            self.__runtime_packages.append('libgfortran3')
+            self.toolchain.F77 = 'gfortran'
+            self.toolchain.F90 = 'gfortran'
+            self.toolchain.FC = 'gfortran'
+
+    def runtime(self, _from='0'):
+        """Runtime specification"""
+        instructions = []
+        instructions.append(comment('GNU compiler runtime'))
+        instructions.append(apt_get(ospackages=self.__runtime_packages))
+        return instructions
+
+    def toString(self, ctype):
+        """Building block container specification"""
+
+        instructions = []
+        instructions.append(comment('GNU compiler').toString(ctype))
+        instructions.append(apt_get(
+            ospackages=self.__compiler_packages).toString(ctype))
+
+        return '\n'.join(instructions)

--- a/hpccm/hdf5.py
+++ b/hpccm/hdf5.py
@@ -15,7 +15,7 @@
 # pylint: disable=invalid-name, too-few-public-methods
 # pylint: disable=too-many-instance-attributes
 
-"""Documentation TBD"""
+"""HDF5 building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -35,10 +35,10 @@ from .toolchain import toolchain
 from .wget import wget
 
 class hdf5(ConfigureMake, tar, wget):
-    """Documentation TBD"""
+    """HDF5 building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         # Trouble getting MRO with kwargs working correctly, so just call
         # the parent class constructors manually for now.
@@ -69,16 +69,17 @@ class hdf5(ConfigureMake, tar, wget):
         self.__wd = '/tmp' # working directory
 
     def cleanup_step(self, items=None):
-        """Documentation TBD"""
+        """Cleanup temporary files"""
 
-        if not items:
+        if not items: # pragma: no cover
             logging.warning('items are not defined')
             return ''
 
         return 'rm -rf {}'.format(' '.join(items))
 
     def __setup(self):
-        """Documentation TBD"""
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
 
         # The download URL has the format contains vMAJOR.MINOR in the
         # path and the tarball contains MAJOR.MINOR.REVISION, so pull
@@ -127,7 +128,7 @@ class hdf5(ConfigureMake, tar, wget):
                                     'hdf5-{}'.format(self.__version))]))
 
     def runtime(self, _from='0'):
-        """Documentation TBD"""
+        """Install the runtime from a full build in a previous stage"""
         instructions = []
         instructions.append(comment('HDF5'))
         # TODO: move the definition of runtime ospackages
@@ -139,7 +140,7 @@ class hdf5(ConfigureMake, tar, wget):
         return instructions
 
     def toString(self, ctype):
-        """Documentation TBD"""
+        """Building block container specification"""
 
         self.__setup()
 

--- a/hpccm/hdf5.py
+++ b/hpccm/hdf5.py
@@ -68,6 +68,33 @@ class hdf5(ConfigureMake, tar, wget):
             '{}:$LD_LIBRARY_PATH'.format(os.path.join(self.prefix, 'lib'))}
         self.__wd = '/tmp' # working directory
 
+        # Construct the series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        if self.__directory:
+            instructions.append(comment('HDF5'))
+        else:
+            instructions.append(comment(
+                'HDF5 version {}'.format(self.__version)))
+
+        instructions.append(apt_get(ospackages=self.__ospackages))
+
+        if self.__directory:
+            # Use source from local build context
+            instructions.append(
+                copy(src=self.__directory,
+                     dest=os.path.join(self.__wd, self.__directory)))
+
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
     def cleanup_step(self, items=None):
         """Cleanup temporary files"""
 
@@ -86,7 +113,7 @@ class hdf5(ConfigureMake, tar, wget):
         # apart the full version to get the MAJOR and MINOR components.
         match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)', self.__version)
         major_minor = '{0}.{1}'.format(match.groupdict()['major'],
-                                        match.groupdict()['minor'])
+                                       match.groupdict()['minor'])
         tarball = 'hdf5-{}.tar.bz2'.format(self.__version)
         url = '{0}/hdf5-{1}/hdf5-{2}/src/{3}'.format(self.__baseurl,
                                                      major_minor,
@@ -138,28 +165,3 @@ class hdf5(ConfigureMake, tar, wget):
         instructions.append(environment(
             variables=self.__environment_variables))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        self.__setup()
-
-        instructions = []
-        if self.__directory:
-            instructions.append(comment('HDF5').toString(ctype))
-        else:
-            instructions.append(comment(
-                'HDF5 version {}'.format(self.__version)).toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.__ospackages).toString(ctype))
-        if self.__directory:
-            # Use source from local build context
-            instructions.append(
-                copy(src=self.__directory,
-                     dest=os.path.join(self.__wd,
-                                       self.__directory)).toString(ctype))
-        instructions.append(shell(commands=self.__commands).toString(ctype))
-        instructions.append(environment(
-            variables=self.__environment_variables).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/label.py
+++ b/hpccm/label.py
@@ -14,56 +14,57 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Label primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class label(object):
-    """Documentation TBD"""
+    """Label primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(label, self).__init__()
 
-        self.metadata = kwargs.get('metadata', {})
+        self.__metadata = kwargs.get('metadata', {})
 
-    def toString(self, ctype):
-        """Documentation TBD"""
+    def __str__(self):
+        """String representation of the primitive"""
 
-        if self.metadata:
-            if ctype == container_type.DOCKER:
+        if self.__metadata:
+            if hpccm.config.g_ctype == container_type.DOCKER:
                 # Format:
                 # LABEL K1=V1 \
                 #     K2=V2 \
                 #     K3=V3
                 keyvals = []
-                for key, val in sorted(self.metadata.items()):
+                for key, val in sorted(self.__metadata.items()):
                     keyvals.append('{0}={1}'.format(key, val))
 
-                label = ['LABEL {}'.format(keyvals[0])]
-                label.extend(['    {}'.format(x) for x in keyvals[1:]])
-                return ' \\\n'.join(label)
-            elif ctype == container_type.SINGULARITY:
+                l = ['LABEL {}'.format(keyvals[0])]
+                l.extend(['    {}'.format(x) for x in keyvals[1:]])
+                return ' \\\n'.join(l)
+            elif hpccm.config.g_ctype == container_type.SINGULARITY:
                 # Format:
                 # %labels
                 #     K1 V1
                 #     K2 V2
                 #     K3 V3
                 keyvals = []
-                for key, val in sorted(self.metadata.items()):
+                for key, val in sorted(self.__metadata.items()):
                     keyvals.append('{0} {1}'.format(key, val))
 
-                label = ['%labels']
-                label.extend(['    {}'.format(x) for x in keyvals])
-                return '\n'.join(label)
+                l = ['%labels']
+                l.extend(['    {}'.format(x) for x in keyvals])
+                return '\n'.join(l)
             else:
-                logging.error('Unknown container type')
-                return ''
+                raise RuntimeError('Unknown container type')
         else:
             return ''

--- a/hpccm/mlnx_ofed.py
+++ b/hpccm/mlnx_ofed.py
@@ -53,6 +53,20 @@ class mlnx_ofed(tar, wget):
         self.__commands = []
         self.__wd = '/tmp'
 
+        # Construct the series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        instructions.append(comment(
+            'Mellanox OFED version {}'.format(self.__version)))
+        instructions.append(apt_get(ospackages=self.__ospackages))
+        instructions.append(shell(commands=self.__commands))
+
+        return '\n'.join(str(x) for x in instructions)
+
     def __cleanup_step(self, items=None):
         """Cleanup temporary files"""
 
@@ -65,10 +79,6 @@ class mlnx_ofed(tar, wget):
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
            self.__commands"""
-
-        # Check to see if the setup has already been performed
-        if self.__commands:
-            return
 
         # This is Ubuntu 16.04 specific.  This should be generic.
         prefix = 'MLNX_OFED_LINUX-{}-ubuntu16.04-x86_64'.format(self.__version)
@@ -96,17 +106,3 @@ class mlnx_ofed(tar, wget):
     def runtime(self, _from='0'):
         """Install the runtime from a full build in a previous stage"""
         return self
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        self.__setup()
-
-        instructions = []
-        instructions.append(comment(
-            'Mellanox OFED version {}'.format(self.__version)).toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.__ospackages).toString(ctype))
-        instructions.append(shell(commands=self.__commands).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/mlnx_ofed.py
+++ b/hpccm/mlnx_ofed.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Mellanox OFED building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -29,10 +29,10 @@ from .tar import tar
 from .wget import wget
 
 class mlnx_ofed(tar, wget):
-    """Documentation TBD"""
+    """Mellanox OFED building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         # Trouble getting MRO with kwargs working correctly, so just call
         # the parent class constructors manually for now.
@@ -54,16 +54,17 @@ class mlnx_ofed(tar, wget):
         self.__wd = '/tmp'
 
     def __cleanup_step(self, items=None):
-        """Documentation TBD"""
+        """Cleanup temporary files"""
 
-        if not items:
+        if not items: # pragma: no cover
             logging.warning('items are not defined')
             return ''
 
         return 'rm -rf {}'.format(' '.join(items))
 
     def __setup(self):
-        """Documentation TBD"""
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
 
         # Check to see if the setup has already been performed
         if self.__commands:
@@ -93,11 +94,11 @@ class mlnx_ofed(tar, wget):
                    os.path.join(self.__wd, prefix)]))
 
     def runtime(self, _from='0'):
-        """Documentation TBD"""
+        """Install the runtime from a full build in a previous stage"""
         return self
 
     def toString(self, ctype):
-        """Documentation TBD"""
+        """Building block container specification"""
 
         self.__setup()
 

--- a/hpccm/mlnx_ofed.py
+++ b/hpccm/mlnx_ofed.py
@@ -47,6 +47,7 @@ class mlnx_ofed(tar, wget):
                                         'libnuma1', 'wget'])
         self.__packages = kwargs.get('packages',
                                      ['libibverbs1', 'libibverbs-dev',
+                                      'libibumad', 'libibmad',
                                       'libmlx5-1', 'ibverbs-utils'])
         self.__version = kwargs.get('version', '3.4-1.0.0.0')
 

--- a/hpccm/mvapich2.py
+++ b/hpccm/mvapich2.py
@@ -76,6 +76,30 @@ class mvapich2(ConfigureMake, tar, wget):
         self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',
                                    F90='mpif90', FC='mpifort')
 
+        # Construct the series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        if self.directory:
+            instructions.append(comment('MVAPICH2'))
+        else:
+            instructions.append(comment(
+                'MVAPICH2 version {}'.format(self.version)))
+        instructions.append(apt_get(ospackages=self.ospackages))
+        if self.directory:
+            # Use source from local build context
+            instructions.append(
+                copy(src=self.directory,
+                     dest=os.path.join(self.__wd, self.directory)))
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
     def cleanup_step(self, items=None):
         """Cleanup temporary files"""
 
@@ -147,28 +171,3 @@ class mvapich2(ConfigureMake, tar, wget):
         instructions.append(environment(
             variables=self.__environment_variables))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        self.__setup()
-
-        instructions = []
-        if self.directory:
-            instructions.append(comment('MVAPICH2').toString(ctype))
-        else:
-            instructions.append(comment(
-                'MVAPICH2 version {}'.format(self.version)).toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.ospackages).toString(ctype))
-        if self.directory:
-            # Use source from local build context
-            instructions.append(
-                copy(src=self.directory,
-                     dest=os.path.join(self.__wd,
-                                       self.directory)).toString(ctype))
-        instructions.append(shell(commands=self.__commands).toString(ctype))
-        instructions.append(environment(
-            variables=self.__environment_variables).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/mvapich2_gdr.py
+++ b/hpccm/mvapich2_gdr.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""MVAPICH2-GDR building block"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+import re
+
+from .apt_get import apt_get
+from .comment import comment
+from .copy import copy
+from .environment import environment
+from .shell import shell
+from .toolchain import toolchain
+from .wget import wget
+
+class mvapich2_gdr(wget):
+    """MVAPICH2-GDR building block"""
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        # Trouble getting MRO with kwargs working correctly, so just call
+        # the parent class constructors manually for now.
+        #super(mvapich2_gdr, self).__init__(**kwargs)
+        wget.__init__(self, **kwargs)
+
+        self.__baseurl = kwargs.get('baseurl',
+                                    'http://mvapich.cse.ohio-state.edu/download/mvapich/gdr')
+        self.__cuda_version = kwargs.get('cuda_version', '9.0')
+        self.__gnu = kwargs.get('gnu', True)
+        self.__gnu_version = '4.8.5'
+        self.__mofed_version = kwargs.get('mlnx_ofed_version', '3.4')
+        self.__ospackages = kwargs.get('ospackages',
+                                       ['openssh-client', 'wget'])
+        self.__package = kwargs.get('package', '')
+        self.__pgi = kwargs.get('pgi', False)
+        self.__pgi_version = '17.10'
+        self.version = kwargs.get('version', '2.3a')
+        self.__wd = '/tmp' # working directory
+
+        # Output toolchain
+        self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',
+                                   F90='mpif90', FC='mpifort')
+
+        # Validate compiler choice
+        if self.__gnu and self.__pgi:
+            logging.warning('Multiple compilers selected, using PGI')
+            self.__gnu = False
+        elif not self.__gnu and not self.__pgi:
+            logging.warning('No compiler selected, using GNU')
+            self.__gnu = True
+
+        self.__commands = []              # Filled in by __setup()
+        self.__environment_variables = {} # Filled in by __setup()
+        self.__install_path = ''          # Filled in by __setup()
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        if self.__package:
+            instructions.append(comment('MVAPICH2-GDR'))
+        else:
+            instructions.append(comment(
+                'MVAPICH2-GDR version {}'.format(self.version)))
+
+        instructions.append(apt_get(ospackages=self.__ospackages))
+
+        if self.__package:
+            # Use source from local build context
+            instructions.append(copy(src=self.__package,
+                                     dest=os.path.join(self.__wd,
+                                                       self.__package)))
+
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
+    def cleanup_step(self, items=None):
+        """Cleanup temporary files"""
+
+        if not items: # pragma: no cover
+            logging.warning('items are not defined')
+            return ''
+
+        return 'rm -rf {}'.format(' '.join(items))
+
+    def __setup(self):
+        """Construct the series of shell commands and environment variables,
+           i.e., fill in self.__commands and self.__environment_variables"""
+
+        if self.__package:
+            # Install a package from the local build context
+            package = self.__package
+
+            # Deduce version strings from package name
+            match = re.search(r'(?P<cuda>cuda\d+\.\d+)\.(?P<mofed>mofed\d+\.\d+)\.(?P<compiler>(gnu\d+\.\d+\.\d+)|(pgi\d+\.\d+))', package)
+            cuda_string = match.groupdict()['cuda']
+            mofed_string = match.groupdict()['mofed']
+            compiler_string = match.groupdict()['compiler']
+        else:
+            # Download a package
+
+            # Build the version strings based on the specified options
+            if self.__gnu:
+                compiler_string = 'gnu{}'.format(self.__gnu_version)
+            elif self.__pgi:
+                compiler_string = 'pgi{}'.format(self.__pgi_version)
+            else:
+                logging.error('Unknown compiler')
+                compiler_string = 'unknown'
+
+            cuda_string = 'cuda{}'.format(self.__cuda_version)
+            mofed_string = 'mofed{}'.format(self.__mofed_version)
+
+            # Package filename
+            package = 'mvapich2-gdr-mcast.{0}.{1}.{2}_{3}-1.el7.centos_amd64.deb'.format(cuda_string, mofed_string, compiler_string, self.version)
+        
+            # Download source from web
+            url = '{0}/{1}/{2}/{3}'.format(self.__baseurl, self.version,
+                                           mofed_string, package)
+            self.__commands.append(self.download_step(url=url,
+                                                      directory=self.__wd))
+
+        # Install the package
+        self.__commands.append('dpkg --install {0}'.format(
+            os.path.join(self.__wd, package)))
+
+        # Workaround for bad path in the MPI compiler wrappers
+        self.__commands.append('(test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash)')
+
+        # Workaround for using compiler wrappers in the build stage
+        cuda_home = '/usr/local/cuda'
+        self.__commands.append('ln -s {0} {1}'.format(
+            os.path.join(cuda_home, 'lib64', 'stubs', 'nvidia-ml.so'),
+            os.path.join(cuda_home, 'lib64', 'stubs', 'nvidia-ml.so.1')))
+
+        # Cleanup
+        self.__commands.append(self.cleanup_step(
+            items=[os.path.join(self.__wd, package)]))
+
+        # Setup environment variables
+        self.__install_path = os.path.join('/opt', 'mvapich2', 'gdr',
+                                           self.version, 'mcast', 'no-openacc',
+                                           cuda_string, mofed_string,
+                                           'mpirun', compiler_string)
+        self.__environment_variables = {
+            'LD_LIBRARY_PATH':
+            '{}:$LD_LIBRARY_PATH'.format(os.path.join(self.__install_path,
+                                                      'lib64')),
+            'MV2_USE_GPUDIRECT': 0,
+            'MV2_USE_GPUDIRECT_GDRCOPY': 0,
+            'PATH': '{}:$PATH'.format(os.path.join(self.__install_path,
+                                                   'bin')),
+            # Workaround for using compiler wrappers in the build stage
+            'PROFILE_POSTLIB': '"-L{} -lnvidia-ml"'.format(
+                '/usr/local/cuda/lib64/stubs')}
+
+    def runtime(self, _from='0'):
+        """Install the runtime from a full build in a previous stage"""
+        instructions = []
+        instructions.append(comment('MVAPICH2-GDR'))
+        # TODO: move the definition of runtime ospackages
+        instructions.append(apt_get(ospackages=['openssh-client']))
+        instructions.append(copy(src=self.__install_path,
+                                 dest=self.__install_path, _from=_from))
+        # No need to workaround compiler wrapper issue for the runtime.
+        # Copy the dictionary so not to modify the original.
+        vars = dict(self.__environment_variables)
+        del vars['PROFILE_POSTLIB']
+        instructions.append(environment(variables=vars))
+        return instructions

--- a/hpccm/ofed.py
+++ b/hpccm/ofed.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""OFED building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -25,10 +25,10 @@ from .apt_get import apt_get
 from .comment import comment
 
 class ofed(object):
-    """Documentation TBD"""
+    """OFED building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         # Trouble getting MRO with kwargs working correctly, so just call
         # the parent class constructors manually for now.
@@ -46,11 +46,11 @@ class ofed(object):
                                         'opensm', 'rdmacm-utils'])
 
     def runtime(self, _from='0'):
-        """Documentation TBD"""
+        """Install the runtime from a full build in a previous stage"""
         return self
 
     def toString(self, ctype):
-        """Documentation TBD"""
+        """Building block container specification"""
 
         instructions = []
         instructions.append(comment('OFED').toString(ctype))

--- a/hpccm/ofed.py
+++ b/hpccm/ofed.py
@@ -45,16 +45,13 @@ class ofed(object):
                                         'librdmacm1', 'librdmacm-dev',
                                         'opensm', 'rdmacm-utils'])
 
+    def __str__(self):
+        """String representation of the building block"""
+        instructions = []
+        instructions.append(comment('OFED'))
+        instructions.append(apt_get(ospackages=self.__ospackages))
+        return '\n'.join(str(x) for x in instructions)
+
     def runtime(self, _from='0'):
         """Install the runtime from a full build in a previous stage"""
         return self
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        instructions = []
-        instructions.append(comment('OFED').toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.__ospackages).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/openmpi.py
+++ b/hpccm/openmpi.py
@@ -76,6 +76,29 @@ class openmpi(ConfigureMake, tar, wget):
         self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',
                                    F90='mpif90', FC='mpifort')
 
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        if self.directory:
+            instructions.append(comment('OpenMPI'))
+        else:
+            instructions.append(comment(
+                'OpenMPI version {}'.format(self.version)))
+        instructions.append(apt_get(ospackages=self.ospackages))
+        if self.directory:
+            # Use source from local build context
+            instructions.append(
+                copy(src=self.directory,
+                     dest=os.path.join(self.__wd, self.directory)))
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
     def cleanup_step(self, items=None):
         """Cleanup temporary files"""
 
@@ -160,28 +183,3 @@ class openmpi(ConfigureMake, tar, wget):
         instructions.append(environment(
             variables=self.__environment_variables))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-
-        self.__setup()
-
-        instructions = []
-        if self.directory:
-            instructions.append(comment('OpenMPI').toString(ctype))
-        else:
-            instructions.append(comment(
-                'OpenMPI version {}'.format(self.version)).toString(ctype))
-        instructions.append(apt_get(
-            ospackages=self.ospackages).toString(ctype))
-        if self.directory:
-            # Use source from local build context
-            instructions.append(
-                copy(src=self.directory,
-                     dest=os.path.join(self.__wd,
-                                       self.directory)).toString(ctype))
-        instructions.append(shell(commands=self.__commands).toString(ctype))
-        instructions.append(environment(
-            variables=self.__environment_variables).toString(ctype))
-
-        return '\n'.join(instructions)

--- a/hpccm/pgi.py
+++ b/hpccm/pgi.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""PGI building block"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -22,8 +22,6 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import re
 import os
-
-from enum import Enum
 
 from .apt_get import apt_get
 from .comment import comment
@@ -35,10 +33,10 @@ from .toolchain import toolchain
 from .wget import wget
 
 class pgi(tar, wget):
-    """Documentation TBD"""
+    """PGI building block"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize building block"""
 
         # Trouble getting MRO with kwargs working correctly, so just call
         # the parent class constructors manually for now.
@@ -67,7 +65,7 @@ class pgi(tar, wget):
                                    F90='pgfortran', FC='pgfortran')
 
     def cleanup_step(self, items=None):
-        """Documentation TBD"""
+        """Cleanup temporary files"""
 
         if not items: # pragma: no cover
             logging.warning('items are not defined')
@@ -76,7 +74,8 @@ class pgi(tar, wget):
         return 'rm -rf {}'.format(' '.join(items))
 
     def __setup(self):
-        """Documentation TBD"""
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
 
         if self.__tarball:
             # Use tarball from local build context
@@ -114,7 +113,7 @@ class pgi(tar, wget):
             items=[os.path.join(self.__wd, tarball), self.__wd]))
 
     def runtime(self, _from='0'):
-        """Documentation TBD"""
+        """Install the runtime from a full build in a previous stage"""
         instructions = []
         instructions.append(comment('PGI compiler'))
         if self.__ospackages:
@@ -140,7 +139,7 @@ class pgi(tar, wget):
         return instructions
 
     def toString(self, ctype):
-        """Documentation TBD"""
+        """Building block container specification"""
 
         self.__setup()
         ospackages = list(self.__ospackages)

--- a/hpccm/pgi.py
+++ b/hpccm/pgi.py
@@ -54,15 +54,13 @@ class pgi(tar, wget):
         self.__eula = kwargs.get('eula', False)
 
         self.__ospackages = kwargs.get('ospackages', ['libnuma1'])
-        self.__referer = 'http://www.pgroup.com/products/community.htm'
+        self.__referer = r'https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155'
         self.__tarball = kwargs.get('tarball', '')
-        self.__url = 'http://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64'
+        self.__url = 'https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64'
 
         # The version is fragile since the latest version is
         # automatically downloaded, which may not match this default.
-        # This will need to be updated to 2018 once the community
-        # version is updated.
-        self.__version = kwargs.get('version', '17.10')
+        self.__version = kwargs.get('version', '18.4')
         self.__wd = '/tmp/pgi' # working directory
 
         self.toolchain = toolchain(CC='pgcc', CXX='pgc++', F77='pgfortran',

--- a/hpccm/python.py
+++ b/hpccm/python.py
@@ -46,17 +46,17 @@ class python(object):
         if self.__python3:
             self.__packages.append('python3')
 
+    def __str__(self):
+        """String representation of the building block"""
+        instructions = []
+        instructions.append(comment('Python'))
+        instructions.append(apt_get(ospackages=self.__packages))
+
+        return '\n'.join([str(x) for x in instructions])
+
     def runtime(self, _from='0'):
         """Runtime specification"""
         instructions = []
         instructions.append(comment('Python'))
         instructions.append(apt_get(ospackages=self.__packages))
         return instructions
-
-    def toString(self, ctype):
-        """Building block container specification"""
-        instructions = []
-        instructions.append(comment('Python'))
-        instructions.append(apt_get(ospackages=self.__packages))
-
-        return '\n'.join([x.toString(ctype) for x in instructions])

--- a/hpccm/python.py
+++ b/hpccm/python.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""Python building block"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+from .apt_get import apt_get
+from .comment import comment
+
+class python(object):
+    """Python building block"""
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        # Trouble getting MRO with kwargs working correctly, so just call
+        # the parent class constructors manually for now.
+        #super(python, self).__init__(**kwargs)
+
+        self.__python2 = kwargs.get('python2', True)
+        self.__python3 = kwargs.get('python3', True)
+
+        self.__packages = [] # Filled in below
+
+        if self.__python2:
+            self.__packages.append('python')
+
+        if self.__python3:
+            self.__packages.append('python3')
+
+    def runtime(self, _from='0'):
+        """Runtime specification"""
+        instructions = []
+        instructions.append(comment('Python'))
+        instructions.append(apt_get(ospackages=self.__packages))
+        return instructions
+
+    def toString(self, ctype):
+        """Building block container specification"""
+        instructions = []
+        instructions.append(comment('Python'))
+        instructions.append(apt_get(ospackages=self.__packages))
+
+        return '\n'.join([x.toString(ctype) for x in instructions])

--- a/hpccm/raw.py
+++ b/hpccm/raw.py
@@ -14,33 +14,34 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Raw primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class raw(object):
-    """Documentation TBD"""
+    """Raw primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Raw primitive"""
 
         #super(raw, self).__init__()
 
-        self.docker = kwargs.get('docker', '') # Docker specific
-        self.singularity = kwargs.get('singularity', '') # Singularity specific
+        self.__docker = kwargs.get('docker', '') # Docker specific
+        self.__singularity = kwargs.get('singularity', '') # Singularity
+                                                           # specific
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
-        if ctype == container_type.DOCKER:
-            return self.docker
-        elif ctype == container_type.SINGULARITY:
-            return self.singularity
+    def __str__(self):
+        """String representation of the primitive"""
+        if hpccm.config.g_ctype == container_type.DOCKER:
+            return str(self.__docker)
+        elif hpccm.config.g_ctype == container_type.SINGULARITY:
+            return str(self.__singularity)
         else:
-            logging.error('Unknown container type')
-            return ''
+            raise RuntimeError('Unknown container type')

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -43,6 +43,7 @@ from .hdf5 import hdf5               # pylint: disable=unused-import
 from .label import label             # pylint: disable=unused-import
 from .mlnx_ofed import mlnx_ofed     # pylint: disable=unused-import
 from .mvapich2 import mvapich2       # pylint: disable=unused-import
+from .mvapich2_gdr import mvapich2_gdr # pylint: disable=unused-import
 from .ofed import ofed               # pylint: disable=unused-import
 from .openmpi import openmpi         # pylint: disable=unused-import
 from .pgi import pgi                 # pylint: disable=unused-import

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -35,6 +35,7 @@ from .copy import copy               # pylint: disable=unused-import
 from .environment import environment # pylint: disable=unused-import
 from .fftw import fftw               # pylint: disable=unused-import
 from .git import git                 # pylint: disable=unused-import
+from .gnu import gnu                 # pylint: disable=unused-import
 from .hdf5 import hdf5               # pylint: disable=unused-import
 from .label import label             # pylint: disable=unused-import
 from .mlnx_ofed import mlnx_ofed     # pylint: disable=unused-import

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -29,6 +29,7 @@ from .Stage import Stage
 from .apt_get import apt_get         # pylint: disable=unused-import
 from .baseimage import baseimage     # pylint: disable=unused-import
 from .blob import blob               # pylint: disable=unused-import
+from .cmake import cmake             # pylint: disable=unused-import
 from .comment import comment         # pylint: disable=unused-import
 from .copy import copy               # pylint: disable=unused-import
 from .environment import environment # pylint: disable=unused-import

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -43,6 +43,7 @@ from .mvapich2 import mvapich2       # pylint: disable=unused-import
 from .ofed import ofed               # pylint: disable=unused-import
 from .openmpi import openmpi         # pylint: disable=unused-import
 from .pgi import pgi                 # pylint: disable=unused-import
+from .python import python           # pylint: disable=unused-import
 from .raw import raw                 # pylint: disable=unused-import
 from .shell import shell             # pylint: disable=unused-import
 from .workdir import workdir         # pylint: disable=unused-import

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -14,7 +14,7 @@
 
 # pylint: disable=invalid-name
 
-"""Documentation TBD"""
+"""Container recipe"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
@@ -23,7 +23,10 @@ import logging
 
 import hpccm # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
+
 from .Stage import Stage
 
 from .apt_get import apt_get         # pylint: disable=unused-import
@@ -73,6 +76,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
             logging.error(e)
             exit(1)
 
+    # Set the global container type
+    hpccm.config.g_ctype = ctype
+
     # Only process the first stage of a recipe
     if single_stage:
         del stages[1:]
@@ -90,6 +96,6 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
     for index, stage in enumerate(stages):
         if index >= 1:
             r.append('')
-        r.append(stage.toString(ctype))
+        r.append(str(stage))
 
     return '\n'.join(r)

--- a/hpccm/sed.py
+++ b/hpccm/sed.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""sed template"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import shlex
+
+class sed(object):
+    """sed template"""
+
+    def __init__(self, **kwargs):
+        """Initialize sed template"""
+
+        #super(sed, self).__init__()
+
+        self.sed_opts = kwargs.get('opts', [])
+
+    def sed_step(self, file=None, in_place=True, patterns=[]):
+        """Generate sed command line string"""
+
+        if not file:
+            logging.error('file is not defined')
+            return ''
+
+        if not patterns:
+            logging.error('patterns is not defined')
+            return ''
+
+        # Copy so not to modify the member variable
+        opts = list(self.sed_opts)
+
+        if in_place:
+            opts.append('-i')
+
+        opt_string = ' '.join(opts)
+
+        quoted_patterns = ['-e {}'.format(shlex.quote(patterns[0]))]
+        quoted_patterns.extend('        -e {}'.format(shlex.quote(x)) for x in patterns[1:])
+        quoted_pattern_string = ' \\\n'.join(quoted_patterns)
+
+        return 'sed {0} {1} {2}'.format(opt_string, quoted_pattern_string, file) 

--- a/hpccm/shell.py
+++ b/hpccm/shell.py
@@ -14,48 +14,48 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Shell primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 
 class shell(object):
-    """Documentation TBD"""
+    """Shell primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(wget, self).__init__()
 
         self.commands = kwargs.get('commands', [])
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
+    def __str__(self):
+        """String representation of the primitive"""
         if self.commands:
-            if ctype == container_type.DOCKER:
+            if hpccm.config.g_ctype == container_type.DOCKER:
                 # Format:
                 # RUN cmd1 && \
                 #     cmd2 && \
                 #     cmd3
-                shell = ['RUN {}'.format(self.commands[0])]
-                shell.extend(['    {}'.format(x) for x in self.commands[1:]])
-                return ' && \\\n'.join(shell)
-            elif ctype == container_type.SINGULARITY:
+                s = ['RUN {}'.format(self.commands[0])]
+                s.extend(['    {}'.format(x) for x in self.commands[1:]])
+                return ' && \\\n'.join(s)
+            elif hpccm.config.g_ctype == container_type.SINGULARITY:
                 # Format:
                 # %post
                 #     cmd1
                 #     cmd2
                 #     cmd3
-                shell = ['%post']
-                shell.extend(['    {}'.format(x) for x in self.commands])
-                return '\n'.join(shell)
+                s = ['%post']
+                s.extend(['    {}'.format(x) for x in self.commands])
+                return '\n'.join(s)
             else:
-                logging.error('Unknown container type')
-                return ''
+                raise RuntimeError('Unknown container type')
         else:
             return ''

--- a/hpccm/workdir.py
+++ b/hpccm/workdir.py
@@ -14,39 +14,39 @@
 
 # pylint: disable=invalid-name, too-few-public-methods
 
-"""Documentation TBD"""
+"""Working directory primitive"""
 
 from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from .common import container_type
 from .shell import shell
 
 class workdir(object):
-    """Documentation TBD"""
+    """Workdir primitive"""
 
     def __init__(self, **kwargs):
-        """Documentation TBD"""
+        """Initialize primitive"""
 
         #super(workdir, self).__init__()
 
         self.directory = kwargs.get('directory', '')
 
-    def toString(self, ctype):
-        """Documentation TBD"""
-
+    def __str__(self):
+        """String representation of the primitive"""
         if self.directory:
-            if ctype == container_type.DOCKER:
+            if hpccm.config.g_ctype == container_type.DOCKER:
                 return 'WORKDIR {}'.format(self.directory)
-            elif ctype == container_type.SINGULARITY:
+            elif hpccm.config.g_ctype == container_type.SINGULARITY:
                 s = shell(commands=['mkdir -p {}'.format(self.directory),
                                     'cd {}'.format(self.directory)])
-                return s.toString(ctype)
+                return str(s)
             else:
-                logging.error('Unknown container type')
-            return ''
+                raise RuntimeError('Unknown container type')
         else:
             logging.error('No directory specified')
             return ''

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -23,12 +23,13 @@ Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 # Python (use upstream)
 Stage0 += apt_get(ospackages=['python', 'python3'])
 
-# Compilers (use upstream)
-Stage0 += apt_get(ospackages=['gcc', 'g++', 'gfortran'])
+# GNU compilers
+gnu = gnu()
+Stage0 += gnu
 
-# Create a toolchain
-tc = hpccm.toolchain(CC='gcc', CXX='g++', F77='gfortran', F90='gfortran',
-                     FC='gfortran', CUDA_HOME='/usr/local/cuda')
+# Setup the toolchain.  Use the GNU compiler toolchain as the basis.
+tc = gnu.toolchain
+tc.CUDA_HOME = '/usr/local/cuda'
 
 # Mellanox OFED
 ofed = mlnx_ofed(version='3.4-1.0.0.0')
@@ -55,8 +56,8 @@ Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 # Python (use upstream)
 Stage1 += apt_get(ospackages=['python', 'python3'])
 
-# Compiler runtime (use upstream)
-Stage1 += apt_get(ospackages=['libgfortran3', 'libgomp1'])
+# GNU compiler
+Stage1 += gnu.runtime()
 
 # Mellanox OFED
 Stage1 += ofed.runtime()

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -20,8 +20,9 @@ Stage0 += comment(__doc__, reformat=False)
 
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 
-# Python (use upstream)
-Stage0 += apt_get(ospackages=['python', 'python3'])
+# Python
+python = python()
+Stage0 += python
 
 # GNU compilers
 gnu = gnu()
@@ -53,8 +54,8 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 
-# Python (use upstream)
-Stage1 += apt_get(ospackages=['python', 'python3'])
+# Python
+Stage1 += python.runtime()
 
 # GNU compiler
 Stage1 += gnu.runtime()

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -23,12 +23,13 @@ Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 # Python (use upstream)
 Stage0 += apt_get(ospackages=['python', 'python3'])
 
-# Compilers (use upstream)
-Stage0 += apt_get(ospackages=['gcc', 'g++', 'gfortran'])
+# GNU compilers
+gnu = gnu()
+Stage0 += gnu
 
-# Create a toolchain
-tc = hpccm.toolchain(CC='gcc', CXX='g++', F77='gfortran', F90='gfortran',
-                     FC='gfortran', CUDA_HOME='/usr/local/cuda')
+# Setup the toolchain.  Use the GNU compiler toolchain as the basis.
+tc = gnu.toolchain
+tc.CUDA_HOME = '/usr/local/cuda'
 
 # Mellanox OFED
 ofed = mlnx_ofed(version='3.4-1.0.0.0')
@@ -55,8 +56,8 @@ Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 # Python (use upstream)
 Stage1 += apt_get(ospackages=['python', 'python3'])
 
-# Compiler runtime (use upstream)
-Stage1 += apt_get(ospackages=['libgfortran3', 'libgomp1'])
+# GNU compiler
+Stage1 += gnu.runtime()
 
 # Mellanox OFED
 Stage1 += ofed.runtime()

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -20,8 +20,9 @@ Stage0 += comment(__doc__, reformat=False)
 
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 
-# Python (use upstream)
-Stage0 += apt_get(ospackages=['python', 'python3'])
+# Python
+python = python()
+Stage0 += python
 
 # GNU compilers
 gnu = gnu()
@@ -53,8 +54,8 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 
-# Python (use upstream)
-Stage1 += apt_get(ospackages=['python', 'python3'])
+# Python
+Stage1 += python.runtime()
 
 # GNU compiler
 Stage1 += gnu.runtime()

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -28,8 +28,9 @@ Stage0 += comment(__doc__, reformat=False)
 
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 
-# Python (use upstream)
-Stage0 += apt_get(ospackages=['python', 'python3'])
+# Python
+python = python()
+Stage0 += python
 
 # PGI compilers
 pgi = pgi(eula=pgi_eula, version='18.4')
@@ -61,8 +62,8 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 
-# Python (use upstream)
-Stage1 += apt_get(ospackages=['python', 'python3'])
+# Python
+Stage1 += python.runtime()
 
 # PGI compiler
 Stage1 += pgi.runtime()

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -7,7 +7,7 @@ Contents:
   HDF5 version 1.10.1
   Mellanox OFED version 3.4-1.0.0.0
   MVAPICH2 version 2.3b
-  PGI compilers version 17.10
+  PGI compilers version 18.4
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -32,7 +32,7 @@ Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 Stage0 += apt_get(ospackages=['python', 'python3'])
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='17.10')
+pgi = pgi(eula=pgi_eula, version='18.4')
 Stage0 += pgi
 
 # Setup the toolchain.  Use the PGI compiler toolchain as the basis.

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -28,8 +28,9 @@ Stage0 += comment(__doc__, reformat=False)
 
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 
-# Python (use upstream)
-Stage0 += apt_get(ospackages=['python', 'python3'])
+# Python
+python = python()
+Stage0 += python
 
 # PGI compilers
 pgi = pgi(eula=pgi_eula, version='18.4')
@@ -61,8 +62,8 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image='nvidia/cuda:9.0-runtime')
 
-# Python (use upstream)
-Stage1 += apt_get(ospackages=['python', 'python3'])
+# Python
+Stage1 += python.runtime()
 
 # PGI compiler
 Stage1 += pgi.runtime()

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -7,7 +7,7 @@ Contents:
   HDF5 version 1.10.1
   Mellanox OFED version 3.4-1.0.0.0
   OpenMPI version 3.0.0
-  PGI compilers version 17.10
+  PGI compilers version 18.4
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -32,7 +32,7 @@ Stage0 += baseimage(image='nvidia/cuda:9.0-devel', _as='devel')
 Stage0 += apt_get(ospackages=['python', 'python3'])
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='17.10')
+pgi = pgi(eula=pgi_eula, version='18.4')
 Stage0 += pgi
 
 # Setup the toolchain.  Use the PGI compiler toolchain as the basis.

--- a/recipes/milc/examples/apex.sh
+++ b/recipes/milc/examples/apex.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+NGPUS=$1
+
+# setup data home
+MILC_DATA_HOME=/data
+mkdir -p $MILC_DATA_HOME
+cd $MILC_DATA_HOME
+
+# pull test data if not on disk
+CHKLAT=36x36x36x72.chklat
+if [ ! -f $CHKLAT ]; then
+  # install wget if needed
+  which wget || apt-get update \
+    && apt-get install --no-install-recommends -y wget
+
+  # pull test data
+  wget http://portal.nersc.gov/project/m888/apex/MILC_lattices/$CHKLAT
+fi
+
+if [ ! -f MILC_160413.tgz ]; then
+  # install wget if needed
+  which wget || apt-get update \
+    && apt-get install --no-install-recommends -y wget
+
+  wget http://portal.nersc.gov/project/m888/apex/MILC_160413.tgz
+fi
+tar xf MILC_160413.tgz
+
+# configure run dir and copy over files
+RUN_DIR=/apex
+rm -r $RUN_DIR 2>/dev/null || true
+mkdir -p $RUN_DIR
+
+INPUT_FILE=input
+OUTPUT_FILE=apex_result_$(date +%y-%m-%d_%H-%M)
+cp /workspace/examples/inputs/$INPUT_FILE $RUN_DIR
+cp $MILC_DATA_HOME/MILC-apex/benchmarks/rationals_m001m05m5.test1 $RUN_DIR
+cp $MILC_DATA_HOME/$CHKLAT $RUN_DIR
+
+case $NGPUS in
+  1)
+    GEOM="1 1 1 1"
+    ;;
+  2)
+    GEOM="1 1 1 2"
+    ;;
+  4)
+    GEOM="1 1 1 4"
+    ;;
+  8)
+    GEOM="1 1 2 4"
+    ;;
+esac
+
+# run APEX
+cd $RUN_DIR
+echo "Launching with APEX workload. Saving output to $RUN_DIR/$OUTPUT_FILE..."
+mpirun --allow-run-as-root -np $NGPUS su3_rhmd_hisq -geom $GEOM $INPUT_FILE $OUTPUT_FILE
+echo "APEX workload complete, results can be found at $RUN_DIR/$OUTPUT_FILE"

--- a/recipes/milc/examples/inputs/input
+++ b/recipes/milc/examples/inputs/input
@@ -1,0 +1,79 @@
+    prompt 0
+    nx 36
+    ny 36
+    nz 36
+    nt 72
+    iseed 4563421
+    n_pseudo 5
+    load_rhmc_params rationals_m001m05m5.test1
+    beta 6.3
+    n_dyn_masses 3
+    dyn_mass .001 .05 .5
+    dyn_flavors 2 1 1
+    u0  0.890
+
+    warms 0
+    trajecs 0
+    traj_between_meas 40
+    microcanonical_time_step .05
+    steps_per_trajectory 20
+    cgresid_md_fa_gr 1 1 1
+    max_multicg_md_fa_gr  5  5  5
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1 1 1
+    max_multicg_md_fa_gr  5  5  5
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1 1 1
+    max_multicg_md_fa_gr  5  5  5
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1 1 1
+    max_multicg_md_fa_gr  5  5  5
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1 1 1
+    max_multicg_md_fa_gr  5  5  5
+    cgprec_md_fa_gr  2 2 2
+    prec_ff 2
+    number_of_pbp_masses 0
+    fresh
+    forget
+
+    warms 0
+    trajecs 2
+    traj_between_meas 2
+    microcanonical_time_step .0333
+    steps_per_trajectory 30
+    cgresid_md_fa_gr 1e-5 1e-5 1e-5
+    max_multicg_md_fa_gr  2500  2500  2500
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1e-7 1e-7 1e-7
+    max_multicg_md_fa_gr  2500  2500  2500
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1e-7 1e-7 1e-7
+    max_multicg_md_fa_gr  2500  2500  2500
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1e-7 1e-7 1e-7
+    max_multicg_md_fa_gr  2500  2500  2500
+    cgprec_md_fa_gr  2 2 2
+    cgresid_md_fa_gr 1e-7 1e-7 1e-7
+    max_multicg_md_fa_gr  2500  2500  2500
+    cgprec_md_fa_gr  2 2 2
+    prec_ff 2
+    number_of_pbp_masses 3
+    max_cg_prop 500
+    max_cg_prop_restarts 1
+    npbp_reps 1
+    prec_pbp 2
+    mass 0.01
+    naik_term_epsilon 0
+    error_for_propagator 1e-8
+    rel_error_for_propagator 0
+    mass 0.05
+    naik_term_epsilon 0
+    error_for_propagator 1e-8
+    rel_error_for_propagator 0
+    mass 0.5
+    naik_term_epsilon 0
+    error_for_propagator 1e-8
+    rel_error_for_propagator 0
+    reload_parallel 36x36x36x72.chklat
+    forget

--- a/recipes/milc/examples/sc15_cluster.sh
+++ b/recipes/milc/examples/sc15_cluster.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+NGPUS=$1
+
+# setup data home
+MILC_DATA_HOME=/data
+mkdir -p $MILC_DATA_HOME
+cd $MILC_DATA_HOME
+
+SC15_DATA_HOME=$MILC_DATA_HOME/SC15
+mkdir -p $SC15_DATA_HOME
+cd $SC15_DATA_HOME
+
+# pull test data if not on disk
+BMARK_ARCHIVE=benchmarks.tar
+if [ ! -f $BMARK_ARCHIVE ]; then
+  # install wget if needed
+  which wget || apt-get update \
+    && apt-get install --no-install-recommends -y wget
+
+  # pull test data
+  wget http://denali.physics.indiana.edu/~sg/SC15_student_cluster_competition/$BMARK_ARCHIVE
+fi
+tar xf $BMARK_ARCHIVE
+
+# configure run dir and copy over files
+RUN_DIR=/sc15_cluster
+rm -r $RUN_DIR 2>/dev/null || true
+mkdir -p $RUN_DIR
+
+INPUT_FILE=small.bench.in
+OUTPUT_FILE=small_bench_$(date +%y-%m-%d_%H-%M)
+cp -r $SC15_DATA_HOME/small $RUN_DIR/small
+cp -r $SC15_DATA_HOME/ratfunc $RUN_DIR/ratfunc
+
+case $NGPUS in
+  1)
+    GEOM="1 1 1 1"
+    ;;
+  2)
+    GEOM="1 1 1 2"
+    ;;
+  4)
+    GEOM="1 1 1 4"
+    ;;
+  8)
+    GEOM="1 1 2 4"
+    ;;
+esac
+
+# run benchmark
+cd $RUN_DIR/small
+echo "Launching with SC15 student cluster competition benchmark. Saving output to $RUN_DIR/$OUTPUT_FILE..."
+mpirun --allow-run-as-root -np $NGPUS su3_rhmd_hisq -geom $GEOM $INPUT_FILE ../$OUTPUT_FILE
+echo "SC15 student cluster competition benchmark complete, results can be found at $RUN_DIR/$OUTPUT_FILE"

--- a/recipes/milc/milc.py
+++ b/recipes/milc/milc.py
@@ -1,0 +1,106 @@
+"""
+MILC 7.8.1
+
+Contents:
+  Ubuntu 16.04
+  CUDA version 9.0
+  GNU compilers (upstream)
+  OFED (upstream)
+  OpenMPI version 3.0.0
+  QUDA version 0.8.0
+"""
+# pylint: disable=invalid-name, undefined-variable, used-before-assignment
+# pylama: ignore=E0602
+import os
+
+gpu_arch = USERARG.get('GPU_ARCH', 'sm_60')
+
+# add docstring to Dockerfile
+Stage0 += comment(__doc__.strip(), reformat=False)
+
+###############################################################################
+# Devel stage
+###############################################################################
+Stage0.name = 'devel'
+Stage0 += baseimage(image='nvidia/cuda:9.0-devel-ubuntu16.04', _as=Stage0.name)
+
+Stage0 += apt_get(ospackages=['autoconf', 'automake', 'ca-certificates',
+                              'cmake', 'git', 'libnuma-dev'])
+
+ofed = ofed()
+Stage0 += ofed
+
+ompi = openmpi(configure_opts=['--enable-mpi-cxx'], prefix='/opt/openmpi',
+               parallel=32, version='3.0.0')
+Stage0 += ompi
+
+# build QUDA
+g = hpccm.git()
+quda_cmds = ['mkdir -p /quda/build',
+             g.clone_step(repository='https://github.com/lattice/quda',
+                          branch='v0.8.0', path='/quda', directory='src'),
+             'cd /quda/build',
+             'cmake ../src ' +
+             '-DCMAKE_BUILD_TYPE=RELEASE ' +
+             '-DQUDA_DIRAC_CLOVER=ON ' +
+             '-DQUDA_DIRAC_DOMAIN_WALL=ON ' +
+             '-DQUDA_DIRAC_STAGGERED=ON ' +
+             '-DQUDA_DIRAC_TWISTED_CLOVER=ON ' +
+             '-DQUDA_DIRAC_TWISTED_MASS=ON ' +
+             '-DQUDA_DIRAC_WILSON=ON ' +
+             '-DQUDA_FORCE_GAUGE=ON  ' +
+             '-DQUDA_FORCE_HISQ=ON ' +
+             '-DQUDA_GPU_ARCH={} '.format(gpu_arch) +
+             '-DQUDA_INTERFACE_MILC=ON ' +
+             '-DQUDA_INTERFACE_QDP=ON ' +
+             '-DQUDA_LINK_HISQ=ON ' +
+             '-DQUDA_MPI=ON',
+             'make -j32']
+Stage0 += shell(commands=quda_cmds)
+
+# build MILC
+milc_version = '7.8.1'
+milc_cmds = ['mkdir -p /milc',
+             hpccm.wget().download_step(url='http://www.physics.utah.edu/~detar/milc/milc_qcd-{}.tar.gz'.format(milc_version)),
+             hpccm.tar().untar_step(
+                 tarball='/tmp/milc_qcd-{}.tar.gz'.format(milc_version),
+                 directory='/milc'),
+             'cd /milc/milc_qcd-{}/ks_imp_rhmc'.format(milc_version),
+             'cp ../Makefile .',
+             hpccm.sed().sed_step(
+                 file='/milc/milc_qcd-{}/ks_imp_rhmc/Makefile'.format(
+                     milc_version),
+                 patterns=[r's/WANTQUDA\(.*\)=.*/WANTQUDA\1= true/g',
+                           r's/\(WANT_.*_GPU\)\(.*\)= .*/\1\2= true/g',
+                           r's/QUDA_HOME\(.*\)= .*/QUDA_HOME\1= \/quda\/build/g',
+                           r's/CUDA_HOME\(.*\)= .*/CUDA_HOME\1= \/usr\/local\/cuda/g',
+                           r's/#\?MPP = .*/MPP = true/g',
+                           r's/#\?CC = .*/CC = mpicc/g',
+                           r's/LD\(\s+\)= .*/LD\1= mpicxx/g',
+                           r's/PRECISION = [0-9]\+/PRECISION = 2/g',
+                           r's/WANTQIO = .*/WANTQIO = #true or blank.  Implies HAVEQMP./g',
+                           r's/CGEOM =.*-DFIX_NODE_GEOM.*/CGEOM = #-DFIX_NODE_GEOM/g']),
+             'C_INCLUDE_PATH=/quda/build/include make su3_rhmd_hisq']
+Stage0 += shell(commands=milc_cmds)
+
+###############################################################################
+# Release stage
+###############################################################################
+Stage1 += baseimage(image='nvidia/cuda:9.0-runtime-ubuntu16.04')
+Stage1 += apt_get(ospackages=['libnuma1'])
+
+Stage1 += ofed.runtime()
+
+Stage1 += ompi.runtime()
+
+Stage1 += copy(_from=Stage0.name,
+               src='/milc/milc_qcd-{}/ks_imp_rhmc/su3_rhmd_hisq'.format(
+                   milc_version),
+               dest='/milc/su3_rhmd_hisq')
+Stage1 += environment(variables={'PATH': '$PATH:/milc'})
+
+# Include examples if they exist in the build context
+if os.path.isdir('recipes/milc/examples'):
+    Stage1 += copy(src='recipes/milc/examples', dest='/workspace/examples')
+
+Stage1 += workdir(directory='/workspace')

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Unit testing helpers"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+import hpccm.config
+
+from hpccm.common import container_type
+
+def docker(function):
+    """Decorator to set the global containter type to docker"""
+    def wrapper(*args, **kwargs):
+        """Wrapper"""
+        hpccm.config.g_ctype = container_type.DOCKER
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def invalid_ctype(function):
+    """Decorator to set the global containter type to an invalid value"""
+    def wrapper(*args, **kwargs):
+        """Wrapper"""
+        hpccm.config.g_ctype = None
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def singularity(function):
+    """Decorator to set the global containter type to singularity"""
+    def wrapper(*args, **kwargs):
+        """Wrapper"""
+        hpccm.config.g_ctype = container_type.SINGULARITY
+        return function(*args, **kwargs)
+
+    return wrapper

--- a/test/test_Stage.py
+++ b/test/test_Stage.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.shell import shell
 from hpccm.Stage import Stage
 
@@ -45,18 +46,19 @@ class Test_Stage(unittest.TestCase):
         s += [1, 2]
         self.assertTrue(s.is_defined())
 
+    @docker
     def test_baseimage(self):
         """Base image specification"""
         s = Stage()
         s.name = 'bar'
         s.baseimage('foo')
-        self.assertEqual(s.toString(container_type.DOCKER), 'FROM foo AS bar')
+        self.assertEqual(str(s), 'FROM foo AS bar')
 
+    @docker
     def test_baseimage_first(self):
         """Base image is always first"""
         s = Stage()
         s += shell(commands=['abc'])
         s.name = 'bar'
         s.baseimage('foo')
-        self.assertEqual(s.toString(container_type.DOCKER),
-                         'FROM foo AS bar\n\nRUN abc')
+        self.assertEqual(str(s), 'FROM foo AS bar\n\nRUN abc')

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker, invalid_ctype, singularity
+
 from hpccm.baseimage import baseimage
 
 class Test_baseimage(unittest.TestCase):
@@ -30,34 +31,57 @@ class Test_baseimage(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
-    def test_empty(self):
+    @docker
+    def test_empty_docker(self):
         """Default base image"""
         b = baseimage()
-        self.assertNotEqual(b.toString(container_type.DOCKER), '')
-        self.assertNotEqual(b.toString(container_type.SINGULARITY), '')
+        self.assertNotEqual(str(b), '')
 
+    @singularity
+    def test_empty_singularity(self):
+        """Default base image"""
+        b = baseimage()
+        self.assertNotEqual(str(b), '')
+
+    @invalid_ctype
     def test_invalid_ctype(self):
         """Invalid container type specified"""
         b = baseimage()
-        self.assertEqual(b.toString(None), '')
+        with self.assertRaises(RuntimeError):
+            str(b)
 
-    def test_value(self):
+    @docker
+    def test_value_docker(self):
         """Image name is specified"""
         b = baseimage(image='foo')
-        self.assertEqual(b.toString(container_type.DOCKER), 'FROM foo')
-        self.assertEqual(b.toString(container_type.SINGULARITY),
-                         'BootStrap: docker\nFrom: foo')
+        self.assertEqual(str(b), 'FROM foo')
 
-    def test_as_deprecated(self):
+    @singularity
+    def test_value_singularity(self):
+        """Image name is specified"""
+        b = baseimage(image='foo')
+        self.assertEqual(str(b), 'BootStrap: docker\nFrom: foo')
+
+    @docker
+    def test_as_deprecated_docker(self):
         """Docker specified image naming"""
         b = baseimage(image='foo', AS='dev')
-        self.assertEqual(b.toString(container_type.DOCKER), 'FROM foo AS dev')
-        self.assertEqual(b.toString(container_type.SINGULARITY),
-                         'BootStrap: docker\nFrom: foo')
+        self.assertEqual(str(b), 'FROM foo AS dev')
 
-    def test_as(self):
+    @singularity
+    def test_as_deprecated_singularity(self):
+        """Docker specified image naming"""
+        b = baseimage(image='foo', AS='dev')
+        self.assertEqual(str(b), 'BootStrap: docker\nFrom: foo')
+
+    @docker
+    def test_as_docker(self):
         """Docker specified image naming"""
         b = baseimage(image='foo', _as='dev')
-        self.assertEqual(b.toString(container_type.DOCKER), 'FROM foo AS dev')
-        self.assertEqual(b.toString(container_type.SINGULARITY),
-                         'BootStrap: docker\nFrom: foo')
+        self.assertEqual(str(b), 'FROM foo AS dev')
+
+    @singularity
+    def test_as_singularity(self):
+        """Docker specified image naming"""
+        b = baseimage(image='foo', _as='dev')
+        self.assertEqual(str(b), 'BootStrap: docker\nFrom: foo')

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the cmake module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.cmake import cmake
+
+class Test_pgi(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default cmake building block"""
+        c = cmake()
+        self.assertEqual(c.toString(container_type.DOCKER),
+r'''# CMake version 3.11.1
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
+    /bin/sh /tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /tmp/cmake-3.11.1-Linux-x86_64.sh''')
+
+    def test_eula(self):
+        """Accept EULA"""
+        c = cmake(eula=True)
+        self.assertEqual(c.toString(container_type.DOCKER),
+r'''# CMake version 3.11.1
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
+    /bin/sh /tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /tmp/cmake-3.11.1-Linux-x86_64.sh''')
+
+    def test_version(self):
+        """Version option"""
+        c = cmake(eula=True, version='3.10.3')
+        self.assertEqual(c.toString(container_type.DOCKER),
+r'''# CMake version 3.10.3
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh && \
+    /bin/sh /tmp/cmake-3.10.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /tmp/cmake-3.10.3-Linux-x86_64.sh''')
+
+    def test_runtime(self):
+        """Runtime"""
+        c = cmake(eula=True)
+        r = c.runtime()
+        self.assertEqual(r.toString(container_type.DOCKER),
+r'''# CMake version 3.11.1
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
+    /bin/sh /tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /tmp/cmake-3.11.1-Linux-x86_64.sh''')

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the cmake module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.cmake import cmake
 
 class Test_cmake(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_cmake(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default cmake building block"""
         c = cmake()
-        self.assertEqual(c.toString(container_type.DOCKER),
+        self.assertEqual(str(c),
 r'''# CMake version 3.11.1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -43,10 +45,11 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/fi
     /bin/sh /tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local && \
     rm -rf /tmp/cmake-3.11.1-Linux-x86_64.sh''')
 
+    @docker
     def test_eula(self):
         """Accept EULA"""
         c = cmake(eula=True)
-        self.assertEqual(c.toString(container_type.DOCKER),
+        self.assertEqual(str(c),
 r'''# CMake version 3.11.1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -56,10 +59,11 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/fi
     /bin/sh /tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /tmp/cmake-3.11.1-Linux-x86_64.sh''')
 
+    @docker
     def test_version(self):
         """Version option"""
         c = cmake(eula=True, version='3.10.3')
-        self.assertEqual(c.toString(container_type.DOCKER),
+        self.assertEqual(str(c),
 r'''# CMake version 3.10.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -69,11 +73,12 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://cmake.org/fi
     /bin/sh /tmp/cmake-3.10.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /tmp/cmake-3.10.3-Linux-x86_64.sh''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         c = cmake(eula=True)
         r = c.runtime()
-        self.assertEqual(r.toString(container_type.DOCKER),
+        self.assertEqual(str(r),
 r'''# CMake version 3.11.1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -25,7 +25,7 @@ import unittest
 from hpccm.common import container_type
 from hpccm.cmake import cmake
 
-class Test_pgi(unittest.TestCase):
+class Test_cmake(unittest.TestCase):
     def setUp(self):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)

--- a/test/test_comment.py
+++ b/test/test_comment.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker, invalid_ctype, singularity
+
 from hpccm.comment import comment
 
 class Test_comment(unittest.TestCase):
@@ -30,34 +31,45 @@ class Test_comment(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_empty(self):
         """No comment string specified"""
         c = comment()
-        self.assertEqual(c.toString(container_type.DOCKER), '')
+        self.assertEqual(str(c), '')
 
+    @docker
     def test_empty_noreformat(self):
         """No comment string specified, reformatting disabled"""
         c = comment(reformat=False)
-        self.assertEqual(c.toString(container_type.DOCKER), '')
+        self.assertEqual(str(c), '')
 
+    @invalid_ctype
     def test_invalid_ctype(self):
         """Invalid container type specified
            Assumes default comment format."""
         c = comment('foo')
-        self.assertEqual(c.toString(None), '# foo')
+        self.assertEqual(str(c), '# foo')
 
-    def test_comment(self):
+    @docker
+    def test_comment_docker(self):
         """Comment string specified"""
         c = comment('foo')
-        self.assertEqual(c.toString(container_type.DOCKER), '# foo')
-        self.assertEqual(c.toString(container_type.SINGULARITY), '# foo')
+        self.assertEqual(str(c), '# foo')
 
+    @singularity
+    def test_comment_singularity(self):
+        """Comment string specified"""
+        c = comment('foo')
+        self.assertEqual(str(c), '# foo')
+
+    @docker
     def test_noreformat(self):
         """Disable reformatting"""
         c = comment('foo\nbar', reformat=False)
-        self.assertEqual(c.toString(container_type.DOCKER), '# foo\n# bar')
+        self.assertEqual(str(c), '# foo\n# bar')
 
+    @docker
     def test_wrap(self):
         """Comment wrapping"""
         c = comment('foo\nbar')
-        self.assertEqual(c.toString(container_type.DOCKER), '# foo bar')
+        self.assertEqual(str(c), '# foo bar')

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the fftw module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.fftw import fftw
 
 class Test_fftw(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_fftw(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default fftw building block"""
         f = fftw()
-        self.assertEqual(f.toString(container_type.DOCKER),
+        self.assertEqual(str(f),
 r'''# FFTW version 3.3.7
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -49,20 +51,22 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp ftp://ftp.fftw.org/p
     rm -rf /tmp/fftw-3.3.7.tar.gz /tmp/fftw-3.3.7
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         f = fftw()
         r = f.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# FFTW
 COPY --from=0 /usr/local/fftw /usr/local/fftw
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @docker
     def test_directory(self):
         """Directory in local build context"""
         f = fftw(directory='fftw-3.3.7')
-        self.assertEqual(f.toString(container_type.DOCKER),
+        self.assertEqual(str(f),
 r'''# FFTW
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the fftw module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.fftw import fftw
+
+class Test_fftw(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default fftw building block"""
+        f = fftw()
+        self.assertEqual(f.toString(container_type.DOCKER),
+r'''# FFTW version 3.3.7
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz && \
+    tar -x -f /tmp/fftw-3.3.7.tar.gz -C /tmp -z && \
+    cd /tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/fftw-3.3.7.tar.gz /tmp/fftw-3.3.7
+ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
+
+    def test_runtime(self):
+        """Runtime"""
+        f = fftw()
+        r = f.runtime()
+        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        self.assertEqual(s,
+r'''# FFTW
+COPY --from=0 /usr/local/fftw /usr/local/fftw
+ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
+
+    def test_directory(self):
+        """Directory in local build context"""
+        f = fftw(directory='fftw-3.3.7')
+        self.assertEqual(f.toString(container_type.DOCKER),
+r'''# FFTW
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+COPY fftw-3.3.7 /tmp/fftw-3.3.7
+RUN cd /tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/fftw-3.3.7
+ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the gnu module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.gnu import gnu
 
 class Test_gnu(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_gnu(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default gnu building block"""
         g = gnu()
-        self.assertEqual(g.toString(container_type.DOCKER),
+        self.assertEqual(str(g),
 r'''# GNU compiler
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -42,11 +44,12 @@ RUN apt-get update -y && \
         gfortran && \
     rm -rf /var/lib/apt/lists/*''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         g = gnu()
         r = g.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# GNU compiler runtime
 RUN apt-get update -y && \

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the gnu module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.gnu import gnu
+
+class Test_gnu(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default gnu building block"""
+        g = gnu()
+        self.assertEqual(g.toString(container_type.DOCKER),
+r'''# GNU compiler
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        gfortran && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    def test_runtime(self):
+        """Runtime"""
+        g = gnu()
+        r = g.runtime()
+        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        self.assertEqual(s,
+r'''# GNU compiler runtime
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libgomp1 \
+        libgfortran3 && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    def test_toolchain(self):
+        """Toolchain"""
+        g = gnu()
+        tc = g.toolchain
+        self.assertEqual(tc.CC, 'gcc')
+        self.assertEqual(tc.CXX, 'g++')
+        self.assertEqual(tc.FC, 'gfortran')
+        self.assertEqual(tc.F77, 'gfortran')
+        self.assertEqual(tc.F90, 'gfortran')

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the hdf5 module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.hdf5 import hdf5
+
+class Test_hdf5(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default hdf5 building block"""
+        h = hdf5()
+        self.assertEqual(h.toString(container_type.DOCKER),
+r'''# HDF5 version 1.10.1
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2 && \
+    tar -x -f /tmp/hdf5-1.10.1.tar.bz2 -C /tmp -j && \
+    cd /tmp/hdf5-1.10.1 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/hdf5-1.10.1.tar.bz2 /tmp/hdf5-1.10.1
+ENV HDF5_DIR=/usr/local/hdf5 \
+    LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/hdf5/bin:$PATH''')
+
+    def test_runtime(self):
+        """Runtime"""
+        h = hdf5()
+        r = h.runtime()
+        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        self.assertEqual(s,
+r'''# HDF5
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        zlib1g && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=0 /usr/local/hdf5 /usr/local/hdf5
+ENV HDF5_DIR=/usr/local/hdf5 \
+    LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/hdf5/bin:$PATH''')
+
+    def test_directory(self):
+        """Directory in local build context"""
+        h = hdf5(directory='hdf5-1.10.1')
+        self.assertEqual(h.toString(container_type.DOCKER),
+r'''# HDF5
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+COPY hdf5-1.10.1 /tmp/hdf5-1.10.1
+RUN cd /tmp/hdf5-1.10.1 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/hdf5-1.10.1
+ENV HDF5_DIR=/usr/local/hdf5 \
+    LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/hdf5/bin:$PATH''')

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the hdf5 module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.hdf5 import hdf5
 
 class Test_hdf5(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_hdf5(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default hdf5 building block"""
         h = hdf5()
-        self.assertEqual(h.toString(container_type.DOCKER),
+        self.assertEqual(str(h),
 r'''# HDF5 version 1.10.1
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -52,11 +54,12 @@ ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         h = hdf5()
         r = h.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# HDF5
 RUN apt-get update -y && \
@@ -68,10 +71,11 @@ ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')
 
+    @docker
     def test_directory(self):
         """Directory in local build context"""
         h = hdf5(directory='hdf5-1.10.1')
-        self.assertEqual(h.toString(container_type.DOCKER),
+        self.assertEqual(str(h),
 r'''# HDF5
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the mlnx_ofed module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.mlnx_ofed import mlnx_ofed
 
 class Test_mlnx_ofed(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
-        self.assertEqual(mofed.toString(container_type.DOCKER),
+        self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 3.4-1.0.0.0
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -50,11 +52,12 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mella
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
     rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         mofed = mlnx_ofed()
         r = mofed.runtime()
-        self.assertEqual(r.toString(container_type.DOCKER),
+        self.assertEqual(str(r),
 r'''# Mellanox OFED version 3.4-1.0.0.0
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the mlnx_ofed module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.mlnx_ofed import mlnx_ofed
+
+class Test_mlnx_ofed(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default mlnx_ofed building block"""
+        mofed = mlnx_ofed()
+        self.assertEqual(mofed.toString(container_type.DOCKER),
+r'''# Mellanox OFED version 3.4-1.0.0.0
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mellanox.com/ofed/MLNX_OFED-3.4-1.0.0.0/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz && \
+    tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
+    rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
+
+    def test_runtime(self):
+        """Runtime"""
+        mofed = mlnx_ofed()
+        r = mofed.runtime()
+        self.assertEqual(r.toString(container_type.DOCKER),
+r'''# Mellanox OFED version 3.4-1.0.0.0
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mellanox.com/ofed/MLNX_OFED-3.4-1.0.0.0/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz && \
+    tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
+    rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -48,6 +48,8 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mella
     tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
     rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
@@ -70,6 +72,8 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mella
     tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
     rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -52,6 +52,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
     def test_directory(self):
+        """Directory in local build context"""
         mv2 = mvapich2(directory='mvapich2-2.3')
         self.assertEqual(mv2.toString(container_type.DOCKER),
 r'''# MVAPICH2
@@ -71,6 +72,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
     def test_runtime(self):
+        """Runtime"""
         mv2 = mvapich2()
         r = mv2.runtime()
         s = '\n'.join(x.toString(container_type.DOCKER) for x in r)

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the mvapich2 module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.mvapich2 import mvapich2
 
 class Test_mvapich2(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_mvapich2(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default mvapich2 building block"""
         mv2 = mvapich2()
-        self.assertEqual(mv2.toString(container_type.DOCKER),
+        self.assertEqual(str(mv2),
 r'''# MVAPICH2 version 2.3b
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -51,10 +53,11 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.o
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
+    @docker
     def test_directory(self):
         """Directory in local build context"""
         mv2 = mvapich2(directory='mvapich2-2.3')
-        self.assertEqual(mv2.toString(container_type.DOCKER),
+        self.assertEqual(str(mv2),
 r'''# MVAPICH2
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -71,11 +74,12 @@ RUN cd /tmp/mvapich2-2.3 &&   ./configure --prefix=/usr/local/mvapich2 --disable
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         mv2 = mvapich2()
         r = mv2.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# MVAPICH2
 RUN apt-get update -y && \

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the mvapich2_gdr module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import docker
+
+from hpccm.mvapich2_gdr import mvapich2_gdr
+
+class Test_mvapich2_gdr(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @docker
+    def test_defaults(self):
+        """Default mvapich2_gdr building block"""
+        mv2 = mvapich2_gdr()
+        self.maxDiff = None
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR version 2.3a
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed3.4/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
+
+    @docker
+    def test_options(self):
+        """PGI compiler and different Mellanox OFED version"""
+        mv2 = mvapich2_gdr(pgi=True, gnu=False, cuda_version='8.0', 
+                           mlnx_ofed_version='4.0')
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR version 2.3a
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed4.0/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
+    dpkg --install /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
+
+    @docker
+    def test_package(self):
+        """Directory in local build context"""
+        mv2 = mvapich2_gdr(package='mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb')
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+COPY mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+RUN dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
+
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        mv2 = mvapich2_gdr()
+        r = mv2.runtime()
+        s = '\n'.join(str(x) for x in r)
+        self.maxDiff = None
+        self.assertEqual(s,
+r'''# MVAPICH2-GDR
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=0 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')

--- a/test/test_ofed.py
+++ b/test/test_ofed.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the ofed module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.ofed import ofed
+
+class Test_ofed(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default ofed building block"""
+        o = ofed()
+        self.assertEqual(o.toString(container_type.DOCKER),
+r'''# OFED
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        dapl2-utils \
+        ibutils \
+        ibverbs-utils \
+        infiniband-diags \
+        libdapl-dev \
+        libibcm-dev \
+        libibmad5 \
+        libibmad-dev \
+        libibverbs1 \
+        libibverbs-dev \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm1 \
+        librdmacm-dev \
+        opensm \
+        rdmacm-utils && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    def test_runtime(self):
+        """Runtime"""
+        o = ofed()
+        r = o.runtime()
+        self.assertEqual(r.toString(container_type.DOCKER),
+r'''# OFED
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        dapl2-utils \
+        ibutils \
+        ibverbs-utils \
+        infiniband-diags \
+        libdapl-dev \
+        libibcm-dev \
+        libibmad5 \
+        libibmad-dev \
+        libibverbs1 \
+        libibverbs-dev \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm1 \
+        librdmacm-dev \
+        opensm \
+        rdmacm-utils && \
+    rm -rf /var/lib/apt/lists/*''')

--- a/test/test_ofed.py
+++ b/test/test_ofed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the ofed module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.ofed import ofed
 
 class Test_ofed(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_ofed(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default ofed building block"""
         o = ofed()
-        self.assertEqual(o.toString(container_type.DOCKER),
+        self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -57,11 +59,12 @@ RUN apt-get update -y && \
         rdmacm-utils && \
     rm -rf /var/lib/apt/lists/*''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         o = ofed()
         r = o.runtime()
-        self.assertEqual(r.toString(container_type.DOCKER),
+        self.assertEqual(str(r),
 r'''# OFED
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the openmpi module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.openmpi import openmpi
+
+class Test_openmpi(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default openmpi building block"""
+        ompi = openmpi()
+        self.assertEqual(ompi.toString(container_type.DOCKER),
+r'''# OpenMPI version 3.0.0
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        hwloc \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2 && \
+    tar -x -f /tmp/openmpi-3.0.0.tar.bz2 -C /tmp -j && \
+    cd /tmp/openmpi-3.0.0 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/openmpi-3.0.0.tar.bz2 /tmp/openmpi-3.0.0
+ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/openmpi/bin:$PATH''')
+
+    def test_directory(self):
+        """Directory in local build context"""
+        ompi = openmpi(directory='openmpi-3.0.0')
+        self.assertEqual(ompi.toString(container_type.DOCKER),
+r'''# OpenMPI
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        file \
+        hwloc \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+COPY openmpi-3.0.0 /tmp/openmpi-3.0.0
+RUN cd /tmp/openmpi-3.0.0 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+    make -j4 && \
+    make -j4 install && \
+    rm -rf /tmp/openmpi-3.0.0
+ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/openmpi/bin:$PATH''')
+
+    def test_runtime(self):
+        """Runtime"""
+        ompi = openmpi()
+        r = ompi.runtime()
+        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        self.assertEqual(s,
+r'''# OpenMPI
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        hwloc \
+        openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=0 /usr/local/openmpi /usr/local/openmpi
+ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/openmpi/bin:$PATH''')
+
+    def test_toolchain(self):
+        """Toolchain"""
+        ompi = openmpi()
+        tc = ompi.toolchain
+        self.assertEqual(tc.CC, 'mpicc')
+        self.assertEqual(tc.CXX, 'mpicxx')
+        self.assertEqual(tc.FC, 'mpifort')
+        self.assertEqual(tc.F77, 'mpif77')
+        self.assertEqual(tc.F90, 'mpif90')

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the openmpi module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.openmpi import openmpi
 
 class Test_openmpi(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_openmpi(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default openmpi building block"""
         ompi = openmpi()
-        self.assertEqual(ompi.toString(container_type.DOCKER),
+        self.assertEqual(str(ompi),
 r'''# OpenMPI version 3.0.0
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -51,10 +53,11 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp https://www.open-mpi
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
+    @docker
     def test_directory(self):
         """Directory in local build context"""
         ompi = openmpi(directory='openmpi-3.0.0')
-        self.assertEqual(ompi.toString(container_type.DOCKER),
+        self.assertEqual(str(ompi),
 r'''# OpenMPI
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -71,11 +74,12 @@ RUN cd /tmp/openmpi-3.0.0 &&   ./configure --prefix=/usr/local/openmpi --disable
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         ompi = openmpi()
         r = ompi.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# OpenMPI
 RUN apt-get update -y && \

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the pgi module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.pgi import pgi
 
 class Test_pgi(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_pgi(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default pgi building block"""
         p = pgi()
-        self.assertEqual(p.toString(container_type.DOCKER),
+        self.assertEqual(str(p),
 r'''# PGI compiler version 18.4
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -47,10 +49,11 @@ RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-communit
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
 
+    @docker
     def test_eula(self):
         """Accept EULA"""
         p = pgi(eula=True)
-        self.assertEqual(p.toString(container_type.DOCKER),
+        self.assertEqual(str(p),
 r'''# PGI compiler version 18.4
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -64,10 +67,11 @@ RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-communit
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
 
+    @docker
     def test_tarball(self):
         """tarball"""
         p = pgi(eula=True, tarball='pgilinux-2017-1710-x86_64.tar.gz')
-        self.assertEqual(p.toString(container_type.DOCKER),
+        self.assertEqual(str(p),
 r'''# PGI compiler version 17.10
 COPY pgilinux-2017-1710-x86_64.tar.gz /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz
 RUN apt-get update -y && \
@@ -80,11 +84,12 @@ RUN tar -x -f /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz -C /tmp/pgi -z && \
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         p = pgi()
         r = p.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# PGI compiler
 RUN apt-get update -y && \

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -34,35 +34,35 @@ class Test_pgi(unittest.TestCase):
         """Default pgi building block"""
         p = pgi()
         self.assertEqual(p.toString(container_type.DOCKER),
-r'''# PGI compiler version 17.10
+r'''# PGI compiler version 18.4
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer http://www.pgroup.com/products/community.htm -P /tmp/pgi http://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
+RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=decline ./install && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
 
     def test_eula(self):
         """Accept EULA"""
         p = pgi(eula=True)
         self.assertEqual(p.toString(container_type.DOCKER),
-r'''# PGI compiler version 17.10
+r'''# PGI compiler version 18.4
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer http://www.pgroup.com/products/community.htm -P /tmp/pgi http://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
+RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_SILENT=true PGI_ACCEPT_EULA=accept ./install && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
 
     def test_tarball(self):
         """tarball"""
@@ -85,16 +85,15 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
         p = pgi()
         r = p.runtime()
         s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
-        self.maxDiff = None
         self.assertEqual(s,
 r'''# PGI compiler
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         libnuma1 && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/pgi/linux86-64/17.10/REDIST/*.so /opt/pgi/linux86-64/17.10/lib/
-RUN ln -s /opt/pgi/linux86-64/17.10/lib/libpgnuma.so /opt/pgi/linux86-64/17.10/lib/libnuma.so
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/pgi/linux86-64/18.4/REDIST/*.so /opt/pgi/linux86-64/18.4/lib/
+RUN ln -s /opt/pgi/linux86-64/18.4/lib/libpgnuma.so /opt/pgi/linux86-64/18.4/lib/libnuma.so
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the python module"""
 
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker
+
 from hpccm.python import python
 
 class Test_python(unittest.TestCase):
@@ -30,10 +31,11 @@ class Test_python(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_defaults(self):
         """Default python building block"""
         p = python()
-        self.assertEqual(p.toString(container_type.DOCKER),
+        self.assertEqual(str(p),
 r'''# Python
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
@@ -41,11 +43,12 @@ RUN apt-get update -y && \
         python3 && \
     rm -rf /var/lib/apt/lists/*''')
 
+    @docker
     def test_runtime(self):
         """Runtime"""
         p = python()
         r = p.runtime()
-        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        s = '\n'.join(str(x) for x in r)
         self.assertEqual(s,
 r'''# Python
 RUN apt-get update -y && \

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the python module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.common import container_type
+from hpccm.python import python
+
+class Test_python(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_defaults(self):
+        """Default python building block"""
+        p = python()
+        self.assertEqual(p.toString(container_type.DOCKER),
+r'''# Python
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        python \
+        python3 && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    def test_runtime(self):
+        """Runtime"""
+        p = python()
+        r = p.runtime()
+        s = '\n'.join(x.toString(container_type.DOCKER) for x in r)
+        self.assertEqual(s,
+r'''# Python
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        python \
+        python3 && \
+    rm -rf /var/lib/apt/lists/*''')

--- a/test/test_raw.py
+++ b/test/test_raw.py
@@ -22,7 +22,8 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from hpccm.common import container_type
+from helpers import docker, invalid_ctype, singularity
+
 from hpccm.raw import raw
 
 class Test_raw(unittest.TestCase):
@@ -30,32 +31,51 @@ class Test_raw(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @docker
     def test_empty(self):
         """No raw strings specified"""
         r = raw()
-        self.assertEqual(r.toString(container_type.DOCKER), '')
+        self.assertEqual(str(r), '')
 
+    @invalid_ctype
     def test_invalid_ctype(self):
         """Invalid container type specified"""
         r = raw(docker='RAW')
-        self.assertEqual(r.toString(None), '')
+        with self.assertRaises(RuntimeError):
+            str(r)
 
-    def test_docker_only(self):
+    @docker
+    def test_docker_only_docker(self):
         """Only Docker string specified"""
         r = raw(docker='RAW string')
-        self.assertEqual(r.toString(container_type.DOCKER), 'RAW string')
-        self.assertEqual(r.toString(container_type.SINGULARITY), '')
+        self.assertEqual(str(r), 'RAW string')
 
-    def test_singularity_only(self):
+    @singularity
+    def test_docker_only_singularity(self):
+        """Only Docker string specified"""
+        r = raw(docker='RAW string')
+        self.assertEqual(str(r), '')
+
+    @docker
+    def test_singularity_only_docker(self):
         """Only Singularity string specified"""
         r = raw(singularity='%raw\n    string')
-        self.assertEqual(r.toString(container_type.DOCKER), '')
-        self.assertEqual(r.toString(container_type.SINGULARITY),
-                         '%raw\n    string')
+        self.assertEqual(str(r), '')
 
-    def test_all(self):
+    @singularity
+    def test_singularity_only_singularity(self):
+        """Only Singularity string specified"""
+        r = raw(singularity='%raw\n    string')
+        self.assertEqual(str(r), '%raw\n    string')
+
+    @docker
+    def test_all_docker(self):
         """Both Docker and Singularity strings specified"""
         r = raw(docker='RAW string', singularity='%raw\n    string')
-        self.assertEqual(r.toString(container_type.DOCKER), 'RAW string')
-        self.assertEqual(r.toString(container_type.SINGULARITY),
-                         '%raw\n    string')
+        self.assertEqual(str(r), 'RAW string')
+
+    @singularity
+    def test_all_singularity(self):
+        """Both Docker and Singularity strings specified"""
+        r = raw(docker='RAW string', singularity='%raw\n    string')
+        self.assertEqual(str(r), '%raw\n    string')

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
 
 """Test cases for the recipe module"""
 
@@ -35,21 +35,21 @@ class Test_recipe(unittest.TestCase):
         """No arguments"""
 
         with self.assertRaises(TypeError):
-            r = recipe()
+            recipe()
 
     def test_bad_recipe(self):
         """Bad (invalid) recipe file"""
         path = os.path.dirname(__file__)
         rf = os.path.join(path, 'bad_recipe.py')
         with self.assertRaises(SystemExit):
-            r = recipe(rf)
+            recipe(rf)
 
     def test_raise_exceptions(self):
         """Bad (invalid) recipe file with raise exceptions enabled"""
         path = os.path.dirname(__file__)
         rf = os.path.join(path, 'bad_recipe.py')
         with self.assertRaises(SyntaxError):
-            r = recipe(rf, raise_exceptions=True)
+            recipe(rf, raise_exceptions=True)
 
     def test_basic_example(self):
         """Basic example"""

--- a/test/test_sed.py
+++ b/test/test_sed.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the sed module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.sed import sed
+
+class Test_sed(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_basic(self):
+        """Basic sed"""
+        s = sed()
+        self.assertEqual(s.sed_step(file='foo',
+                                    patterns=[r's/a/A/g',
+                                              r's/FOO = BAR/FOO = BAZ/g']),
+r'''sed -i -e s/a/A/g \
+        -e 's/FOO = BAR/FOO = BAZ/g' foo''')
+
+    def test_nofile(self):
+        """No file specified"""
+        s = sed()
+        self.assertEqual(s.sed_step(patterns=[r's/a/A/g']), '')
+
+    def test_nopatterns(self):
+        """No patterns specified"""
+        s = sed()
+        self.assertEqual(s.sed_step(file='foo'), '')


### PR DESCRIPTION
The MVAPICH2 compiler wrappers, e.g., `mpicc`, do not work when called from the container build stage (there are no issues when used from a built container invoked with `nvidia-docker` or `singularity run --nv`).  The error is:

```
Step 16/16 : RUN cd /tmp &&     mpicc test.c
 ---> Running in 1ae33aa005a4
/usr/bin/ld: warning: libnvidia-ml.so.1, needed by /usr/local/mvapich2/lib/libmpi.so, not found (try using -rpath or -rpath-link)
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetMaxPcieLinkGeneration'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetName'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetMaxPcieLinkWidth'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetUUID'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetPciInfo_v3'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetSerial'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlShutdown'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlInit_v2'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetHandleByIndex_v2'
/usr/local/mvapich2/lib/libmpi.so: undefined reference to `nvmlDeviceGetCount_v2'
collect2: error: ld returned 1 exit status
The command '/bin/sh -c cd /tmp &&     mpicc test.c' returned a non-zero code: 1
```

The issue is that `libmpi.so` depends on `libnvidia-ml.so.1`, but the latter is not mapped into the container build process.

This fix uses the stub version of `libnvidia-ml.so` that is part of the CUDA toolkit.  It hijacks the MPI compiler wrapper profiling hooks (`PROFILE_POSTLIB`) to transparently add `-L/usr/local/cuda/lib64/stubs -lnvidia-ml` to the compiler command line.  This allows the MPI compiler wrappers to work in the container build context, but still resolves to the proper driver library at runtime.