### PR TITLE
Add MVAPICH2-GDR building block

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -442,8 +442,8 @@ Parameters:
   `libnuma1`, and `wget`.
 
 - `packages`: List of packages to install from Mellanox OFED.  The
-  default values are `libibverbs1`, `libibverbs-dev`, `libmlx5-1`, and
-  `ibverbs-utils`.
+  default values are `libibverbs1`, `libibverbs-dev`, `libibumad`,
+  `libibmad`, `libmlx5-1`, and `ibverbs-utils`.
 
 - `version`: The version of Mellanox OFED to download.  The default
   value is `3.4-1.0.0.0`.  Only versions that provide an Ubuntu 16.04
@@ -550,6 +550,85 @@ mvapich2(configure_opts=['--disable-fortran', '--disable-mcast'],
 
 ```python
 mv2 = mvapich2()
+Stage0 += mv2
+...
+Stage1 += mv2.runtime()
+```
+
+### mvapich2_gdr
+
+The `mvapich2_gdr` building blocks installs the
+[MVAPICH2-GDR](http://mvapich.cse.ohio-state.edu) component.
+Depending on the parameters, the package will be downloaded from the
+web (default) or copied from the local build context.
+
+MVAPICH2-GDR is distributed as a binary package, so certain
+dependencies need to be met and only certain combinations of recipe
+components are supported; please refer to the MVAPICH2-GDR
+documentation for more information.
+
+The [GNU compiler](#gnu) building block should be installed prior to
+this building block.
+
+The [Mellanox OFED](#mlnx_ofed) building block should be installed
+prior to this building block.
+
+As a side effect, this building block modifies `PATH` and
+`LD_LIBRARY_PATH` to include the MVAPICH2-GDR build.
+
+As a side effect, a toolchain is created containing the MPI compiler
+wrappers.  The toolchain can be passed to other operations that want
+to build using the MPI compiler wrappers.
+
+```python
+mv2 = mvapich2_gdr()
+
+operation(..., toolchain=mv2.toolchain, ...)
+```
+
+Parameters:
+
+- `cuda_version`: The version of CUDA the MVAPICH2-GDR package was
+  built against.  The version string format is X.Y.  The version
+  should match the version of CUDA provided by the base image.  This
+  value is ignored if `package` is set.  The default value is `9.0`.
+
+- `mlnx_ofed_version`: The version of Mellanox OFED the MVAPICH2-GDR
+  package was built against.  The version string format is X.Y.  The
+  version should match the version of Mellanox OFED installed by the
+  `mlnx_ofed` building block.  This value is ignored if `package` is
+  set.  The default value is `3.4`.
+
+- `ospackages`: List of OS packages to install prior to installation.
+  The default values are `openssh-client` and `wget`.
+
+- `package`: Path to the package file relative to the local build
+  context.  The default value is empty.  If this is defined, the
+  package in the local build context will be used rather than
+  downloading the package from the web.  The package should correspond
+  to the other recipe components (e.g., compiler version, CUDA
+  version, Mellanox OFED version).
+
+- `version`: The version of MVAPICH2-GDR to download.  The value is
+  ignored if `package` is set.  The default value is `2.3a`.
+
+Methods:
+
+- `runtime(_from='...')`: Generate the set of instructions to install
+  the runtime specific components from a build in a previous stage.
+
+Examples:
+
+```python
+mvapich2_gdr(version='2.3a')
+```
+
+```python
+mvapich2_gdr(package='mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb')
+```
+
+```python
+mv2 = mvapich2_gdr()
 Stage0 += mv2
 ...
 Stage1 += mv2.runtime()

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -35,6 +35,7 @@ from .hdf5 import hdf5
 from .label import label
 from .mlnx_ofed import mlnx_ofed
 from .mvapich2 import mvapich2
+from .mvapich2_gdr import mvapich2_gdr
 from .ofed import ofed
 from .openmpi import openmpi
 from .pgi import pgi

--- a/hpccm/mlnx_ofed.py
+++ b/hpccm/mlnx_ofed.py
@@ -47,6 +47,7 @@ class mlnx_ofed(tar, wget):
                                         'libnuma1', 'wget'])
         self.__packages = kwargs.get('packages',
                                      ['libibverbs1', 'libibverbs-dev',
+                                      'libibumad', 'libibmad',
                                       'libmlx5-1', 'ibverbs-utils'])
         self.__version = kwargs.get('version', '3.4-1.0.0.0')
 

--- a/hpccm/mvapich2_gdr.py
+++ b/hpccm/mvapich2_gdr.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""MVAPICH2-GDR building block"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+import re
+
+from .apt_get import apt_get
+from .comment import comment
+from .copy import copy
+from .environment import environment
+from .shell import shell
+from .toolchain import toolchain
+from .wget import wget
+
+class mvapich2_gdr(wget):
+    """MVAPICH2-GDR building block"""
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        # Trouble getting MRO with kwargs working correctly, so just call
+        # the parent class constructors manually for now.
+        #super(mvapich2_gdr, self).__init__(**kwargs)
+        wget.__init__(self, **kwargs)
+
+        self.__baseurl = kwargs.get('baseurl',
+                                    'http://mvapich.cse.ohio-state.edu/download/mvapich/gdr')
+        self.__cuda_version = kwargs.get('cuda_version', '9.0')
+        self.__gnu = kwargs.get('gnu', True)
+        self.__gnu_version = '4.8.5'
+        self.__mofed_version = kwargs.get('mlnx_ofed_version', '3.4')
+        self.__ospackages = kwargs.get('ospackages',
+                                       ['openssh-client', 'wget'])
+        self.__package = kwargs.get('package', '')
+        self.__pgi = kwargs.get('pgi', False)
+        self.__pgi_version = '17.10'
+        self.version = kwargs.get('version', '2.3a')
+        self.__wd = '/tmp' # working directory
+
+        # Output toolchain
+        self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',
+                                   F90='mpif90', FC='mpifort')
+
+        # Validate compiler choice
+        if self.__gnu and self.__pgi:
+            logging.warning('Multiple compilers selected, using PGI')
+            self.__gnu = False
+        elif not self.__gnu and not self.__pgi:
+            logging.warning('No compiler selected, using GNU')
+            self.__gnu = True
+
+        self.__commands = []              # Filled in by __setup()
+        self.__environment_variables = {} # Filled in by __setup()
+        self.__install_path = ''          # Filled in by __setup()
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        instructions = []
+        if self.__package:
+            instructions.append(comment('MVAPICH2-GDR'))
+        else:
+            instructions.append(comment(
+                'MVAPICH2-GDR version {}'.format(self.version)))
+
+        instructions.append(apt_get(ospackages=self.__ospackages))
+
+        if self.__package:
+            # Use source from local build context
+            instructions.append(copy(src=self.__package,
+                                     dest=os.path.join(self.__wd,
+                                                       self.__package)))
+
+        instructions.append(shell(commands=self.__commands))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+
+        return '\n'.join(str(x) for x in instructions)
+
+    def cleanup_step(self, items=None):
+        """Cleanup temporary files"""
+
+        if not items: # pragma: no cover
+            logging.warning('items are not defined')
+            return ''
+
+        return 'rm -rf {}'.format(' '.join(items))
+
+    def __setup(self):
+        """Construct the series of shell commands and environment variables,
+           i.e., fill in self.__commands and self.__environment_variables"""
+
+        if self.__package:
+            # Install a package from the local build context
+            package = self.__package
+
+            # Deduce version strings from package name
+            match = re.search(r'(?P<cuda>cuda\d+\.\d+)\.(?P<mofed>mofed\d+\.\d+)\.(?P<compiler>(gnu\d+\.\d+\.\d+)|(pgi\d+\.\d+))', package)
+            cuda_string = match.groupdict()['cuda']
+            mofed_string = match.groupdict()['mofed']
+            compiler_string = match.groupdict()['compiler']
+        else:
+            # Download a package
+
+            # Build the version strings based on the specified options
+            if self.__gnu:
+                compiler_string = 'gnu{}'.format(self.__gnu_version)
+            elif self.__pgi:
+                compiler_string = 'pgi{}'.format(self.__pgi_version)
+            else:
+                logging.error('Unknown compiler')
+                compiler_string = 'unknown'
+
+            cuda_string = 'cuda{}'.format(self.__cuda_version)
+            mofed_string = 'mofed{}'.format(self.__mofed_version)
+
+            # Package filename
+            package = 'mvapich2-gdr-mcast.{0}.{1}.{2}_{3}-1.el7.centos_amd64.deb'.format(cuda_string, mofed_string, compiler_string, self.version)
+        
+            # Download source from web
+            url = '{0}/{1}/{2}/{3}'.format(self.__baseurl, self.version,
+                                           mofed_string, package)
+            self.__commands.append(self.download_step(url=url,
+                                                      directory=self.__wd))
+
+        # Install the package
+        self.__commands.append('dpkg --install {0}'.format(
+            os.path.join(self.__wd, package)))
+
+        # Workaround for bad path in the MPI compiler wrappers
+        self.__commands.append('(test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash)')
+
+        # Cleanup
+        self.__commands.append(self.cleanup_step(
+            items=[os.path.join(self.__wd, package)]))
+
+        # Setup environment variables
+        self.__install_path = os.path.join('/opt', 'mvapich2', 'gdr',
+                                           self.version, 'mcast', 'no-openacc',
+                                           cuda_string, mofed_string,
+                                           'mpirun', compiler_string)
+        self.__environment_variables = {
+            'MV2_USE_GPUDIRECT_GDRCOPY': 0,
+            'PATH': '{}:$PATH'.format(os.path.join(self.__install_path,
+                                                   'bin')),
+            'LD_LIBRARY_PATH':
+            '{}:$LD_LIBRARY_PATH'.format(os.path.join(self.__install_path,
+                                                      'lib64'))}
+
+    def runtime(self, _from='0'):
+        """Install the runtime from a full build in a previous stage"""
+        instructions = []
+        instructions.append(comment('MVAPICH2-GDR'))
+        # TODO: move the definition of runtime ospackages
+        instructions.append(apt_get(ospackages=['openssh-client']))
+        instructions.append(copy(src=self.__install_path,
+                                 dest=self.__install_path, _from=_from))
+        instructions.append(environment(
+            variables=self.__environment_variables))
+        return instructions

--- a/hpccm/mvapich2_gdr.py
+++ b/hpccm/mvapich2_gdr.py
@@ -172,6 +172,7 @@ class mvapich2_gdr(wget):
             'LD_LIBRARY_PATH':
             '{}:$LD_LIBRARY_PATH'.format(os.path.join(self.__install_path,
                                                       'lib64')),
+            'MV2_USE_GPUDIRECT': 0,
             'MV2_USE_GPUDIRECT_GDRCOPY': 0,
             'PATH': '{}:$PATH'.format(os.path.join(self.__install_path,
                                                    'bin')),

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -43,6 +43,7 @@ from .hdf5 import hdf5               # pylint: disable=unused-import
 from .label import label             # pylint: disable=unused-import
 from .mlnx_ofed import mlnx_ofed     # pylint: disable=unused-import
 from .mvapich2 import mvapich2       # pylint: disable=unused-import
+from .mvapich2_gdr import mvapich2_gdr # pylint: disable=unused-import
 from .ofed import ofed               # pylint: disable=unused-import
 from .openmpi import openmpi         # pylint: disable=unused-import
 from .pgi import pgi                 # pylint: disable=unused-import

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -48,6 +48,8 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mella
     tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
     rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
@@ -70,6 +72,8 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://content.mella
     tar -x -f /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /tmp -z && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb && \
+    dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb && \
     dpkg --install /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb && \
     rm -rf /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -49,6 +49,7 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.o
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
     PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
@@ -71,6 +72,7 @@ RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.o
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
     PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
@@ -92,6 +94,7 @@ RUN dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
     PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
@@ -111,5 +114,6 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT=0 \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
     PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the mvapich2_gdr module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import docker
+
+from hpccm.mvapich2_gdr import mvapich2_gdr
+
+class Test_mvapich2_gdr(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @docker
+    def test_defaults(self):
+        """Default mvapich2_gdr building block"""
+        mv2 = mvapich2_gdr()
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR version 2.3a
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed3.4/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')
+
+    @docker
+    def test_options(self):
+        """PGI compiler and different Mellanox OFED version"""
+        mv2 = mvapich2_gdr(pgi=True, gnu=False, cuda_version='8.0', 
+                           mlnx_ofed_version='4.0')
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR version 2.3a
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed4.0/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
+    dpkg --install /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/bin:$PATH''')
+
+    @docker
+    def test_package(self):
+        """Directory in local build context"""
+        mv2 = mvapich2_gdr(package='mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb')
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2-GDR
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+COPY mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+RUN dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
+    (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')
+
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        mv2 = mvapich2_gdr()
+        r = mv2.runtime()
+        s = '\n'.join(str(x) for x in r)
+        self.maxDiff = None
+        self.assertEqual(s,
+r'''# MVAPICH2-GDR
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        openssh-client && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=0 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    MV2_USE_GPUDIRECT_GDRCOPY=0 \
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -35,6 +35,7 @@ class Test_mvapich2_gdr(unittest.TestCase):
     def test_defaults(self):
         """Default mvapich2_gdr building block"""
         mv2 = mvapich2_gdr()
+        self.maxDiff = None
         self.assertEqual(str(mv2),
 r'''# MVAPICH2-GDR version 2.3a
 RUN apt-get update -y && \
@@ -45,10 +46,12 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed3.4/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
     dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
     (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
-    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @docker
     def test_options(self):
@@ -65,10 +68,12 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp && wget -q --no-check-certificate -P /tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3a/mofed4.0/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
     dpkg --install /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb && \
     (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda8.0.mofed4.0.pgi17.10_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/lib64:$LD_LIBRARY_PATH \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
-    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/bin:$PATH''')
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpirun/pgi17.10/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @docker
     def test_package(self):
@@ -84,10 +89,12 @@ RUN apt-get update -y && \
 COPY mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
 RUN dpkg --install /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb && \
     (test ! -f /usr/bin/bash && ln -s /bin/bash /usr/bin/bash) && \
+    ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
     rm -rf /tmp/mvapich2-gdr-mcast.cuda9.0.mofed3.4.gnu4.8.5_2.3a-1.el7.centos_amd64.deb
 ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
     MV2_USE_GPUDIRECT_GDRCOPY=0 \
-    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH''')
+    PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @docker
     def test_runtime(self):


### PR DESCRIPTION
Add building block for MVAPICH2-GDR.

Contains 3 workarounds
1. The compiler wrappers look for /usr/bin/bash, but on Ubuntu that path does not exist.  Symlink /usr/bin/bash to /bin/bash.
2. The compiler wrappers pull in libnvidia-ml.so, but that library is not available during the container build stage.  Set `PROFILE_POSTLIB` to point to the stub version of the library.  This is all handled correctly at container runtime thanks to nvidia-docker.
3. Setting `MV2_USE_GPUDIRECT_GDRCOPY=0` since the gdrcopy kernel module may not be present.

A simple recipe to test / demonstrate the new building block:
```
Stage0 += baseimage(image='nvidia/cuda:9.0-devel-ubuntu16.04')
Stage0 += gnu()
Stage0 += mlnx_ofed()
Stage0 += mvapich2_gdr()
```