### PR TITLE
bump default building block component versions

### DIFF
--- a/RECIPES.md
+++ b/RECIPES.md
@@ -21,7 +21,7 @@ Stage0.baseimage('nvidia/cuda:9.0-devel')
 ospackages = ['make', 'wget']
 Stage0 += apt_get(ospackages=ospackages)
 
-p = pgi(eula=True, version='18.4')
+p = pgi(eula=True)
 Stage0 += p
 
 # Use the PGI toolchain to build OpenMPI                                
@@ -256,7 +256,7 @@ Parameters:
   SourceForge repository should be used.  The default is False.
 
 - `version`: The version of Boost source to download.  The default
-  value is `1.67.0`.
+  value is `1.68.0`.
 
 Methods:
 
@@ -388,7 +388,7 @@ Parameters:
   `/usr/local`.
 
 - `version`: The version of CMake to download.  The default value is
-  `3.11.1`.
+  `3.12.3`.
 
 Examples:
 
@@ -438,7 +438,7 @@ Parameters:
   default is empty.
 
 - `version`: The version of FFTW source to download.  This value is
-  ignored if `directory` is set.  The default value is `3.3.7`.
+  ignored if `directory` is set.  The default value is `3.3.8`.
 
 Methods:
 
@@ -577,7 +577,7 @@ Parameters:
   default is empty.
 
 - `version`: The version of HDF5 source to download.  This value is
-  ignored if `directory` is set.  The default value is `1.10.1`.
+  ignored if `directory` is set.  The default value is `1.10.4`.
 
 Methods:
 
@@ -824,7 +824,7 @@ Parameters:
   the default is an empty list.
 
 - `version`: The version of MKL to install.  The default value is
-  `2018.3-051`.
+  `2019.0-045`.
 
 Methods:
 
@@ -953,7 +953,7 @@ Parameters:
   default is empty.
 
 - `version`: The version of MVAPICH2 source to download.  This value
-  is ignored if `directory` is set.  The default value is `2.3b`.
+  is ignored if `directory` is set.  The default value is `2.3`.
 
 Methods:
 
@@ -971,7 +971,7 @@ mvapich2(directory='sources/mvapich2-2.3b')
 ```
 
 ```python
-p = pgi()
+p = pgi(eula=True)
 mvapich2(toolchain=p.toolchain)
 ```
 
@@ -1193,7 +1193,7 @@ Parameters:
   default is empty.
 
 - `version`: The version of OpenBLAS source to download.  The default
-  value is `0.3.1`.
+  value is `0.3.3`.
 
 Methods:
 
@@ -1278,7 +1278,7 @@ Parameters:
   default is empty.
 
 - `version`: The version of OpenMPI source to download.  This value is
-  ignored if `directory` is set.  The default value is `3.0.0`.
+  ignored if `directory` is set.  The default value is `3.1.2`.
 
 Methods:
 
@@ -1441,7 +1441,7 @@ Parameters:
 - `version`: The version of the PGI compiler to use.  Note this value
   is currently only used when setting the environment and does not
   control the version of the compiler downloaded.  The default value
-  is `18.4`.
+  is `18.10`.
 
 Methods:
 
@@ -1451,7 +1451,7 @@ Methods:
 Examples:
 
 ```python
-pgi(eula=True, version='18.4')
+pgi(eula=True)
 ```
 
 ```python

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -58,7 +58,7 @@ class boost(rm, tar, wget):
         self.__prefix = kwargs.get('prefix', '/usr/local/boost')
         self.__python = kwargs.get('python', False)
         self.__sourceforge = kwargs.get('sourceforge', False)
-        self.__version = kwargs.get('version', '1.67.0')
+        self.__version = kwargs.get('version', '1.68.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -52,7 +52,7 @@ class cmake(rm, wget):
 
         self.__ospackages = kwargs.get('ospackages', ['wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local')
-        self.__version = kwargs.get('version', '3.11.1')
+        self.__version = kwargs.get('version', '3.12.3')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -60,7 +60,7 @@ class fftw(ConfigureMake, rm, tar, wget):
         self.__mpi = kwargs.get('mpi', False)
         self.__ospackages = kwargs.get('ospackages', ['file', 'make', 'wget'])
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '3.3.7')
+        self.__version = kwargs.get('version', '3.3.8')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -63,7 +63,7 @@ class hdf5(ConfigureMake, rm, tar, wget):
         self.__ospackages = kwargs.get('ospackages', [])
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '1.10.1')
+        self.__version = kwargs.get('version', '1.10.4')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -54,7 +54,7 @@ class mkl(wget):
 
         self.__mklvars = kwargs.get('mklvars', True)
         self.__ospackages = kwargs.get('ospackages', [])
