### PR TITLE
Add man-db package dependency to the intel_mpi building block

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -645,8 +645,8 @@ Parameters:
 
 - `ospackages`: List of OS packages to install prior to installing
   Intel MPI.  For Ubuntu, the default values are
-  `apt-transport-https`, `ca-certificates`, and `wget`.  For
-  RHEL-based Linux distributions, the default is an empty list.
+  `apt-transport-https`, `ca-certificates`, `man-db`, and `wget`.  For
+  RHEL-based Linux distributions, the default value is `man-db`.
 
 - `version`: The version of Intel MPI to install.  The default value
   is `2018.3-051`.

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -106,13 +106,13 @@ class intel_mpi(wget):
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
                 self.__ospackages = ['apt-transport-https', 'ca-certificates',
-                                     'wget']
+                                     'man-db', 'wget']
 
             self.__bashrc = '/etc/bash.bashrc'
 
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
-                self.__ospackages = []
+                self.__ospackages = ['man-db']
 
             self.__bashrc = '/etc/bashrc'
 

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -50,6 +50,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        man-db \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
@@ -67,6 +68,9 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         impi = intel_mpi(eula=True)
         self.assertEqual(str(impi),
 r'''# Intel MPI version 2018.3-051
+RUN yum install -y \
+        man-db && \
+    rm -rf /var/cache/yum/*
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mpi/setup/intel-mpi.repo && \
     yum install -y \
@@ -85,6 +89,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        man-db \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
@@ -106,6 +111,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        man-db \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
@@ -130,6 +136,7 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        man-db \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \


### PR DESCRIPTION
Building Singularity images fails due to a missing `manpath` dependency.