### PR TITLE
Added env var FORCE_UNSAFE_CONFIGURE=1 to spack recipe.

### DIFF
--- a/recipes/spack.py
+++ b/recipes/spack.py
@@ -37,7 +37,8 @@ Stage0 += shell(commands=[
     '/opt/spack/bin/spack bootstrap',
     'ln -s /opt/spack/share/spack/setup-env.sh /etc/profile.d/spack.sh',
     'ln -s /opt/spack/share/spack/spack-completion.bash /etc/profile.d'])
-Stage0 += environment(variables={'PATH': '/opt/spack/bin:$PATH'})
+Stage0 += environment(variables={'PATH': '/opt/spack/bin:$PATH',
+                                 'FORCE_UNSAFE_CONFIGURE': '1'})
 
 spack_package = USERARG.get('package', None)
 if spack_package:


### PR DESCRIPTION
Without this env var some spack package installations may fail due to running as root, e.g. the `tar`-package. See point `2.` in

https://spack.readthedocs.io/en/latest/workflows.html#using-spack-to-create-docker-images