### PR TITLE
Fix issue with leading zero in PGI compiler version

### DIFF
--- a/hpccm/pgi.py
+++ b/hpccm/pgi.py
@@ -139,7 +139,7 @@ class pgi(tar, wget):
             tarball = self.__tarball
 
             # Figure out the version from the tarball name
-            match = re.match(r'pgilinux-\d+-(?P<year>\d\d)(?P<month>\d\d)',
+            match = re.match(r'pgilinux-\d+-(?P<year>\d\d)0?(?P<month>[1-9][0-9]?)',
                              tarball)
             if match.groupdict()['year'] and match.groupdict()['month']:
                 self.__version = '{0}.{1}'.format(match.groupdict()['year'],

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -123,6 +123,28 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_tarball_leading_zero(self):
+        """tarball"""
+        p = pgi(eula=True, tarball='pgilinux-2018-1804-x86_64.tar.gz')
+        self.assertEqual(str(p),
+r'''# PGI compiler version 18.4
+COPY pgilinux-2018-1804-x86_64.tar.gz /tmp/pgi/pgilinux-2018-1804-x86_64.tar.gz
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        libnuma1 \
+        perl && \
+    rm -rf /var/lib/apt/lists/*
+RUN tar -x -f /tmp/pgi/pgilinux-2018-1804-x86_64.tar.gz -C /tmp/pgi -z && \
+    cd /tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_NVIDIA=true PGI_SILENT=true ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    rm -rf /tmp/pgi/pgilinux-2018-1804-x86_64.tar.gz /tmp/pgi
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_system_cuda(self):
         """System CUDA"""
         p = pgi(eula=True, system_cuda=True)


### PR DESCRIPTION
When using the PGI `tarball` option, if the filename contained a version string with a leading zero, e.g., `1804`, then the version was incorrectly set to `18.04` rather than `18.4`.