### PR TITLE
Setup application environment in the build stage for the GROMACS and MILC examples

### DIFF
--- a/recipes/gromacs/gromacs.py
+++ b/recipes/gromacs/gromacs.py
@@ -58,6 +58,16 @@ build_cmds = [git().clone_step(
               cm.build_step(target='check')]
 Stage0 += shell(commands=build_cmds)
 
+# Include examples if they exist in the build context
+if os.path.isdir('recipes/gromacs/examples'):
+    Stage0 += copy(src='recipes/gromacs/examples', dest='/workspace/examples')
+
+Stage0 += environment(variables={'PATH': '$PATH:/gromacs/install/bin'})
+
+Stage0 += label(metadata={'com.nvidia.gromacs.version': gromacs_version})
+
+Stage0 += workdir(directory='/workspace')
+
 ######
 # Runtime image stage
 ######

--- a/recipes/milc/milc.py
+++ b/recipes/milc/milc.py
@@ -87,6 +87,14 @@ milc_cmds = ['mkdir -p /milc',
                            r's/CGEOM =.*-DFIX_NODE_GEOM.*/CGEOM = #-DFIX_NODE_GEOM/g']),
              'C_INCLUDE_PATH=/quda/build/include make su3_rhmd_hisq']
 Stage0 += shell(commands=milc_cmds)
+Stage0 += environment(variables={
+    'PATH': '$PATH:/milc/milc_qcd-{}/ks_imp_rhmc'.format(milc_version)})
+
+# Include examples if they exist in the build context
+if os.path.isdir('recipes/milc/examples'):
+    Stage0 += copy(src='recipes/milc/examples', dest='/workspace/examples')
+
+Stage0 += workdir(directory='/workspace')
 
 ###############################################################################
 # Release stage


### PR DESCRIPTION
Resolve an issue identified by @chrisreidy when building a image based on the first stage only, e.g., using `singularity build`.