-        self.version = kwargs.get('version', '2018.3-051')
+        self.version = kwargs.get('version', '2019.0-045')
 
         self.__bashrc = ''      # Filled in by __distro()
 

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -70,7 +70,7 @@ class mvapich2(ConfigureMake, rm, sed, tar, wget):
         # MVAPICH2 does not accept F90
         self.toolchain_control = {'CC': True, 'CXX': True, 'F77': True,
                                   'F90': False, 'FC': True}
-        self.version = kwargs.get('version', '2.3rc2')
+        self.version = kwargs.get('version', '2.3')
 
         self.__commands = []              # Filled in by __setup()
         self.__environment_variables = {} # Filled in by __setup()

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -52,7 +52,7 @@ class openblas(rm, tar, wget):
         self.__ospackages = kwargs.get('ospackages', ['make', 'tar', 'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/openblas')
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '0.3.1')
+        self.__version = kwargs.get('version', '0.3.3')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -68,7 +68,7 @@ class openmpi(ConfigureMake, rm, tar, wget):
 
         # Input toolchain, i.e., what to use when building
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.version = kwargs.get('version', '3.0.0')
+        self.version = kwargs.get('version', '3.1.2')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/pgi.py
+++ b/hpccm/building_blocks/pgi.py
@@ -69,7 +69,7 @@ class pgi(rm, tar, wget):
 
         # The version is fragile since the latest version is
         # automatically downloaded, which may not match this default.
-        self.__version = kwargs.get('version', '18.4')
+        self.__version = kwargs.get('version', '18.10')
         self.__wd = '/var/tmp' # working directory
 
         self.__basepath = os.path.join(self.__prefix, 'linux86-64')

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -3,11 +3,11 @@ HPC Base image
 
 Contents:
   CUDA version 9.0
-  FFTW version 3.3.7
+  FFTW version 3.3.8
   GNU compilers (upstream)
-  HDF5 version 1.10.1
+  HDF5 version 1.10.4
   Mellanox OFED version 3.4-1.0.0.0
-  MVAPICH version 2.3rc2
+  MVAPICH version 2.3
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -45,15 +45,15 @@ ofed = mlnx_ofed(version='3.4-1.0.0.0')
 Stage0 += ofed
 
 # MVAPICH2
-mv2 = mvapich2(version='2.3rc2', toolchain=tc)
+mv2 = mvapich2(version='2.3', toolchain=tc)
 Stage0 += mv2
 
 # FFTW
-fftw = fftw(version='3.3.7', toolchain=tc)
+fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
 Stage0 += fftw
 
 # HDF5
-hdf5 = hdf5(version='1.10.1', toolchain=tc)
+hdf5 = hdf5(version='1.10.4', toolchain=tc)
 Stage0 += hdf5
 
 ######

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -3,11 +3,11 @@ HPC Base image
 
 Contents:
   CUDA version 9.0
-  FFTW version 3.3.7
+  FFTW version 3.3.8
   GNU compilers (upstream)
-  HDF5 version 1.10.1
+  HDF5 version 1.10.4
   Mellanox OFED version 3.4-1.0.0.0
-  OpenMPI version 3.0.0
+  OpenMPI version 3.1.2
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -45,15 +45,15 @@ ofed = mlnx_ofed(version='3.4-1.0.0.0')
 Stage0 += ofed
 
 # OpenMPI
-ompi = openmpi(version='3.0.0', toolchain=tc)
+ompi = openmpi(version='3.1.2', toolchain=tc)
 Stage0 += ompi
 
 # FFTW
-fftw = fftw(version='3.3.7', toolchain=tc)
+fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
 Stage0 += fftw
 
 # HDF5
-hdf5 = hdf5(version='1.10.1', toolchain=tc)
+hdf5 = hdf5(version='1.10.4', toolchain=tc)
 Stage0 += hdf5
 
 ######

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -3,11 +3,11 @@ HPC Base image
 
 Contents:
   CUDA version 9.0
