### PR TITLE
Added a missing cd - in openmpi block.

### DIFF
--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -186,6 +186,8 @@ class openmpi(ConfigureMake, tar, wget):
 
         self.__commands.append(self.install_step())
 
+        self.__commands.append('cd -')
+
         if self.directory:
             # Using source from local build context, cleanup directory
             self.__commands.append(self.cleanup_step(


### PR DESCRIPTION
Before this fix this was an example output for Singularity:

```
%post
    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.2.tar.bz2
    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.0.2.tar.bz2 -C /var/tmp -j
    cd /var/tmp/openmpi-3.0.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --without-cuda --with-verbs
    make -j4
    make -j4 install
    rm -rf /var/tmp/openmpi-3.0.2.tar.bz2 /var/tmp/openmpi-3.0.2
```

You see that on the last line the directory is deleted which is also the current working directory (`/var/tmp/openmpi-3.0.2`). This lead to failure in subsequent commands, e.g. `git.clone_step()`.