### PR TITLE
Add option to specify the CUDA install used by the PGI compiler

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -867,11 +867,6 @@ Parameters:
   bundled with the PGI compiler will be installed.  The default value
   is False.
 
-- `system_cuda`: Boolean flag to specify whether the PGI compiler
-  should use the system CUDA.  If False, the version(s) of CUDA
-  bundled with the PGI compiler will be installed.  The default value
-  is False.
-
 - `tarball`: Path to the PGI compiler tarball relative to the local
   build context.  The default value is empty.  If this is defined, the
   tarball in the local build context will be used rather than

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -862,6 +862,11 @@ Parameters:
   also `wget` (if downloading the PGI compiler rather than using a
   tarball in the local build context).
 
+- `system_cuda`: Boolean flag to specify whether the PGI compiler
+  should use the system CUDA.  If False, the version(s) of CUDA
+  bundled with the PGI compiler will be installed.  The default value
+  is False.
+
 - `tarball`: Path to the PGI compiler tarball relative to the local
   build context.  The default value is empty.  If this is defined, the
   tarball in the local build context will be used rather than

--- a/hpccm/pgi.py
+++ b/hpccm/pgi.py
@@ -164,6 +164,9 @@ class pgi(tar, wget):
             logging.warning('PGI EULA was not accepted')
             self.__commands.append('cd {} && PGI_ACCEPT_EULA=decline ./install'.format(self.__wd))
 
+        # Create siterc to specify use of the system CUDA
+        self.__commands.append('echo "set CUDAROOT=/usr/local/cuda;" >> {}'.format(os.path.join(self.__basepath, self.__version, 'bin', 'siterc')))
+
         self.__commands.append(self.cleanup_step(
             items=[os.path.join(self.__wd, tarball), self.__wd]))
 

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -46,8 +46,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
-    cd /tmp/pgi && PGI_ACCEPT_EULA=decline ./install && \
-    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    cd /tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_NVIDIA=true PGI_SILENT=false ./install && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -86,8 +85,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
-    cd /tmp/pgi && PGI_SILENT=true PGI_ACCEPT_EULA=accept ./install && \
-    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=true PGI_SILENT=true ./install && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -106,13 +104,31 @@ RUN apt-get update -y && \
         perl && \
     rm -rf /var/lib/apt/lists/*
 RUN tar -x -f /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz -C /tmp/pgi -z && \
-    cd /tmp/pgi && PGI_SILENT=true PGI_ACCEPT_EULA=accept ./install && \
-    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=true PGI_SILENT=true ./install && \
     rm -rf /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
 
     @ubuntu
+    @docker
+    def test_system_cuda(self):
+        """tarball"""
+        p = pgi(eula=True, system_cuda=True)
+        self.assertEqual(str(p),
+r'''# PGI compiler version 18.4
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
+    tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
+    cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=false PGI_SILENT=true ./install && \
+    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+
     @docker
     def test_runtime(self):
         """Runtime"""

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -47,6 +47,7 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=decline ./install && \
+    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -86,6 +87,7 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_SILENT=true PGI_ACCEPT_EULA=accept ./install && \
+    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -105,6 +107,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN tar -x -f /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_SILENT=true PGI_ACCEPT_EULA=accept ./install && \
+    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
     rm -rf /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')


### PR DESCRIPTION
Add a parameter to the PGI building block to specify whether to use the system CUDA or have PGI install it's own CUDA.  The default is for PGI to install its own CUDA.