### PR TITLE
add Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+matrix:
+  include:
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+script:
+  - ./runtests.sh


### PR DESCRIPTION
Adding a Travis config file is useful to ensure the tests pass at all times, and is especially handy when you start getting contributions from others.

See also https://docs.travis-ci.com/user/getting-started/ .