### PR TITLE
Change directory to / at the beginning of Singularity %post blocks

### DIFF
--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -49,7 +49,7 @@ class apt_get(object):
 
     def __str__(self):
         """String representation of the building block"""
-        return str(shell(commands=self.__commands))
+        return str(shell(chdir=False, commands=self.__commands))
 
     def __setup(self):
         """Construct the series of commands to execute"""

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -50,7 +50,7 @@ class yum(object):
 
     def __str__(self):
         """String representation of the building block"""
-        return str(shell(commands=self.__commands))
+        return str(shell(chdir=False, commands=self.__commands))
 
     def __setup(self):
         """Construct the series of commands to execute"""

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -70,7 +70,8 @@ class baseimage(object):
         elif hpccm.config.g_ctype == container_type.SINGULARITY:
             # Singularity does not inherit the environment from the
             # Docker base image automatically.  Do it manually.
-            docker_env = shell(commands=['. /.singularity.d/env/10-docker.sh'])
+            docker_env = shell(chdir=False,
+                               commands=['. /.singularity.d/env/10-docker.sh'])
             return 'BootStrap: docker\nFrom: {0}\n{1}'.format(self.image,
                                                               str(docker_env))
         else:

--- a/hpccm/primitives/shell.py
+++ b/hpccm/primitives/shell.py
@@ -54,6 +54,7 @@ class shell(object):
                 #     cmd2
                 #     cmd3
                 s = ['%post']
+                s.append('    cd /') # for consistency with Docker
                 s.extend(['    {}'.format(x) for x in self.commands])
                 return '\n'.join(s)
             else:

--- a/hpccm/primitives/shell.py
+++ b/hpccm/primitives/shell.py
@@ -34,6 +34,7 @@ class shell(object):
 
         #super(wget, self).__init__()
 
+        self.chdir = kwargs.get('chdir', True)
         self.commands = kwargs.get('commands', [])
 
     def __str__(self):
@@ -54,7 +55,13 @@ class shell(object):
                 #     cmd2
                 #     cmd3
                 s = ['%post']
-                s.append('    cd /') # for consistency with Docker
+
+                # For consistency with Docker. Docker resets the
+                # working directory to '/' at the beginning of each
+                # 'RUN' instruction.
+                if self.chdir:
+                    s.append('    cd /')
+
                 s.extend(['    {}'.format(x) for x in self.commands])
                 return '\n'.join(s)
             else:

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -67,6 +67,7 @@ class Test_baseimage(unittest.TestCase):
 r'''BootStrap: docker
 From: foo
 %post
+    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker
@@ -83,6 +84,7 @@ From: foo
 r'''BootStrap: docker
 From: foo
 %post
+    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker
@@ -99,6 +101,7 @@ From: foo
 r'''BootStrap: docker
 From: foo
 %post
+    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -67,7 +67,6 @@ class Test_baseimage(unittest.TestCase):
 r'''BootStrap: docker
 From: foo
 %post
-    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker
@@ -84,7 +83,6 @@ From: foo
 r'''BootStrap: docker
 From: foo
 %post
-    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker
@@ -101,7 +99,6 @@ From: foo
 r'''BootStrap: docker
 From: foo
 %post
-    cd /
     . /.singularity.d/env/10-docker.sh''')
 
     @docker

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -78,7 +78,6 @@ From: ubuntu:16.04
     . /.singularity.d/env/10-docker.sh
 
 %post
-    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         gcc \
@@ -130,7 +129,6 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
 
 # GNU compiler
 %post
-    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         gcc \
@@ -140,7 +138,6 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
 
 # FFTW version 3.3.7
 %post
-    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         file \

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -75,9 +75,11 @@ RUN apt-get update -y && \
 r'''BootStrap: docker
 From: ubuntu:16.04
 %post
+    cd /
     . /.singularity.d/env/10-docker.sh
 
 %post