-  FFTW version 3.3.7
-  HDF5 version 1.10.1
+  FFTW version 3.3.8
+  HDF5 version 1.10.4
   Mellanox OFED version 3.4-1.0.0.0
-  MVAPICH2 version 2.3rc2
-  PGI compilers version 18.4
+  MVAPICH2 version 2.3
+  PGI compilers version 18.10
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -41,7 +41,7 @@ python = python()
 Stage0 += python
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='18.4')
+pgi = pgi(eula=pgi_eula, version='18.10')
 Stage0 += pgi
 
 # Setup the toolchain.  Use the PGI compiler toolchain as the basis.
@@ -53,15 +53,15 @@ ofed = mlnx_ofed(version='3.4-1.0.0.0')
 Stage0 += ofed
 
 # MVAPICH2
-mv2 = mvapich2(version='2.3rc2', toolchain=tc)
+mv2 = mvapich2(version='2.3', toolchain=tc)
 Stage0 += mv2
 
 # FFTW
-fftw = fftw(version='3.3.7', toolchain=tc)
+fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
 Stage0 += fftw
 
 # HDF5
-hdf5 = hdf5(version='1.10.1', toolchain=tc)
+hdf5 = hdf5(version='1.10.4', toolchain=tc)
 Stage0 += hdf5
 
 ######

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -3,11 +3,11 @@ HPC Base image
 
 Contents:
   CUDA version 9.0
-  FFTW version 3.3.7
-  HDF5 version 1.10.1
+  FFTW version 3.3.8
+  HDF5 version 1.10.4
   Mellanox OFED version 3.4-1.0.0.0
-  OpenMPI version 3.0.0
-  PGI compilers version 18.4
+  OpenMPI version 3.1.2
+  PGI compilers version 18.10
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -41,7 +41,7 @@ python = python()
 Stage0 += python
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='18.4')
+pgi = pgi(eula=pgi_eula, version='18.10')
 Stage0 += pgi
 
 # Setup the toolchain.  Use the PGI compiler toolchain as the basis.
@@ -53,15 +53,15 @@ ofed = mlnx_ofed(version='3.4-1.0.0.0')
 Stage0 += ofed
 
 # OpenMPI
-ompi = openmpi(version='3.0.0', toolchain=tc)
+ompi = openmpi(version='3.1.2', toolchain=tc)
 Stage0 += ompi
 
 # FFTW
-fftw = fftw(version='3.3.7', toolchain=tc)
+fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
 Stage0 += fftw
 
 # HDF5
-hdf5 = hdf5(version='1.10.1', toolchain=tc)
+hdf5 = hdf5(version='1.10.4', toolchain=tc)
 Stage0 += hdf5
 
 ######

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -37,7 +37,7 @@ class Test_boost(unittest.TestCase):
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.67.0
+r'''# Boost version 1.68.0
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,11 +46,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_67_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_67_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j4 -q install && \
-    rm -rf /var/tmp/boost_1_67_0.tar.bz2 /var/tmp/boost_1_67_0
+    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -59,7 +59,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.67.0
+r'''# Boost version 1.68.0
 RUN yum install -y \
         bzip2 \
         bzip2-devel \
@@ -68,11 +68,11 @@ RUN yum install -y \
         which \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_67_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_67_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j4 -q install && \
