### PR TITLE
Changes to support Ubuntu 18.04

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -585,7 +585,7 @@ slightly from that set by `mpivars.sh`.  The default value is
 
 - __ospackages__: List of OS packages to install prior to installing
 Intel MPI.  For Ubuntu, the default values are
-`apt-transport-https`, `ca-certificates`, `man-db`,
+`apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
 `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
 the default values are `man-db` and `openssh-clients`.
 
@@ -822,7 +822,7 @@ The default value is `True`.
 
 - __ospackages__: List of OS packages to install prior to installing
 MKL.  For Ubuntu, the default values are `apt-transport-https`,
-`ca-certificates`, and `wget`.  For RHEL-based Linux
+`ca-certificates`, `gnupg`, and `wget`.  For RHEL-based Linux
 distributions, the default is an empty list.
 
 - __version__: The version of MKL to install.  The default value is
@@ -884,7 +884,7 @@ RHEL-based Linux distributions, the default values are
 `librdmacm-devel`.
 
 - __version__: The version of Mellanox OFED to download.  The default
-value is `3.4-1.0.0.0`.
+value is `4.5-1.0.1.0`.
 
 __Examples__
 
@@ -1119,11 +1119,17 @@ ofed(self, **kwargs)
 The `ofed` building block installs the OpenFabrics Enterprise
 Distribution packages that are part of the Linux distribution.
 
-For Ubuntu, the following packages are installed: `dapl2-utils`,
-`ibutils`, `ibverbs-utils`, `infiniband-diags`, `libdapl-dev`,
-`libibcm-dev`, `libibmad5`, `libibmad-dev`, `libibverbs1`,
-`libibverbs-dev`, `libmlx4-1`, `libmlx4-dev`, `libmlx5-1`,
-`libmlx5-dev`, `librdmacm1`, `librdmacm-dev`, `opensm`, and
+For Ubuntu 16.04, the following packages are installed:
+`dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
+`libdapl-dev`, `libibcm-dev`, `libibmad5`, `libibmad-dev`,
+`libibverbs1`, `libibverbs-dev`, `libmlx4-1`, `libmlx4-dev`,
+`libmlx5-1`, `libmlx5-dev`, `librdmacm1`, `librdmacm-dev`,
+`opensm`, and `rdmacm-utils`.
+
+For Ubuntu 18.04, the following packages are installed:
+`dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
+`libdapl-dev`, `libibmad5`, `libibmad-dev`, `libibverbs1`,
+`libibverbs-dev`, `librdmacm1`, `librdmacm-dev`, `opensm`, and
 `rdmacm-utils`.
 
 For RHEL-based Linux distributions, the following packages are
@@ -1143,6 +1149,7 @@ __Examples__
 ```python
 ofed()
 ```
