### PR TITLE
Enable directly importing hpccm in a script

### DIFF
--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -21,6 +21,10 @@ from hpccm.Stage import Stage
 from hpccm.recipe import recipe
 from hpccm.toolchain import toolchain
 
+import hpccm.building_blocks
+import hpccm.templates
+import hpccm.primitives
+
 # Templates
 # For backwards compatibility with recipes that use "hpccm.git()", etc.
 from hpccm.templates.ConfigureMake import ConfigureMake

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -13,3 +13,28 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from hpccm.building_blocks.apt_get import apt_get
+from hpccm.building_blocks.boost import boost
+from hpccm.building_blocks.cgns import cgns
+from hpccm.building_blocks.charm import charm
+from hpccm.building_blocks.cmake import cmake
+from hpccm.building_blocks.fftw import fftw
+from hpccm.building_blocks.gnu import gnu
+from hpccm.building_blocks.hdf5 import hdf5
+from hpccm.building_blocks.intel_mpi import intel_mpi
+from hpccm.building_blocks.intel_psxe import intel_psxe
+from hpccm.building_blocks.llvm import llvm
+from hpccm.building_blocks.mkl import mkl
+from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
+from hpccm.building_blocks.mvapich2 import mvapich2
+from hpccm.building_blocks.mvapich2_gdr import mvapich2_gdr
+from hpccm.building_blocks.netcdf import netcdf
+from hpccm.building_blocks.ofed import ofed
+from hpccm.building_blocks.openblas import openblas
+from hpccm.building_blocks.openmpi import openmpi
+from hpccm.building_blocks.packages import packages
+from hpccm.building_blocks.pgi import pgi
+from hpccm.building_blocks.pnetcdf import pnetcdf
+from hpccm.building_blocks.python import python
+from hpccm.building_blocks.yum import yum

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -23,9 +23,20 @@ hpccm.config.var
 
 from __future__ import absolute_import
 
+import sys
+
 from hpccm.common import container_type
 from hpccm.common import linux_distro
 
 # Global variables
 g_ctype = container_type.DOCKER      # Container type
 g_linux_distro = linux_distro.UBUNTU # Linux distribution
+
+def set_container_format(ctype):
+  this = sys.modules[__name__]
+  if ctype == 'docker':
+    this.g_ctype = container_type.DOCKER
+  elif ctype == 'singularity':
+    this.g_ctype = container_type.SINGULARITY
+  else:
+    raise RuntimeError('Unrecognized container format: {}'.format(ctype))

--- a/hpccm/primitives/__init__.py
+++ b/hpccm/primitives/__init__.py
@@ -13,3 +13,15 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from hpccm.primitives.baseimage import baseimage
+from hpccm.primitives.blob import blob
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.environment import environment
+from hpccm.primitives.label import label
+from hpccm.primitives.raw import raw
+from hpccm.primitives.runscript import runscript
+from hpccm.primitives.shell import shell
+from hpccm.primitives.user import user
+from hpccm.primitives.workdir import workdir

--- a/hpccm/templates/__init__.py
+++ b/hpccm/templates/__init__.py
@@ -13,3 +13,11 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
+from hpccm.templates.CMakeBuild import CMakeBuild
+from hpccm.templates.ConfigureMake import ConfigureMake
+from hpccm.templates.git import git
+from hpccm.templates.rm import rm
+from hpccm.templates.sed import sed
+from hpccm.templates.tar import tar
+from hpccm.templates.wget import wget

--- a/recipes/examples/script.py
+++ b/recipes/examples/script.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+"""This example demonstrates importing hpccm in a Python script.
+
+Rather than using the hpccm command line tool to convert a recipe into
+a container specification, import hpccm directly.
+
+The script is responsible for handling user arguments, managing
+layers, and printing the output.
+
+Note: HPCCM must be installed via pip prior to using this script.
+
+Usage:
+$ python recipes/examples/script.py --help
+$ python recipes/examples/script.py --linux ubuntu
+$ python recipes/examples/script.py --format singularity
+
+"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import argparse
+import hpccm
+
+### Parse command line arguments
+parser = argparse.ArgumentParser(description='HPCCM example')
+parser.add_argument('--compiler', type=str, default='gnu',
+                    choices=['gnu', 'llvm', 'pgi'],
+                    help='Compiler choice (default: gnu)')
+parser.add_argument('--format', type=str, default='docker',
+                    choices=['docker', 'singularity'],
+                    help='Container specification format (default: docker)')
+parser.add_argument('--linux', type=str, default='centos',
+                    choices=['centos', 'ubuntu'],
+                    help='Linux distribution choice (default: centos)')
+parser.add_argument('--pgi_eula_accept', action='store_true',
+                    default=False,
+                    help='Accept PGI EULA (default: false)')
+args = parser.parse_args()
+
+### Create Stage
+Stage0 = hpccm.Stage()
+
+### Linux distribution
+if args.linux == 'centos':
+    Stage0 += hpccm.primitives.baseimage(image='centos:7')
+elif args.linux == 'ubuntu':
+    Stage0 += hpccm.primitives.baseimage(image='ubuntu:16.04')
+
+### Compiler
+if args.compiler == 'gnu':
+    Stage0 += hpccm.building_blocks.gnu()
+elif args.compiler == 'llvm':
+    Stage0 += hpccm.building_blocks.llvm()
+elif args.compiler == 'pgi':
+    if not args.pgi_eula_accept:
+        print('PGI EULA not accepted. To accept, use "--pgi_eula_accept".\n'
+              'See PGI EULA at https://www.pgroup.com/doc/LICENSE')
+        exit(1)
+    Stage0 += hpccm.building_blocks.pgi(eula=args.pgi_eula_accept)
+
+### Set container specification output format
+hpccm.config.set_container_format(args.format)
+
+### Output container specification
+print(Stage0)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the config module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import docker, singularity
+
+import hpccm.config
+
+class Test_config(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @singularity
+    def test_set_container_format_docker(self):
+        """Set container format to Docker"""
+        hpccm.config.set_container_format('docker')
+        self.assertEqual(hpccm.config.g_ctype, hpccm.container_type.DOCKER)
+
+    @docker
+    def test_set_container_format_singularity(self):
+        """Set container format to Singularity"""
+        hpccm.config.set_container_format('singularity')
+        self.assertEqual(hpccm.config.g_ctype, hpccm.container_type.SINGULARITY)
+
+    @docker
+    def test_set_container_format_invalid(self):
+        """Set container format to invalid value"""
+        with self.assertRaises(RuntimeError):
+            hpccm.config.set_container_format('invalid')


### PR DESCRIPTION
Some users may find it preferable to write a "real" Python script rather than a recipe.  This change enables users to put `import hpccm` at the top of their script and then just write a standalone Python script without needing to use the `hpccm` command line tool.

A new example has been added to show how to do this (`recipes/examples/script.py`).  In this case, the user is responsible for handling user input, managing layers, and printing the output.