+    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         gcc \
@@ -125,10 +127,12 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 r'''BootStrap: docker
 From: nvidia/cuda:9.0-devel-ubuntu16.04
 %post
+    cd /
     . /.singularity.d/env/10-docker.sh
 
 # GNU compiler
 %post
+    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         gcc \
@@ -138,6 +142,7 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
 
 # FFTW version 3.3.7
 %post
+    cd /
     apt-get update -y
     apt-get install -y --no-install-recommends \
         file \
@@ -145,6 +150,7 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
         wget
     rm -rf /var/lib/apt/lists/*
 %post
+    cd /
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz
     mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z
     cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -75,7 +75,6 @@ RUN apt-get update -y && \
 r'''BootStrap: docker
 From: ubuntu:16.04
 %post
-    cd /
     . /.singularity.d/env/10-docker.sh
 
 %post
@@ -127,7 +126,6 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 r'''BootStrap: docker
 From: nvidia/cuda:9.0-devel-ubuntu16.04
 %post
-    cd /
     . /.singularity.d/env/10-docker.sh
 
 # GNU compiler

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -59,14 +59,14 @@ class Test_shell(unittest.TestCase):
         self.assertEqual(str(s), '%post\n    cd /\n    z')
 
     @docker
-    def test_nochdir(self):
+    def test_nochdir_docker(self):
         """chdir disable"""
         cmd = ['z']
         s = shell(chdir=False, commands=cmd)
         self.assertEqual(str(s), 'RUN z')
 
     @singularity
-    def test_nochdir(self):
+    def test_nochdir_singularity(self):
         """chdir disable"""
         cmd = ['z']
         s = shell(chdir=False, commands=cmd)

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -59,6 +59,20 @@ class Test_shell(unittest.TestCase):
         self.assertEqual(str(s), '%post\n    cd /\n    z')
 
     @docker
+    def test_nochdir(self):
+        """chdir disable"""
+        cmd = ['z']
+        s = shell(chdir=False, commands=cmd)
+        self.assertEqual(str(s), 'RUN z')
+
+    @singularity
+    def test_nochdir(self):
+        """chdir disable"""
+        cmd = ['z']
+        s = shell(chdir=False, commands=cmd)
+        self.assertEqual(str(s), '%post\n    z')
+
+    @docker
     def test_multiple_docker(self):
         """List of commands specified"""
         cmds = ['a', 'b', 'c']

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -56,7 +56,7 @@ class Test_shell(unittest.TestCase):
         """Single command specified"""
         cmd = ['z']
         s = shell(commands=cmd)
-        self.assertEqual(str(s), '%post\n    z')
+        self.assertEqual(str(s), '%post\n    cd /\n    z')
 
     @docker
     def test_multiple_docker(self):
@@ -70,4 +70,4 @@ class Test_shell(unittest.TestCase):
         """List of commands specified"""
         cmds = ['a', 'b', 'c']
         s = shell(commands=cmds)
-        self.assertEqual(str(s), '%post\n    a\n    b\n    c')
+        self.assertEqual(str(s), '%post\n    cd /\n    a\n    b\n    c')

--- a/test/test_workdir.py
+++ b/test/test_workdir.py
@@ -54,4 +54,4 @@ class Test_workdir(unittest.TestCase):
     def test_dir_singularity(self):
         """Working directory specified"""
         w = workdir(directory='foo')
-        self.assertEqual(str(w), '%post\n    mkdir -p foo\n    cd foo')
+        self.assertEqual(str(w), '%post\n    cd /\n    mkdir -p foo\n    cd foo')


### PR DESCRIPTION
Docker resets the current working directory to / for each RUN instruction, while Singularity does not do the same for each %post block.

For example:

```
RUN cd /tmp && pwd
RUN pwd
```

returns

```
/tmp
/
```

while

```
%post
    cd /tmp
    pwd

%post
    pwd
```

returns

```
/tmp
/tmp
```

This change makes Singularity behave the same as Docker so recipe behavior is consistent.  It automatically inserts `cd /` at the top of each `%post` block, except when specifically disabled using `shell(chdir=False, commands=[...])`.