-    rm -rf /var/tmp/boost_1_67_0.tar.bz2 /var/tmp/boost_1_67_0
+    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
@@ -81,7 +81,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """python option"""
         b = boost(python=True)
         self.assertEqual(str(b),
-r'''# Boost version 1.67.0
+r'''# Boost version 1.68.0
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bzip2 \
@@ -90,11 +90,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_67_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_67_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
     ./b2 -j4 -q install && \
-    rm -rf /var/tmp/boost_1_67_0.tar.bz2 /var/tmp/boost_1_67_0
+    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -37,14 +37,14 @@ class Test_cmake(unittest.TestCase):
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.11.1
+r'''# CMake version 3.12.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.11.1-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
 
     @centos
     @docker
@@ -52,13 +52,13 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.11.1
+r'''# CMake version 3.12.3
 RUN yum install -y \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.11.1-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
 
     @ubuntu
     @docker
@@ -66,14 +66,14 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Accept EULA"""
         c = cmake(eula=True)
         self.assertEqual(str(c),
-r'''# CMake version 3.11.1
+r'''# CMake version 3.12.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.11.1-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
 
     @ubuntu
     @docker
@@ -97,11 +97,11 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         c = cmake(eula=True)
         r = c.runtime()
         self.assertEqual(r,
-r'''# CMake version 3.11.1
+r'''# CMake version 3.12.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.11/cmake-3.11.1-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.11.1-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.11.1-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -37,19 +37,19 @@ class Test_fftw(unittest.TestCase):
         """Default fftw building block"""
         f = fftw()
         self.assertEqual(str(f),
-r'''# FFTW version 3.3.7
+r'''# FFTW version 3.3.8
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/fftw-3.3.7.tar.gz /var/tmp/fftw-3.3.7
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -58,18 +58,18 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
         """Default fftw building block"""
         f = fftw()
         self.assertEqual(str(f),
-r'''# FFTW version 3.3.7
+r'''# FFTW version 3.3.8
 RUN yum install -y \
         file \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/fftw-3.3.7.tar.gz /var/tmp/fftw-3.3.7
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
@@ -78,19 +78,19 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
         """MPI enabled"""
         f = fftw(mpi=True)
         self.assertEqual(str(f),
-r'''# FFTW version 3.3.7
+r'''# FFTW version 3.3.8
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 --enable-mpi && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 --enable-mpi && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/fftw-3.3.7.tar.gz /var/tmp/fftw-3.3.7
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -37,7 +37,7 @@ class Test_hdf5(unittest.TestCase):
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.1
+r'''# HDF5 version 1.10.4
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.1.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.1 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.4.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.4 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/hdf5-1.10.1.tar.bz2 /var/tmp/hdf5-1.10.1
+    rm -rf /var/tmp/hdf5-1.10.4.tar.bz2 /var/tmp/hdf5-1.10.4
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')
@@ -62,7 +62,7 @@ ENV HDF5_DIR=/usr/local/hdf5 \
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.1
+r'''# HDF5 version 1.10.4
 RUN yum install -y \
         bzip2 \
         file \
@@ -70,12 +70,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.1/src/hdf5-1.10.1.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.1.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.1 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.4.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.4 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/hdf5-1.10.1.tar.bz2 /var/tmp/hdf5-1.10.1
+    rm -rf /var/tmp/hdf5-1.10.4.tar.bz2 /var/tmp/hdf5-1.10.4
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -45,7 +45,7 @@ class Test_mkl(unittest.TestCase):
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2018.3-051
+r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -56,7 +56,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2018.3-051 && \
+        intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
 
@@ -66,11 +66,11 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2018.3-051
+r'''# MKL version 2019.0-045
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo && \
     yum install -y \
-        intel-mkl-64bit-2018.3-051 && \
+        intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/cache/yum/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bashrc''')
 
@@ -101,7 +101,7 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         """mklvars is False"""
         m = mkl(eula=True, mklvars=False)
         self.assertEqual(str(m),
-r'''# MKL version 2018.3-051
+r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -112,7 +112,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2018.3-051 && \
+        intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 ENV CPATH=/opt/intel/mkl/include:$CPATH \
     LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
@@ -126,7 +126,7 @@ ENV CPATH=/opt/intel/mkl/include:$CPATH \
         m = mkl(eula=True)
         r = m.runtime()
         self.assertEqual(r,
-r'''# MKL version 2018.3-051
+r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -137,6 +137,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2018.3-051 && \
+        intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -38,7 +38,7 @@ class Test_mvapich2(unittest.TestCase):
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3rc2
+r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         byacc \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
+    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -70,7 +70,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         tc.FC = 'pgfortran'
         mv2 = mvapich2(toolchain=tc, cuda=True)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3rc2
+r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         byacc \
@@ -81,12 +81,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
+    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -125,7 +125,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Disable CUDA"""
         mv2 = mvapich2(cuda=False)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3rc2
+r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         byacc \
@@ -134,12 +134,12 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --disable-cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --disable-cuda && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
+    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
@@ -149,7 +149,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3rc2
+r'''# MVAPICH2 version 2.3
 RUN yum install -y \
         byacc \
         file \
@@ -159,12 +159,12 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3rc2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3rc2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3rc2 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/mvapich2-2.3rc2.tar.gz /var/tmp/mvapich2-2.3rc2
+    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')

--- a/test/test_openblas.py
+++ b/test/test_openblas.py
@@ -39,18 +39,18 @@ class Test_openblas(unittest.TestCase):
         tc = toolchain(CC='gcc', FC='gfortran')
         o = openblas(toolchain=tc)
         self.assertEqual(str(o),
-r'''# OpenBLAS version 0.3.1
+r'''# OpenBLAS version 0.3.3
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         make \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/OpenBLAS-0.3.1 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/OpenBLAS-0.3.3 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
     make install PREFIX=/usr/local/openblas && \
-    rm -rf /var/tmp/v0.3.1.tar.gz /var/tmp/OpenBLAS-0.3.1
+    rm -rf /var/tmp/v0.3.3.tar.gz /var/tmp/OpenBLAS-0.3.3
 ENV LD_LIBRARY_PATH=/usr/local/openblas/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -37,7 +37,7 @@ class Test_openmpi(unittest.TestCase):
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 3.0.0
+r'''# OpenMPI version 3.1.2
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         bzip2 \
@@ -50,12 +50,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.0.0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-3.0.0 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-3.1.2.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.1.2.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-3.1.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/openmpi-3.0.0.tar.bz2 /var/tmp/openmpi-3.0.0
+    rm -rf /var/tmp/openmpi-3.1.2.tar.bz2 /var/tmp/openmpi-3.1.2
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
@@ -65,7 +65,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 3.0.0
+r'''# OpenMPI version 3.1.2
 RUN yum install -y \
         bzip2 \
         file \
@@ -77,12 +77,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.0/downloads/openmpi-3.0.0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.0.0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-3.0.0 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-3.1.2.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.1.2.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-3.1.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/openmpi-3.0.0.tar.bz2 /var/tmp/openmpi-3.0.0
+    rm -rf /var/tmp/openmpi-3.1.2.tar.bz2 /var/tmp/openmpi-3.1.2
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -37,7 +37,7 @@ class Test_pgi(unittest.TestCase):
         """Default pgi building block"""
         p = pgi()
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=false ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @centos
     @docker
@@ -62,7 +62,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         """Default pgi building block"""
         p = pgi()
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN yum install -y \
         gcc \
         gcc-c++ \
@@ -73,12 +73,12 @@ RUN yum install -y \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=false ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -86,7 +86,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         """Accept EULA"""
         p = pgi(eula=True)
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -98,12 +98,12 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -159,7 +159,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         """System CUDA"""
         p = pgi(eula=True, system_cuda=True)
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -171,13 +171,13 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=false PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -185,7 +185,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         """System CUDA"""
         p = pgi(eula=True, mpi=True)
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -197,12 +197,12 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=true PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=true PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -210,7 +210,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         """Extended environment without MPI"""
         p = pgi(eula=True, extended_environment=True, mpi=False)
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -222,19 +222,19 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV CC=/opt/pgi/linux86-64/18.4/bin/pgcc \
-    CPP="/opt/pgi/linux86-64/18.4/bin/pgcc -Mcpp" \
-    CXX=/opt/pgi/linux86-64/18.4/bin/pgc++ \
-    F77=/opt/pgi/linux86-64/18.4/bin/pgf77 \
-    F90=/opt/pgi/linux86-64/18.4/bin/pgf90 \
-    FC=/opt/pgi/linux86-64/18.4/bin/pgfortran \
-    LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+ENV CC=/opt/pgi/linux86-64/18.10/bin/pgcc \
+    CPP="/opt/pgi/linux86-64/18.10/bin/pgcc -Mcpp" \
+    CXX=/opt/pgi/linux86-64/18.10/bin/pgc++ \
+    F77=/opt/pgi/linux86-64/18.10/bin/pgf77 \
+    F90=/opt/pgi/linux86-64/18.10/bin/pgf90 \
+    FC=/opt/pgi/linux86-64/18.10/bin/pgfortran \
+    LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
     MODULEPATH=/opt/pgi/modulefiles:$MODULEPATH \
-    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -242,7 +242,7 @@ ENV CC=/opt/pgi/linux86-64/18.4/bin/pgcc \
         """Extended environment with MPI"""
         p = pgi(eula=True, extended_environment=True, mpi=True)
         self.assertEqual(str(p),
-r'''# PGI compiler version 18.4
+r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         gcc \
@@ -254,21 +254,21 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
     mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
     cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=true PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=true PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV CC=/opt/pgi/linux86-64/18.4/bin/pgcc \
-    CPP="/opt/pgi/linux86-64/18.4/bin/pgcc -Mcpp" \
-    CXX=/opt/pgi/linux86-64/18.4/bin/pgc++ \
-    F77=/opt/pgi/linux86-64/18.4/bin/pgf77 \
-    F90=/opt/pgi/linux86-64/18.4/bin/pgf90 \
-    FC=/opt/pgi/linux86-64/18.4/bin/pgfortran \
-    LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/mpi/openmpi/lib:/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+ENV CC=/opt/pgi/linux86-64/18.10/bin/pgcc \
+    CPP="/opt/pgi/linux86-64/18.10/bin/pgcc -Mcpp" \
+    CXX=/opt/pgi/linux86-64/18.10/bin/pgc++ \
+    F77=/opt/pgi/linux86-64/18.10/bin/pgf77 \
+    F90=/opt/pgi/linux86-64/18.10/bin/pgf90 \
+    FC=/opt/pgi/linux86-64/18.10/bin/pgfortran \
+    LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/mpi/openmpi/lib:/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
     MODULEPATH=/opt/pgi/modulefiles:$MODULEPATH \
-    PATH=/opt/pgi/linux86-64/18.4/mpi/openmpi/bin:/opt/pgi/linux86-64/18.4/bin:$PATH \
-    PGI_OPTL_INCLUDE_DIRS=/opt/pgi/linux86-64/18.4/mpi/openmpi/include \
-    PGI_OPTL_LIB_DIRS=/opt/pgi/linux86-64/18.4/mpi/openmpi/lib''')
+    PATH=/opt/pgi/linux86-64/18.10/mpi/openmpi/bin:/opt/pgi/linux86-64/18.10/bin:$PATH \
+    PGI_OPTL_INCLUDE_DIRS=/opt/pgi/linux86-64/18.10/mpi/openmpi/include \
+    PGI_OPTL_LIB_DIRS=/opt/pgi/linux86-64/18.10/mpi/openmpi/lib''')
 
     @ubuntu
     @docker
