### PR TITLE
Added option lfs to git().clone_step()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v18.8.0
 
 - Added `user`-primitive for setting the active user in Dockerfiles, usage: `Stage0 += user(user='root')`
+- Added option `lfs` to `git().clone_step()` to pull lfs files faster, usage: `git().clone_step(..., lfs=True)`
 
 # v18.7.0
 

--- a/hpccm/templates/git.py
+++ b/hpccm/templates/git.py
@@ -65,7 +65,7 @@ class git(object):
         return
 
     def clone_step(self, branch=None, commit=None, directory='', path='/tmp',
-                   repository=None, verify=None):
+                   repository=None, verify=None, lfs=False):
         """Clone a git repository"""
 
         if not repository:
@@ -105,13 +105,18 @@ class git(object):
             self.__verify(repository, branch=branch, commit=commit,
                           fatal=fatal)
 
+        # If lfs=True use `git lfs clone`
+        lfs_string = " "
+        if lfs:
+          lfs_string = " lfs "
+
         # Ensure the path exists
         # Would prefer to use 'git -C', but the ancient git included
         # with CentOS7 does not support that option.
         clone = ['mkdir -p {0}'.format(path),
                  'cd {0}'.format(path),
-                 'git clone {0} {1} {2}'.format(
-                     opt_string, repository, directory).strip(),
+                 'git{0}clone {1} {2} {3}'.format(
+                     lfs_string, opt_string, repository, directory).strip(),
                  'cd -']
 
         if commit:

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -76,6 +76,13 @@ class Test_git(unittest.TestCase):
                                       directory='hpccm'),
                          'mkdir -p /tmp && cd /tmp && git clone --depth=1 https://github.com/NVIDIA/hpc-container-maker.git hpccm && cd -')
 
+    def test_lfs(self):
+        """Basic git"""
+        g = git()
+        self.assertEqual(g.clone_step(repository='https://github.com/NVIDIA/hpc-container-maker.git',
+                                      lfs=True),
+                         'mkdir -p /tmp && cd /tmp && git lfs clone --depth=1 https://github.com/NVIDIA/hpc-container-maker.git hpc-container-maker && cd -')
+
     def test_opts(self):
         """git with non-default command line options"""
         g = git(opts=['--single-branch'])


### PR DESCRIPTION
Added option `lfs` to `git().clone_step()` to pull lfs-tracked files faster.

Usage:

```python
git().clone_step(..., lfs=True)
```