### PR TITLE
include documentation, recipes, and other misc files in Python source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+include CHANGELOG.md
+include LICENSE
+include README.md
+include RECIPES.md
+include hpccm.py
+include test/bad_recipe.py
+include test/docker.blob
+include test/global_vars_recipe.py
+include test/helpers.py
+include test/singularity.blob
+graft recipes


### PR DESCRIPTION
When building a Python source distribution (`python setup.py sdist`), some files were not being included.