### PR TITLE
Include CUDA stub libraries when building MVAPICH2 with CUDA support

### DIFF
--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -169,6 +169,9 @@ class mvapich2(ConfigureMake, rm, sed, tar, wget):
                     toolchain.LD_LIBRARY_PATH = os.path.join(cuda_home,
                                                              'lib64', 'stubs') + ':$LD_LIBRARY_PATH'
             else:
+                if not toolchain.LD_LIBRARY_PATH:
+                    toolchain.LD_LIBRARY_PATH = os.path.join(cuda_home,
+                                                             'lib64', 'stubs') + ':$LD_LIBRARY_PATH'
                 self.configure_opts.append(
                     '--enable-cuda --with-cuda={}'.format(cuda_home))
 

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -50,7 +50,7 @@ RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stub
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    cd /var/tmp/mvapich2-2.3rc2 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
     rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
@@ -108,7 +108,7 @@ RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stub
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3b.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3b.tar.gz -C /var/tmp -z && \
     sed -i -e 's/-arch sm_20/-arch sm_60/g' /var/tmp/mvapich2-2.3b/Makefile.in && \
-    cd /var/tmp/mvapich2-2.3b &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    cd /var/tmp/mvapich2-2.3b &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
     rm -rf /var/tmp/mvapich2-2.3b.tar.gz /var/tmp/mvapich2-2.3b
@@ -157,7 +157,7 @@ RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stub
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    cd /var/tmp/mvapich2-2.3rc2 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
     rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
@@ -182,7 +182,7 @@ RUN apt-get update -y && \
 COPY mvapich2-2.3 /var/tmp/mvapich2-2.3
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    cd /var/tmp/mvapich2-2.3 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
     rm -rf /var/tmp/mvapich2-2.3


### PR DESCRIPTION
Fix error `configure: error: Unable to run program linked with CUDA` when building some configurations.