### PR TITLE
Added user-primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v18.8.0
+
+- Added `user`-primitive for setting the active user in Dockerfiles, usage: `Stage0 += user(user='root')`
+
 # v18.7.0
 
 - Adds Charm++ (`charm`), Intel Parallel Studio XE (`intel_psxe`), and

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ $ pip install https://github.com/NVIDIA/hpc-container-maker/tarball/master
 In either case, `hpccm` will be installed in your `PATH`.
 
 You can also use `hpccm.py` or `python -m hpccm.cli` from a clone of
-the repository without having to install anything.
+the repository without having to install anything (maybe you have to install the `six`-package: `pip install six`).
 
 The sections below assume `hpccm.py` from a clone of the repository.
 

--- a/hpccm/primitives/user.py
+++ b/hpccm/primitives/user.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""User primitive"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+import hpccm.config
+
+from hpccm.common import container_type
+
+class user(object):
+    """User primitive"""
+
+    def __init__(self, **kwargs):
+        """Initialize primitive"""
+
+        self.user = kwargs.get('user', '')
+
+    def __str__(self):
+        """String representation of the primitive"""
+        if self.user:
+            if hpccm.config.g_ctype == container_type.DOCKER:
+                return 'USER {}'.format(self.user)
+            elif hpccm.config.g_ctype == container_type.SINGULARITY:
+                return ''
+            else:
+                raise RuntimeError('Unknown container type')
+        else:
+            logging.error('No user specified')
+            return ''

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -40,6 +40,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.label import label
 from hpccm.primitives.raw import raw
 from hpccm.primitives.shell import shell
+from hpccm.primitives.user import user
 from hpccm.primitives.workdir import workdir
 
 # Building blocks

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the user module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import docker, invalid_ctype, singularity
+
+from hpccm.primitives.user import user
+
+class Test_user(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @docker
+    def test_empty(self):
+        """No user specified"""
+        u = user()
+        self.assertEqual(str(u), '')
+
+    @invalid_ctype
+    def test_invalid_ctype(self):
+        """Invalid container type specified"""
+        u = user(user='root')
+        with self.assertRaises(RuntimeError):
+            str(u)
+
+    @docker
+    def test_docker(self):
+        """User specified"""
+        u = user(user='root')
+        self.assertEqual(str(u), 'USER root')
+
+    @singularity
+    def test_singularity(self):
+        """User specified"""
+        u = user(user='root')
+        self.assertEqual(str(u), '')


### PR DESCRIPTION
Usage:

```python
Stage0 += user(user='root')
```

Is useful when using a base image where the active user is not root, e.g. `centos/devtoolset-6-toolchain-centos7`. Applies only to Docker.