### PR TITLE
PGI compiler recognizing LIBRARY_PATH

### DIFF
--- a/hpccm/pgi.py
+++ b/hpccm/pgi.py
@@ -176,8 +176,15 @@ class pgi(tar, wget):
                                                                 flag_string))
 
         # Create siterc to specify use of the system CUDA
+        siterc = os.path.join(self.__basepath, self.__version, 'bin', 'siterc')
         if self.__system_cuda:
-            self.__commands.append('echo "set CUDAROOT=/usr/local/cuda;" >> {}'.format(os.path.join(self.__basepath, self.__version, 'bin', 'siterc')))
+            self.__commands.append('echo "set CUDAROOT=/usr/local/cuda;" >> {}'.format(siterc))
+
+        # Create siterc to respect LIBRARY_PATH
+        # https://www.pgroup.com/support/faq.htm#lib_path_ldflags
+        self.__commands.append(r'echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> {}'.format(siterc))
+        self.__commands.append(r'echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> {}'.format(siterc))
+        self.__commands.append(r'echo "append LDLIBARGS=\$library_path;" >> {}'.format(siterc))
 
         self.__commands.append(self.cleanup_step(
             items=[os.path.join(self.__wd, tarball), self.__wd]))

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -47,6 +47,9 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_NVIDIA=true PGI_SILENT=false ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -66,6 +69,9 @@ RUN yum install -y \
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_NVIDIA=true PGI_SILENT=false ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -86,6 +92,9 @@ RUN apt-get update -y && \
 RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /tmp/pgi https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=true PGI_SILENT=true ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
@@ -105,6 +114,9 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN tar -x -f /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=true PGI_SILENT=true ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
     rm -rf /tmp/pgi/pgilinux-2017-1710-x86_64.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
@@ -126,6 +138,9 @@ RUN mkdir -p /tmp/pgi && wget -q --no-check-certificate -O /tmp/pgi/pgi-communit
     tar -x -f /tmp/pgi/pgi-community-linux-x64-latest.tar.gz -C /tmp/pgi -z && \
     cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=false PGI_SILENT=true ./install && \
     echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
     rm -rf /tmp/pgi/pgi-community-linux-x64-latest.tar.gz /tmp/pgi
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')


### PR DESCRIPTION
By default the PGI compiler does not recognize `LIBRARY_PATH`.  This implements the workaround described at https://www.pgroup.com/support/faq.htm?tab=link#lib_path_ldflags.