### PR TITLE
Fix setting of global container type.

### DIFF
--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -84,6 +84,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
     Stage0 = stages[0] # alias # pylint: disable=unused-variable
     Stage1 = stages[1] # alias # pylint: disable=unused-variable
 
+    # Set the global container type
+    hpccm.config.g_ctype = ctype
+
     try:
         with open(recipe_file) as f:
             # pylint: disable=exec-used
@@ -94,9 +97,6 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
         else:
             logging.error(e)
             exit(1)
-
-    # Set the global container type
-    hpccm.config.g_ctype = ctype
 
     # Only process the first stage of a recipe
     if single_stage:

--- a/test/global_vars_recipe.py
+++ b/test/global_vars_recipe.py
@@ -1,0 +1,5 @@
+import hpccm
+from hpccm.common import container_type
+
+if hpccm.config.g_ctype != container_type.SINGULARITY:
+    raise Exception("Global variable g_ctype not set correctly!")

--- a/test/test_global_vars.py
+++ b/test/test_global_vars.py
@@ -1,0 +1,22 @@
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+import os
+
+from helpers import docker, ubuntu
+
+from hpccm.common import container_type
+from hpccm.recipe import recipe
+
+class Test_global_vars(unittest.TestCase):
+    def test_global_vars(self):
+        """Global variables"""
+        path = os.path.dirname(__file__)
+        rf = os.path.join(path, 'global_vars_recipe.py')
+        try:
+            recipe(rf, ctype=container_type.SINGULARITY, raise_exceptions=True)
+        except Exception as e:
+            self.fail(e)


### PR DESCRIPTION
The global variable has to be set before `exec(compile(f.read(), recipe_file, 'exec'))`.
Otherwise the variable is not properly set in the recipe itself (i.e. it is always set to its default value of `DOCKER`).

When using the variable in a building block it worked without this fix as they are evaluated later than the recipe itself.