### PR TITLE
Do not use deprecated Intel MPI path

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -618,7 +618,7 @@ Parameters:
   subsequent container image build steps; the environment is available
   when the container image is run.  To set the Intel MPI environment
   in subsequent build steps you can explicitly call `source
-  /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh
+  /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh
   intel64` in each build step.  If this value is to set `False`, then
   the environment is set such that the environment is visible to both
   subsequent container image build steps and when the container image

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -86,7 +86,7 @@ class intel_mpi(wget):
             # Source the mpivars environment script when starting the
             # container, but the variables not be available for any
             # subsequent build steps.
-            instructions.append(shell(commands=['echo "source /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh intel64" >> {}'.format(self.__bashrc)]))
+            instructions.append(shell(commands=['echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> {}'.format(self.__bashrc)]))
         else:
             # Set the environment so that it will be available to
             # subsequent build steps and when starting the container,
@@ -94,8 +94,8 @@ class intel_mpi(wget):
             # environment script.
             instructions.append(environment(variables={
                 'I_MPI_ROOT': '/opt/intel/compilers_and_libraries/linux/mpi',
-                'LD_LIBRARY_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/lib64:$LD_LIBRARY_PATH',
-                'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/bin64:$PATH'}))
+                'LD_LIBRARY_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib:$LD_LIBRARY_PATH',
+                'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:$PATH'}))
 
         return '\n'.join(str(x) for x in instructions)
 

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -58,7 +58,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     apt-get install -y --no-install-recommends \
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
-RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh intel64" >> /etc/bash.bashrc''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
 
     @centos
     @docker
@@ -72,7 +72,7 @@ RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW
     yum install -y \
         intel-mpi-2018.3-051 && \
     rm -rf /var/cache/yum/*
-RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh intel64" >> /etc/bashrc''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bashrc''')
 
     @ubuntu
     @docker
@@ -93,7 +93,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     apt-get install -y --no-install-recommends \
         intel-mpi-2018.2-046 && \
     rm -rf /var/lib/apt/lists/*
-RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh intel64" >> /etc/bash.bashrc''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
 
     @ubuntu
     @docker
@@ -115,8 +115,8 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
 ENV I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
-    LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries/linux/mpi/lib64:$LD_LIBRARY_PATH \
-    PATH=/opt/intel/compilers_and_libraries/linux/mpi/bin64:$PATH''')
+    LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -138,4 +138,4 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     apt-get install -y --no-install-recommends \
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
-RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/bin64/mpivars.sh intel64" >> /etc/bash.bashrc''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')


### PR DESCRIPTION
Use `/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin` rather than `/opt/intel/compilers_and_libraries/linux/mpi/bin64`.