### PR TITLE
Fix tarball handling when the value is a path

### DIFF
--- a/hpccm/building_blocks/pgi.py
+++ b/hpccm/building_blocks/pgi.py
@@ -93,7 +93,8 @@ class pgi(rm, tar, wget):
             # Use tarball from local build context
             instructions.append(
                 copy(src=self.__tarball,
-                     dest=os.path.join(self.__wd, self.__tarball)))
+                     dest=os.path.join(self.__wd,
+                                       os.path.basename(self.__tarball))))
         else:
             # Downloading, so need wget
             self.__ospackages.append('wget')
@@ -177,12 +178,12 @@ class pgi(rm, tar, wget):
 
         if self.__tarball:
             # Use tarball from local build context
-            tarball = self.__tarball
+            tarball = os.path.basename(self.__tarball)
 
             # Figure out the version from the tarball name
             match = re.match(r'pgilinux-\d+-(?P<year>\d\d)0?(?P<month>[1-9][0-9]?)',
                              tarball)
-            if match.groupdict()['year'] and match.groupdict()['month']:
+            if match and match.groupdict()['year'] and match.groupdict()['month']:
                 self.__version = '{0}.{1}'.format(match.groupdict()['year'],
                                                   match.groupdict()['month'])
         else:

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -131,6 +131,29 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_tarball2(self):
+        """tarball"""
+        p = pgi(eula=True, tarball='pkg/pgilinux-2018-1804-x86_64.tar.gz')
+        self.assertEqual(str(p),
+r'''# PGI compiler version 18.4
+COPY pkg/pgilinux-2018-1804-x86_64.tar.gz /var/tmp/pgilinux-2018-1804-x86_64.tar.gz
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        libnuma1 \
+        perl && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgilinux-2018-1804-x86_64.tar.gz -C /var/tmp/pgi -z && \
+    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.4/bin/siterc && \
+    rm -rf /var/tmp/pgilinux-2018-1804-x86_64.tar.gz /var/tmp/pgi
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.4/bin:$PATH''')
+    @ubuntu
+    @docker
     def test_tarball_leading_zero(self):
         """tarball"""
         p = pgi(eula=True, tarball='pgilinux-2018-1804-x86_64.tar.gz')


### PR DESCRIPTION
Fix handling of `pgi(..., tarball='pgi/pgilinux-2018-1804-x86_64.tar.gz')` (note the path in the `tarball` option).