@@ -282,9 +282,8 @@ RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         libnuma1 && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/pgi/linux86-64/18.4/REDIST/*.so /opt/pgi/linux86-64/18.4/lib/
-RUN ln -s /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/18.4/lib/libnuma.so
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/pgi/linux86-64/18.10/REDIST/*.so /opt/pgi/linux86-64/18.10/lib/
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH''')
 
     @centos
     @docker
@@ -297,8 +296,8 @@ r'''# PGI compiler
 RUN yum install -y \
         numactl-libs && \
     rm -rf /var/cache/yum/*
-COPY --from=0 /opt/pgi/linux86-64/18.4/REDIST/*.so /opt/pgi/linux86-64/18.4/lib/
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/pgi/linux86-64/18.10/REDIST/*.so /opt/pgi/linux86-64/18.10/lib/
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -101,19 +101,19 @@ RUN apt-get update -y && \
         gfortran && \
     rm -rf /var/lib/apt/lists/*
 
-# FFTW version 3.3.7
+# FFTW version 3.3.8
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
     make -j4 && \
     make -j4 install && \
-    rm -rf /var/tmp/fftw-3.3.7.tar.gz /var/tmp/fftw-3.3.7
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
     def test_multistage_example_singularity(self):
@@ -136,7 +136,7 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
         gfortran
     rm -rf /var/lib/apt/lists/*
 
-# FFTW version 3.3.7
+# FFTW version 3.3.8
 %post
     apt-get update -y
     apt-get install -y --no-install-recommends \
@@ -146,12 +146,12 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.7.tar.gz
-    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.7.tar.gz -C /var/tmp -z
-    cd /var/tmp/fftw-3.3.7 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2
     make -j4
     make -j4 install
-    rm -rf /var/tmp/fftw-3.3.7.tar.gz /var/tmp/fftw-3.3.7
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 %environment
     export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH
 %post


### PR DESCRIPTION
Update versions to the latest available:

* Boost: 1.67.0 -> 1.68.0
* CMake: 3.11.1 -> 3.12.3
* FFTW: 3.3.7 -> 3.3.8
* HDF5: 1.10.1 -> 1.10.4
* MKL: 2018.3-051 -> 2019.0-045
* MVAPICH2: 2.3rc2 -> 2.3
* OpenBLAS: 0.3.1 -> 0.3.3
* OpenMPI: 3.0.0 -> 3.1.2
* PGI: 18.4 -> 18.10