+
 
 ## runtime
 ```python
@@ -1177,7 +1184,7 @@ __Parameters__
 is `USE_OPENMP=1`.
 
 - __ospackages__: List of OS packages to install prior to building.  The
-default values are `make`, `tar`, and `wget`.
+default values are `make`, `perl`, `tar`, and `wget`.
 
 - __prefix__: The top level installation location.  The default value is
 `/usr/local/openblas`.

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -11,11 +11,11 @@ __Parameters__
 value is empty.
 
 - ___distro__: The underlying Linux distribution of the base image.
-Valid values are `centos`, `redhat`, `rhel`, and `ubuntu`.  By
-default, the primitive attempts to figure out the Linux
-distribution by inspecting the image identifier, and falls back to
-`ubuntu` if unable to determine the Linux distribution
-automatically.
+Valid values are `centos`, `redhat`, `rhel`, `ubuntu`, `ubuntu16`,
+and `ubuntu18`.  By default, the primitive attempts to figure out
+the Linux distribution by inspecting the image identifier, and
+falls back to `ubuntu` if unable to determine the Linux
+distribution automatically.
 
 - __image__: The image identifier to use as the base image.  The default value is `nvidia/cuda:9.0-devel-ubuntu16.04`.
 

--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -88,7 +88,7 @@ class apt_get(object):
         if self.__ppas:
             # Need to install apt-add-repository
             self.__commands.extend(['apt-get update -y',
-                                    'apt-get install -y --no-install-recommends software-properties-common'])
+                                    'DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common'])
             for ppa in self.__ppas:
                 self.__commands.append('apt-add-repository {} -y'.format(ppa))
 
@@ -100,7 +100,7 @@ class apt_get(object):
         if self.ospackages:
             self.__commands.append('apt-get update -y')
 
-            install = 'apt-get install -y --no-install-recommends \\\n'
+            install = 'DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\\n'
             packages = []
             for pkg in self.ospackages:
                 packages.append('        {}'.format(pkg))

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -71,7 +71,7 @@ class intel_mpi(wget):
 
     ospackages: List of OS packages to install prior to installing
     Intel MPI.  For Ubuntu, the default values are
-    `apt-transport-https`, `ca-certificates`, `man-db`,
+    `apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
     `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
     the default values are `man-db` and `openssh-clients`.
 
@@ -152,7 +152,8 @@ class intel_mpi(wget):
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
                 self.__ospackages = ['apt-transport-https', 'ca-certificates',
-                                     'man-db', 'openssh-client', 'wget']
+                                     'gnupg', 'man-db', 'openssh-client',
+                                     'wget']
 
             self.__bashrc = '/etc/bash.bashrc'
 

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -68,7 +68,7 @@ class mkl(wget):
 
     ospackages: List of OS packages to install prior to installing
     MKL.  For Ubuntu, the default values are `apt-transport-https`,
-    `ca-certificates`, and `wget`.  For RHEL-based Linux
+    `ca-certificates`, `gnupg`, and `wget`.  For RHEL-based Linux
     distributions, the default is an empty list.
 
     version: The version of MKL to install.  The default value is
@@ -148,7 +148,7 @@ class mkl(wget):
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
                 self.__ospackages = ['apt-transport-https', 'ca-certificates',
-                                     'wget']
+                                     'gnupg', 'wget']
 
             self.__bashrc = '/etc/bash.bashrc'
 

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 import os
 
@@ -61,7 +62,7 @@ class mlnx_ofed(tar, wget):
     `librdmacm-devel`.
 
     version: The version of Mellanox OFED to download.  The default
-    value is `3.4-1.0.0.0`.
+    value is `4.5-1.0.1.0`.
 
     # Examples
 
@@ -84,7 +85,7 @@ class mlnx_ofed(tar, wget):
         self.__oslabel = kwargs.get('oslabel', '')
         self.__ospackages = kwargs.get('ospackages', [])
         self.__packages = kwargs.get('packages', [])
-        self.__version = kwargs.get('version', '3.4-1.0.0.0')
+        self.__version = kwargs.get('version', '4.5-1.0.1.0')
 
         self.__commands = []
         self.__wd = '/var/tmp'
@@ -121,7 +122,10 @@ class mlnx_ofed(tar, wget):
 
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__oslabel:
-                self.__oslabel = 'ubuntu16.04'
+                if hpccm.config.g_linux_version >= StrictVersion('18.0'):
+                    self.__oslabel = 'ubuntu18.04'
+                else:
+                    self.__oslabel = 'ubuntu16.04'
             if not self.__ospackages:
                 self.__ospackages = ['libnl-3-200', 'libnl-route-3-200',
                                      'libnuma1', 'wget']

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -20,20 +20,30 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 
+import hpccm.config
+
 from hpccm.building_blocks.packages import packages
+from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
 
 class ofed(object):
     """The `ofed` building block installs the OpenFabrics Enterprise
     Distribution packages that are part of the Linux distribution.
 
-    For Ubuntu, the following packages are installed: `dapl2-utils`,
-    `ibutils`, `ibverbs-utils`, `infiniband-diags`, `libdapl-dev`,
-    `libibcm-dev`, `libibmad5`, `libibmad-dev`, `libibverbs1`,
-    `libibverbs-dev`, `libmlx4-1`, `libmlx4-dev`, `libmlx5-1`,
-    `libmlx5-dev`, `librdmacm1`, `librdmacm-dev`, `opensm`, and
+    For Ubuntu 16.04, the following packages are installed:
+    `dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
+    `libdapl-dev`, `libibcm-dev`, `libibmad5`, `libibmad-dev`,
+    `libibverbs1`, `libibverbs-dev`, `libmlx4-1`, `libmlx4-dev`,
+    `libmlx5-1`, `libmlx5-dev`, `librdmacm1`, `librdmacm-dev`,
+    `opensm`, and `rdmacm-utils`.
+
+    For Ubuntu 18.04, the following packages are installed:
+    `dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
+    `libdapl-dev`, `libibmad5`, `libibmad-dev`, `libibverbs1`,
+    `libibverbs-dev`, `librdmacm1`, `librdmacm-dev`, `opensm`, and
     `rdmacm-utils`.
 
     For RHEL-based Linux distributions, the following packages are
@@ -51,6 +61,7 @@ class ofed(object):
     ```python
     ofed()
     ```
+
     """
 
     def __init__(self, **kwargs):
@@ -60,13 +71,25 @@ class ofed(object):
         # the parent class constructors manually for now.
         #super(ofed, self).__init__(**kwargs)
 
-        self.__ospackages_deb = ['dapl2-utils', 'ibutils', 'ibverbs-utils',
-                                 'infiniband-diags', 'libdapl-dev',
-                                 'libibcm-dev', 'libibmad5', 'libibmad-dev',
-                                 'libibverbs1', 'libibverbs-dev', 'libmlx4-1',
-                                 'libmlx4-dev', 'libmlx5-1', 'libmlx5-dev',
-                                 'librdmacm1', 'librdmacm-dev', 'opensm',
-                                 'rdmacm-utils']
+        if (hpccm.config.g_linux_distro == linux_distro.UBUNTU and
+            hpccm.config.g_linux_version >= StrictVersion('18.0')):
+            self.__ospackages_deb = ['dapl2-utils', 'ibutils', 'ibverbs-utils',
+                                     'infiniband-diags', 'libdapl-dev',
+                                     'libibmad5', 'libibmad-dev',
+                                     'libibverbs1', 'libibverbs-dev',
+                                     'librdmacm1', 'librdmacm-dev',
+                                     'opensm', 'rdmacm-utils']
+        else:
+            self.__ospackages_deb = ['dapl2-utils', 'ibutils', 'ibverbs-utils',
+                                     'infiniband-diags', 'libdapl-dev',
+                                     'libibcm-dev',
+                                     'libibmad5', 'libibmad-dev',
+                                     'libibverbs1', 'libibverbs-dev',
+                                     'libmlx4-1', 'libmlx4-dev',
+                                     'libmlx5-1', 'libmlx5-dev',
+                                     'librdmacm1', 'librdmacm-dev',
+                                     'opensm', 'rdmacm-utils']
+
         self.__ospackages_rpm = ['dapl', 'dapl-devel', 'ibutils', 'libibcm',
                                  'libibmad', 'libibmad-devel', 'libmlx5',
                                  'libibumad', 'libibverbs', 'libibverbs-utils',

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -47,7 +47,7 @@ class openblas(rm, tar, wget):
     is `USE_OPENMP=1`.
 
     ospackages: List of OS packages to install prior to building.  The
-    default values are `make`, `tar`, and `wget`.
+    default values are `make`, `perl`, `tar`, and `wget`.
 
     prefix: The top level installation location.  The default value is
     `/usr/local/openblas`.
@@ -83,7 +83,8 @@ class openblas(rm, tar, wget):
 
         self.__baseurl = kwargs.get('baseurl', 'https://github.com/xianyi/OpenBLAS/archive')
         self.__make_opts = kwargs.get('make_opts', ['USE_OPENMP=1'])
-        self.__ospackages = kwargs.get('ospackages', ['make', 'tar', 'wget'])
+        self.__ospackages = kwargs.get('ospackages', ['make', 'perl', 'tar',
+                                                      'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/openblas')
         self.__toolchain = kwargs.get('toolchain', toolchain())
         self.__version = kwargs.get('version', '0.3.3')

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -22,6 +22,7 @@
 
 from __future__ import absolute_import
 
+from distutils.version import StrictVersion
 import sys
 
 from hpccm.common import container_type
@@ -30,6 +31,7 @@ from hpccm.common import linux_distro
 # Global variables
 g_ctype = container_type.DOCKER      # Container type
 g_linux_distro = linux_distro.UBUNTU # Linux distribution
+g_linux_version = StrictVersion('16.04') # Linux distribution version
 
 def set_container_format(ctype):
   """Set the container format

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 import re
 
@@ -37,11 +38,11 @@ class baseimage(object):
     value is empty.
 
     _distro: The underlying Linux distribution of the base image.
-    Valid values are `centos`, `redhat`, `rhel`, and `ubuntu`.  By
-    default, the primitive attempts to figure out the Linux
-    distribution by inspecting the image identifier, and falls back to
-    `ubuntu` if unable to determine the Linux distribution
-    automatically.
+    Valid values are `centos`, `redhat`, `rhel`, `ubuntu`, `ubuntu16`,
+    and `ubuntu18`.  By default, the primitive attempts to figure out
+    the Linux distribution by inspecting the image identifier, and
+    falls back to `ubuntu` if unable to determine the Linux
+    distribution automatically.
 
     image: The image identifier to use as the base image.  The default value is `nvidia/cuda:9.0-devel-ubuntu16.04`.
 
@@ -71,16 +72,33 @@ class baseimage(object):
         self.__distro = self.__distro.lower()
         if self.__distro == 'ubuntu':
             hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('16.04')
+        elif self.__distro == 'ubuntu16':
+            hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('16.04')
+        elif self.__distro == 'ubuntu18':
+            hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('18.04')
         elif (self.__distro == 'centos' or self.__distro == 'rhel' or
               self.__distro == 'redhat'):
             hpccm.config.g_linux_distro = linux_distro.CENTOS
+            hpccm.config.g_linux_version = StrictVersion('7.0')
         elif re.search(r'centos|rhel|redhat', self.image):
             hpccm.config.g_linux_distro = linux_distro.CENTOS
+            hpccm.config.g_linux_version = StrictVersion('7.0')
+        elif re.search(r'ubuntu:?16', self.image):
+            hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('16.04')
+        elif re.search(r'ubuntu:?18', self.image):
+            hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('18.04')
         elif re.search(r'ubuntu', self.image):
             hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('16.04')
         else:
             logging.warning('Unable to determine the Linux distribution, defaulting to Ubuntu')
             hpccm.config.g_linux_distro = linux_distro.UBUNTU
+            hpccm.config.g_linux_version = StrictVersion('16.04')
 
     def __str__(self):
         """String representation of the primitive"""

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -19,6 +19,7 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 
 import hpccm.config
@@ -26,9 +27,10 @@ import hpccm.config
 from hpccm.common import container_type, linux_distro
 
 def centos(function):
-    """Decorator to set the Linux distribution to CentOS"""
+    """Decorator to set the Linux distribution to CentOS 7"""
     def wrapper(*args, **kwargs):
         hpccm.config.g_linux_distro = linux_distro.CENTOS
+        hpccm.config.g_linux_version = StrictVersion('7.0')
         return function(*args, **kwargs)
 
     return wrapper
@@ -66,9 +68,19 @@ def singularity(function):
     return wrapper
 
 def ubuntu(function):
-    """Decorator to set the Linux distribution to Ubuntu"""
+    """Decorator to set the Linux distribution to Ubuntu 16.04"""
     def wrapper(*args, **kwargs):
         hpccm.config.g_linux_distro = linux_distro.UBUNTU
+        hpccm.config.g_linux_version = StrictVersion('16.04')
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def ubuntu18(function):
+    """Decorator to set the Linux distribution to Ubuntu 18.04"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_linux_distro = linux_distro.UBUNTU
+        hpccm.config.g_linux_version = StrictVersion('18.04')
         return function(*args, **kwargs)
 
     return wrapper

--- a/test/test_apt_get.py
+++ b/test/test_apt_get.py
@@ -38,7 +38,7 @@ class Test_yum(unittest.TestCase):
         a = apt_get(ospackages=['gcc', 'g++', 'gfortran'])
         self.assertEqual(str(a),
 r'''RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran && \
@@ -55,6 +55,6 @@ r'''RUN apt-get update -y && \
 r'''RUN wget -qO - https://www.example.com/key.pub | apt-key add - && \
     echo "deb http://www.example.com all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         example && \
     rm -rf /var/lib/apt/lists/*''')

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -24,6 +24,7 @@ import unittest
 
 from helpers import docker, invalid_ctype, singularity
 
+from distutils.version import StrictVersion
 import hpccm.config
 
 from hpccm.primitives.baseimage import baseimage
@@ -104,35 +105,69 @@ From: foo
     @docker
     def test_detect_ubuntu(self):
         """Base image Linux distribution detection"""
+        b = baseimage(image='ubuntu:sixteen')
+        self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+
+    @docker
+    def test_detect_ubuntu16(self):
+        """Base image Linux distribution detection"""
         b = baseimage(image='nvidia/cuda:9.0-devel-ubuntu16.04')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+
+    @docker
+    def test_detect_ubuntu18(self):
+        """Base image Linux distribution detection"""
+        b = baseimage(image='nvidia/cuda:9.2-devel-ubuntu18.04')
+        self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('18.04'))
 
     @docker
     def test_detect_centos(self):
         """Base image Linux distribution detection"""
         b = baseimage(image='nvidia/cuda:9.0-devel-centos7')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.CENTOS)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('7.0'))
 
     @docker
     def test_detect_nonexistent(self):
         """Base image Linux distribution detection"""
         b = baseimage(image='nonexistent')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
 
     @docker
     def test_distro_ubuntu(self):
         """Base image Linux distribution specification"""
         b = baseimage(image='foo', _distro='ubuntu')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+
+    @docker
+    def test_distro_ubuntu16(self):
+        """Base image Linux distribution specification"""
+        b = baseimage(image='foo', _distro='ubuntu16')
+        self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+
+    @docker
+    def test_distro_ubuntu18(self):
+        """Base image Linux distribution specification"""
+        b = baseimage(image='foo', _distro='ubuntu18')
+        self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('18.04'))
 
     @docker
     def test_distro_centos(self):
         """Base image Linux distribution specification"""
         b = baseimage(image='foo', _distro='centos')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.CENTOS)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('7.0'))
 
     @docker
     def test_distro_nonexistent(self):
         """Base image Linux distribution specification"""
         b = baseimage(image='foo', _distro='nonexistent')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
+        self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -39,7 +39,7 @@ class Test_boost(unittest.TestCase):
         self.assertEqual(str(b),
 r'''# Boost version 1.68.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         libbz2-dev \
         tar \
@@ -83,7 +83,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         self.assertEqual(str(b),
 r'''# Boost version 1.68.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         libbz2-dev \
         tar \
@@ -105,7 +105,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         self.assertEqual(str(b),
 r'''# Boost version 1.57.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         libbz2-dev \
         tar \

--- a/test/test_cgns.py
+++ b/test/test_cgns.py
@@ -39,7 +39,7 @@ class Test_cgns(unittest.TestCase):
         self.assertEqual(str(c),
 r'''# CGNS version 3.3.1
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget \
@@ -82,7 +82,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         self.assertEqual(r,
 r'''# CGNS
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         zlib1g && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/cgns /usr/local/cgns''')

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -39,7 +39,7 @@ class Test_charm(unittest.TestCase):
         self.assertEqual(str(c),
 r'''# Charm++ version 6.8.2
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git \
         make \
         wget && \

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -39,7 +39,7 @@ class Test_cmake(unittest.TestCase):
         self.assertEqual(str(c),
 r'''# CMake version 3.12.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
@@ -68,7 +68,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         self.assertEqual(str(c),
 r'''# CMake version 3.12.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
@@ -83,7 +83,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         self.assertEqual(str(c),
 r'''# CMake version 3.10.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh && \
@@ -99,7 +99,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         self.assertEqual(r,
 r'''# CMake version 3.12.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -39,7 +39,7 @@ class Test_fftw(unittest.TestCase):
         self.assertEqual(str(f),
 r'''# FFTW version 3.3.8
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
@@ -80,7 +80,7 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
         self.assertEqual(str(f),
 r'''# FFTW version 3.3.8
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
@@ -112,7 +112,7 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
         self.assertEqual(str(f),
 r'''# FFTW
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -39,7 +39,7 @@ class Test_gdrcopy(unittest.TestCase):
         self.assertEqual(str(g),
 r'''# GDRCOPY version 1.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -39,7 +39,7 @@ class Test_gnu(unittest.TestCase):
         self.assertEqual(str(g),
 r'''# GNU compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran && \
@@ -66,10 +66,10 @@ RUN yum install -y \
         self.assertEqual(str(g),
 r'''# GNU compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends software-properties-common && \
     apt-add-repository ppa:ubuntu-toolchain-r/test -y && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc-7 \
         g++-7 \
         gfortran-7 && \
@@ -102,7 +102,7 @@ ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH''')
         self.assertEqual(r,
 r'''# GNU compiler runtime
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libgomp1 \
         libgfortran3 && \
     rm -rf /var/lib/apt/lists/*''')

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -39,7 +39,7 @@ class Test_hdf5(unittest.TestCase):
         self.assertEqual(str(h),
 r'''# HDF5 version 1.10.4
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         file \
         make \
@@ -89,7 +89,7 @@ ENV HDF5_DIR=/usr/local/hdf5 \
         self.assertEqual(r,
 r'''# HDF5
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         zlib1g && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/hdf5 /usr/local/hdf5
@@ -105,7 +105,7 @@ ENV HDF5_DIR=/usr/local/hdf5 \
         self.assertEqual(str(h),
 r'''# HDF5
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         file \
         make \

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -47,9 +47,10 @@ class Test_intel_mpi(unittest.TestCase):
         self.assertEqual(str(impi),
 r'''# Intel MPI version 2018.3-051
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         man-db \
         openssh-client \
         wget && \
@@ -57,7 +58,7 @@ RUN apt-get update -y && \
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
@@ -88,9 +89,10 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         self.assertEqual(str(impi),
 r'''# Intel MPI version 2018.2-046
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         man-db \
         openssh-client \
         wget && \
@@ -98,7 +100,7 @@ RUN apt-get update -y && \
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mpi-2018.2-046 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
@@ -111,9 +113,10 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         self.assertEqual(str(impi),
 r'''# Intel MPI version 2018.3-051
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         man-db \
         openssh-client \
         wget && \
@@ -121,7 +124,7 @@ RUN apt-get update -y && \
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
 ENV I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
@@ -137,9 +140,10 @@ ENV I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
         self.assertEqual(r,
 r'''# Intel MPI version 2018.3-051
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         man-db \
         openssh-client \
         wget && \
@@ -147,7 +151,7 @@ RUN apt-get update -y && \
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mpi-2018.3-051 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_intel_psxe.py
+++ b/test/test_intel_psxe.py
@@ -47,7 +47,7 @@ class Test_intel_psxe(unittest.TestCase):
         self.assertEqual(str(psxe),
 r'''# Intel Parallel Studio XE
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         cpio && \
     rm -rf /var/lib/apt/lists/*
 COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz
@@ -72,7 +72,7 @@ ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
         self.assertEqual(str(psxe),
 r'''# Intel Parallel Studio XE
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         cpio && \
     rm -rf /var/lib/apt/lists/*
 COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz

--- a/test/test_knem.py
+++ b/test/test_knem.py
@@ -39,7 +39,7 @@ class Test_knem(unittest.TestCase):
         self.assertEqual(str(k),
 r'''# KNEM version 1.1.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         git && \
     rm -rf /var/lib/apt/lists/*

--- a/test/test_llvm.py
+++ b/test/test_llvm.py
@@ -39,7 +39,7 @@ class Test_llvm(unittest.TestCase):
         self.assertEqual(str(l),
 r'''# LLVM compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         clang && \
     rm -rf /var/lib/apt/lists/*''')
 
@@ -66,7 +66,7 @@ RUN yum install -y \
         self.assertEqual(str(l),
 r'''# LLVM compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         clang-6.0 && \
     rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/clang clang $(which clang-6.0) 30 && \
@@ -99,7 +99,7 @@ ENV LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64:$LD_LIBRARY_PATH \
         self.assertEqual(r,
 r'''# LLVM compiler runtime
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libclang1 && \
     rm -rf /var/lib/apt/lists/*''')
 

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -47,15 +47,16 @@ class Test_mkl(unittest.TestCase):
         self.assertEqual(str(m),
 r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
@@ -82,15 +83,16 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bashrc''')
         self.assertEqual(str(m),
 r'''# MKL version 2018.2-046
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2018.2-046 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
@@ -103,15 +105,16 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         self.assertEqual(str(m),
 r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 ENV CPATH=/opt/intel/mkl/include:$CPATH \
@@ -128,15 +131,16 @@ ENV CPATH=/opt/intel/mkl/include:$CPATH \
         self.assertEqual(r,
 r'''# MKL version 2019.0-045
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2019.0-045 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import centos, docker, ubuntu, ubuntu18
 
 from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
 
@@ -37,18 +37,37 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 3.4-1.0.0.0
+r'''# Mellanox OFED version 4.5-1.0.1.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
         libnl-route-3-200 \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-3.4-1.0.0.0/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    dpkg --install /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+
+    @ubuntu18
+    @docker
+    def test_defaults_ubuntu(self):
+        """Default mlnx_ofed building block"""
+        mofed = mlnx_ofed()
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64''')
 
     @centos
     @docker
@@ -56,17 +75,17 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 3.4-1.0.0.0
+r'''# Mellanox OFED version 4.5-1.0.1.0
 RUN yum install -y \
         libnl \
         libnl3 \
         numactl-libs \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-3.4-1.0.0.0/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
-    rpm --install /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-rhel7.2-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
+    rpm --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64''')
 
     @ubuntu
     @docker
@@ -75,15 +94,15 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         mofed = mlnx_ofed()
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 3.4-1.0.0.0
+r'''# Mellanox OFED version 4.5-1.0.1.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
         libnl-route-3-200 \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-3.4-1.0.0.0/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    dpkg --install /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-3.4-1.0.0.0-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -40,7 +40,7 @@ class Test_mvapich2(unittest.TestCase):
         self.assertEqual(str(mv2),
 r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
         file \
         make \
@@ -72,7 +72,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(mv2),
 r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
         file \
         make \
@@ -99,7 +99,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(mv2),
 r'''# MVAPICH2 version 2.3b
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
         file \
         make \
@@ -127,7 +127,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(mv2),
 r'''# MVAPICH2 version 2.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
         file \
         make \
@@ -177,7 +177,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(mv2),
 r'''# MVAPICH2
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
         file \
         make \
@@ -204,7 +204,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         self.assertEqual(r,
 r'''# MVAPICH2
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/mvapich2 /usr/local/mvapich2

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -39,7 +39,7 @@ class Test_mvapich2_gdr(unittest.TestCase):
         self.assertEqual(str(mv2),
 r'''# MVAPICH2-GDR version 2.3a
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
@@ -86,7 +86,7 @@ ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpi
         self.assertEqual(str(mv2),
 r'''# MVAPICH2-GDR version 2.3a
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
@@ -109,7 +109,7 @@ ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda8.0/mofed4.0/mpi
         self.assertEqual(str(mv2),
 r'''# MVAPICH2-GDR
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
@@ -133,7 +133,7 @@ ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpi
         self.assertEqual(r,
 r'''# MVAPICH2-GDR
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3a/mcast/no-openacc/cuda9.0/mofed3.4/mpirun/gnu4.8.5

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -40,7 +40,7 @@ class Test_netcdf(unittest.TestCase):
 r'''# NetCDF version 4.6.1, NetCDF C++ version 4.3.0, NetCDF Fortran
 # version 4.4.4
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         file \
         libcurl4-openssl-dev \
@@ -117,7 +117,7 @@ ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
         self.assertEqual(r,
 r'''# NetCDF
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         zlib1g && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/netcdf /usr/local/netcdf

--- a/test/test_ofed.py
+++ b/test/test_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import centos, docker, ubuntu, ubuntu18
 
 from hpccm.building_blocks.ofed import ofed
 
@@ -39,7 +39,7 @@ class Test_ofed(unittest.TestCase):
         self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         dapl2-utils \
         ibutils \
         ibverbs-utils \
@@ -54,6 +54,30 @@ RUN apt-get update -y && \
         libmlx4-dev \
         libmlx5-1 \
         libmlx5-dev \
+        librdmacm1 \
+        librdmacm-dev \
+        opensm \
+        rdmacm-utils && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    @ubuntu18
+    @docker
+    def test_defaults_ubuntu18(self):
+        """Default ofed building block"""
+        o = ofed()
+        self.assertEqual(str(o),
+r'''# OFED
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        dapl2-utils \
+        ibutils \
+        ibverbs-utils \
+        infiniband-diags \
+        libdapl-dev \
+        libibmad5 \
+        libibmad-dev \
+        libibverbs1 \
+        libibverbs-dev \
         librdmacm1 \
         librdmacm-dev \
         opensm \
@@ -93,7 +117,7 @@ RUN yum install -y \
         self.assertEqual(r,
 r'''# OFED
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         dapl2-utils \
         ibutils \
         ibverbs-utils \

--- a/test/test_openblas.py
+++ b/test/test_openblas.py
@@ -41,8 +41,9 @@ class Test_openblas(unittest.TestCase):
         self.assertEqual(str(o),
 r'''# OpenBLAS version 0.3.3
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
+        perl \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -39,7 +39,7 @@ class Test_openmpi(unittest.TestCase):
         self.assertEqual(str(ompi),
 r'''# OpenMPI version 3.1.2
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         file \
         hwloc \
@@ -94,7 +94,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(ompi),
 r'''# OpenMPI
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         file \
         hwloc \
@@ -122,7 +122,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         self.assertEqual(r,
 r'''# OpenMPI
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         hwloc \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -38,7 +38,7 @@ class Test_packages(unittest.TestCase):
         p = packages(ospackages=['gcc', 'g++', 'gfortran'])
         self.assertEqual(str(p),
 r'''RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran && \

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -39,7 +39,7 @@ class Test_pgi(unittest.TestCase):
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -88,7 +88,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -114,7 +114,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
 r'''# PGI compiler version 17.10
 COPY pgilinux-2017-1710-x86_64.tar.gz /var/tmp/pgilinux-2017-1710-x86_64.tar.gz
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -138,7 +138,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
 r'''# PGI compiler version 18.4
 COPY pkg/pgilinux-2018-1804-x86_64.tar.gz /var/tmp/pgilinux-2018-1804-x86_64.tar.gz
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -161,7 +161,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
 r'''# PGI compiler version 18.4
 COPY pgilinux-2018-1804-x86_64.tar.gz /var/tmp/pgilinux-2018-1804-x86_64.tar.gz
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -184,7 +184,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -210,7 +210,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -235,7 +235,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -267,7 +267,7 @@ ENV CC=/opt/pgi/linux86-64/18.10/bin/pgcc \
         self.assertEqual(str(p),
 r'''# PGI compiler version 18.10
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         libnuma1 \
@@ -302,7 +302,7 @@ ENV CC=/opt/pgi/linux86-64/18.10/bin/pgcc \
         self.assertEqual(r,
 r'''# PGI compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnuma1 && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /opt/pgi/linux86-64/18.10/REDIST/*.so /opt/pgi/linux86-64/18.10/lib/

--- a/test/test_pnetcdf.py
+++ b/test/test_pnetcdf.py
@@ -39,7 +39,7 @@ class Test_pnetcdf(unittest.TestCase):
         self.assertEqual(str(p),
 r'''# PnetCDF version 1.10.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         m4 \
         make \
         tar \

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -39,7 +39,7 @@ class Test_python(unittest.TestCase):
         self.assertEqual(str(p),
 r'''# Python
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python \
         python3 && \
     rm -rf /var/lib/apt/lists/*''')
@@ -66,7 +66,7 @@ RUN yum install -y epel-release && \
         self.assertEqual(r,
 r'''# Python
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python \
         python3 && \
     rm -rf /var/lib/apt/lists/*''')

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -60,7 +60,7 @@ class Test_recipe(unittest.TestCase):
 r'''FROM ubuntu:16.04 AS stage0
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran && \
@@ -79,7 +79,7 @@ From: ubuntu:16.04
 
 %post
     apt-get update -y
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran
@@ -95,7 +95,7 @@ r'''FROM nvidia/cuda:9.0-devel-ubuntu16.04 AS devel
 
 # GNU compiler
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran && \
@@ -103,7 +103,7 @@ RUN apt-get update -y && \
 
 # FFTW version 3.3.8
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget && \
@@ -130,7 +130,7 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
 # GNU compiler
 %post
     apt-get update -y
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         gcc \
         g++ \
         gfortran
@@ -139,7 +139,7 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
 # FFTW version 3.3.8
 %post
     apt-get update -y
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
         make \
         wget
@@ -167,7 +167,7 @@ r'''FROM nvidia/cuda:9.0-devel-ubuntu16.04 AS stage0
 
 # OpenMPI version 2.1.2
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
         file \
         hwloc \

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -39,7 +39,7 @@ class Test_ucx(unittest.TestCase):
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
         file \
         libnuma-dev \
@@ -86,7 +86,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
         file \
         libnuma-dev \
@@ -110,7 +110,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
         file \
         libnuma-dev \
@@ -134,7 +134,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
         file \
         libnuma-dev \

--- a/test/test_xpmem.py
+++ b/test/test_xpmem.py
@@ -39,7 +39,7 @@ class Test_xpmem(unittest.TestCase):
         self.assertEqual(str(x),
 r'''# XPMEM branch master
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         autoconf \
         automake \
         ca-certificates \


### PR DESCRIPTION
- Add g_linux_version global to hold the linux distro version, complementing g_linux_distro which holds the distro family
- apt_get: set DEBIAN_FRONTEND=noninteractive by default
- intel_mpi: add gnupg dependency
- mlnx_ofed building block: bump default version to 4.5 which supports all 3 supported Linux distros / versions
- mkl: add gnupg dependency
- ofed building block: update for distro package changes
- openblas: add perl dependency