### PR TITLE
Add ldconfig template and update building blocks accordingly

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -37,14 +37,16 @@ boost(self, **kwargs)
 The `boost` building block downloads and installs the
 [Boost](https://www.boost.org) component.
 
-As a side effect, this building block modifies `LD_LIBRARY_PATH`
-to include the Boost build.
-
 __Parameters__
 
 
 - __bootstrap_opts__: List of options to pass to `bootstrap.sh`.  The
 default is an empty list.
+
+- __ldconfig__: Boolean flag to specify whether the Boost library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the Boost library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to building.  For
 Ubuntu, the default values are `bzip2`, `libbz2-dev`, `tar`,
@@ -78,6 +80,7 @@ boost(prefix='/opt/boost/1.67.0', version='1.67.0')
 ```python
 boost(sourceforge=True, version='1.57.0')
 ```
+
 
 ## runtime
 ```python
@@ -160,16 +163,20 @@ charm(self, **kwargs)
 The `charm` building block downloads and install the
 [Charm++](http://charm.cs.illinois.edu/research/charm) component.
 
-As a side effect, this building block modifies `LD_LIBRARY_PATH`
-and `PATH` to include the Charm++ build.  It also sets the
-`CHARMBASE` environment variable to the top level install
-directory.
+As a side effect, this building block modifies `PATH` to include
+the Charm++ build.  It also sets the `CHARMBASE` environment
+variable to the top level install directory.
 
 __Parameters__
 
 
 - __check__: Boolean flag to specify whether the test cases should be
 run.  The default is False.
+
+- __ldconfig__: Boolean flag to specify whether the Charm++ library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the Charm++ library
+directory. The default value is False.
 
 - __options__: List of additional options to use when building Charm++.
 The default values are `--build-shared`, and `--with-production`.
@@ -199,6 +206,7 @@ charm(prefix='/opt', version='6.8.2')
 ```python
 charm(target_architecture='mpi-linux-x86_64')
 ```
+
 
 ## runtime
 ```python
@@ -274,9 +282,6 @@ the parameters, the source will be downloaded from the web
 (default) or copied from a source directory in the local build
 context.
 
-As a side effect, this building block modifies `LD_LIBRARY_PATH`
-to include the FFTW build.
-
 __Parameters__
 
 
@@ -291,6 +296,11 @@ default values are `--enable-shared`, `--enable-openmp`,
 local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
+
+- __ldconfig__: Boolean flag to specify whether the FFTW library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the FFTW library
+directory. The default value is False.
 
 - __mpi__: Boolean flag to specify whether to build with MPI support
 enabled.  The default is False.
@@ -329,6 +339,7 @@ fftw(check=True, configure_opts=['--enable-shared', '--enable-threads',
                                  '--enable-sse2', '--enable-avx'])
 ```
 
+
 ## runtime
 ```python
 fftw.runtime(self, _from=u'0')
@@ -353,11 +364,16 @@ The `gdrcopy` building block builds and installs the user space
 library from the [gdrcopy](https://github.com/NVIDIA/gdrcopy)
 component.
 
-As a side effect, this building block modifies `CPATH`,
-`LD_LIBRARY_PATH`, and `LIBRARY_PATH`.
+As a side effect, this building block modifies `CPATH` and
+`LIBRARY_PATH`.
 
 __Parameters__
 
+
+- __ldconfig__: Boolean flag to specify whether the gdrcopy library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the gdrcopy library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to building.  The
 default values are `make` and `wget`.
@@ -476,8 +492,8 @@ on the parameters, the source will be downloaded from the web
 (default) or copied from a source directory in the local build
 context.
 
-As a side effect, this building block modifies `PATH`,
-`LD_LIBRARY_PATH` to include the HDF5 build, and sets `HDF5_DIR`.
+As a side effect, this building block modifies `PATH`
+to include the HDF5 build, and sets `HDF5_DIR`.
 
 __Parameters__
 
@@ -492,6 +508,11 @@ default values are `--enable-cxx` and `--enable-fortran`.
 local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
+
+- __ldconfig__: Boolean flag to specify whether the HDF5 library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the HDF5 library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are `bzip2`, `file`,
@@ -923,8 +944,8 @@ An InfiniBand building block ([OFED](#ofed) or [Mellanox
 OFED](#mlnx_ofed)) should be installed prior to this building
 block.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the MVAPICH2 build.
+As a side effect, this building block modifies `PATH`
+to include the MVAPICH2 build.
 
 As a side effect, a toolchain is created containing the MPI
 compiler wrappers.  The tool can be passed to other operations
@@ -955,6 +976,11 @@ than downloading the source from the web.
 (2.3b and previous) were hard-coded to use "sm_20".  This option
 has no effect on more recent MVAPICH2 versions.  The default value
 is to use the MVAPICH2 default.
+
+- __ldconfig__: Boolean flag to specify whether the MVAPICH2 library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the MVAPICH2 library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are `byacc`, `file`,
@@ -1174,11 +1200,13 @@ openblas(self, **kwargs)
 The `openblas` building block builds and installs the
 [OpenBLAS](https://www.openblas.net) component.
 
-As a side effect, this building block modifies `LD_LIBRARY_PATH`
-to include the OpenBLAS build.
-
 __Parameters__
 
+
+- __ldconfig__: Boolean flag to specify whether the OpenBLAS library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the OpenBLAS library
+directory. The default value is False.
 
 - __make_opts__: List of options to pass to `make`.  The default value
 is `USE_OPENMP=1`.
@@ -1265,6 +1293,11 @@ than downloading the source from the web.
 capabilities are included.  If True, adds `--with-verbs` to the
 list of `configure` options, otherwise adds `--without-verbs`.
 The default value is True.
+
+- __ldconfig__: Boolean flag to specify whether the OpenMPI library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the OpenMPI library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are `bzip2`, `file`,
@@ -1499,8 +1532,8 @@ installs the
 [PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF/index.html)
 component.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the PnetCDF build.
+As a side effect, this building block modifies `PATH` to include
+the PnetCDF build.
 
 __Parameters__
 
@@ -1510,6 +1543,11 @@ should be performed.  The default is False.
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default values are `--enable-shared`.
+
+- __ldconfig__: Boolean flag to specify whether the PnetCDF library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the PnetCDF library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  The default values are `m4`, `make`, `tar`, and
@@ -1609,8 +1647,8 @@ block.  One or all of the [gdrcopy](#gdrcopy), [KNEM](#knem), and
 [XPMEM](#xpmem) building blocks should also be installed prior to
 this building block.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the UCX build.
+As a side effect, this building block modifies `PATH`
+to include the UCX build.
 
 __Parameters__
 
@@ -1644,6 +1682,11 @@ the list of `configure` options.  The default is an empty string,
 i.e., include neither `--with-knem` not `--without-knem` and let
 `configure` try to automatically detect whether KNEM is present or
 not.
+
+- __ldconfig__: Boolean flag to specify whether the UCX library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the UCX library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are `binutils-dev`,
@@ -1706,8 +1749,8 @@ The `xpmem` building block builds and installs the user space
 library from the [XPMEM](https://gitlab.com/hjelmn/xpmem)
 component.
 
-As a side effect, this building block modifies `CPATH`,
-`LD_LIBRARY_PATH`, and `LIBRARY_PATH`.
+As a side effect, this building block modifies `CPATH` and
+`LIBRARY_PATH`.
 
 __Parameters__
 
@@ -1717,6 +1760,11 @@ __Parameters__
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default values are `--disable-kernel-module`.
+
+- __ldconfig__: Boolean flag to specify whether the XPMEM library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the XPMEM library
+directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  The default value are `autoconf`, `automake`,

--- a/hpccm/templates/__init__.py
+++ b/hpccm/templates/__init__.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 from hpccm.templates.CMakeBuild import CMakeBuild
 from hpccm.templates.ConfigureMake import ConfigureMake
 from hpccm.templates.git import git
+from hpccm.templates.ldconfig import ldconfig
 from hpccm.templates.rm import rm
 from hpccm.templates.sed import sed
 from hpccm.templates.tar import tar

--- a/hpccm/templates/ldconfig.py
+++ b/hpccm/templates/ldconfig.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""ldconfig template"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+
+class ldconfig(object):
+    """Template for manipulating the dynamic linker"""
+
+    def __init__(self, **kwargs):
+        """Initialize template"""
+
+        #super(ldconfig, self).__init__()
+        self.ldconfig = kwargs.get('ldconfig', False)
+
+    def ldcache_step(self, conf='hpccm.conf', directory=None):
+        """Add a directory to the dynamic linker cache"""
+
+        if not directory:
+            logging.error('directory is not defined')
+            return ''
+
+        return 'echo "{0}" >> {1} && ldconfig'.format(
+            directory, os.path.join('/etc/ld.so.conf.d', conf))

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -121,6 +121,28 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        b = boost(ldconfig=True, version='1.68.0')
+        self.assertEqual(str(b),
+r'''# Boost version 1.68.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        libbz2-dev \
+        tar \
+        wget \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+    ./b2 -j$(nproc) -q install && \
+    echo "/usr/local/boost/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         b = boost()

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -54,6 +54,27 @@ ENV CHARMBASE=/usr/local/charm-v6.8.2 \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        c = charm(ldconfig=True, version='6.8.2')
+        self.assertEqual(str(c),
+r'''# Charm++ version 6.8.2
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        git \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz && \
+    mkdir -p /usr/local && tar -x -f /var/tmp/charm-6.8.2.tar.gz -C /usr/local -z && \
+    cd /usr/local/charm-v6.8.2 && ./build charm++ multicore-linux-x86_64 --build-shared --with-production -j4 && \
+    echo "/usr/local/charm-v6.8.2/lib_so" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/charm-6.8.2.tar.gz
+ENV CHARMBASE=/usr/local/charm-v6.8.2 \
+    PATH=/usr/local/charm-v6.8.2/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         c = charm()

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -95,6 +95,27 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        f = fftw(ldconfig=True, version='3.3.8')
+        self.assertEqual(str(f),
+r'''# FFTW version 3.3.8
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2 && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/fftw/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         f = fftw()

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -76,6 +76,28 @@ ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        g = gdrcopy(ldconfig=True, version='1.3')
+        self.assertEqual(str(g),
+r'''# GDRCOPY version 1.3
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v1.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v1.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-1.3 && \
+    mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
+    make PREFIX=/usr/local/gdrcopy lib lib_install && \
+    echo "/usr/local/gdrcopy/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/v1.3.tar.gz /var/tmp/gdrcopy-1.3
+ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
+    LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         g = gdrcopy()

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -82,6 +82,31 @@ ENV HDF5_DIR=/usr/local/hdf5 \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        h = hdf5(ldconfig=True, version='1.10.4')
+        self.assertEqual(str(h),
+r'''# HDF5 version 1.10.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        make \
+        wget \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.4.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.4 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/hdf5/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/hdf5-1.10.4.tar.bz2 /var/tmp/hdf5-1.10.4
+ENV HDF5_DIR=/usr/local/hdf5 \
+    PATH=/usr/local/hdf5/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         h = hdf5()

--- a/test/test_ldconfig.py
+++ b/test/test_ldconfig.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the ldconfig module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.templates.ldconfig import ldconfig
+
+class Test_ldconfig(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_no_directory(self):
+        """No directory specified"""
+        l = ldconfig()
+
+        self.assertEqual(l.ldcache_step(directory=None), '')
+
+    def test_basic(self):
+        """Basic ldconfig"""
+        l = ldconfig()
+
+        self.assertEqual(l.ldcache_step(directory='/usr/local/lib'),
+                         'echo "/usr/local/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig')

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -197,6 +197,33 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        mv2 = mvapich2(ldconfig=True, version='2.3')
+        self.assertEqual(str(mv2),
+r'''# MVAPICH2 version 2.3
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        byacc \
+        file \
+        make \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
+    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/mvapich2/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
+ENV PATH=/usr/local/mvapich2/bin:$PATH \
+    PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         mv2 = mvapich2()

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -110,6 +110,46 @@ ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        n = netcdf(ldconfig=True, version='4.6.1', version_cxx='4.3.0',
+                   version_fortran='4.4.4')
+        self.assertEqual(str(n),
+r'''# NetCDF version 4.6.1, NetCDF C++ version 4.3.0, NetCDF Fortran
+# version 4.4.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        file \
+        libcurl4-openssl-dev \
+        m4 \
+        make \
+        wget \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.6.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.6.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-4.6.1 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/netcdf/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/netcdf-4.6.1.tar.gz /var/tmp/netcdf-4.6.1 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-cxx4-4.3.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/netcdf-cxx4-4.3.0.tar.gz /var/tmp/netcdf-cxx4-4.3.0 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-fortran-4.4.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-fortran-4.4.4 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/netcdf-fortran-4.4.4.tar.gz /var/tmp/netcdf-fortran-4.4.4
+ENV PATH=/usr/local/netcdf/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         n = netcdf()

--- a/test/test_openblas.py
+++ b/test/test_openblas.py
@@ -56,6 +56,28 @@ ENV LD_LIBRARY_PATH=/usr/local/openblas/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        tc = toolchain(CC='gcc', FC='gfortran')
+        o = openblas(ldconfig=True, toolchain=tc, version='0.3.3')
+        self.assertEqual(str(o),
+r'''# OpenBLAS version 0.3.3
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        perl \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/OpenBLAS-0.3.3 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
+    make install PREFIX=/usr/local/openblas && \
+    echo "/usr/local/openblas/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/v0.3.3.tar.gz /var/tmp/OpenBLAS-0.3.3''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         o = openblas()

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -115,6 +115,34 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        ompi = openmpi(ldconfig=True, version='3.1.2')
+        self.assertEqual(str(ompi),
+r'''# OpenMPI version 3.1.2
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        hwloc \
+        libnuma-dev \
+        make \
+        openssh-client \
+        perl \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-3.1.2.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.1.2.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-3.1.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/openmpi/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/openmpi-3.1.2.tar.bz2 /var/tmp/openmpi-3.1.2
+ENV PATH=/usr/local/openmpi/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         ompi = openmpi()

--- a/test/test_pnetcdf.py
+++ b/test/test_pnetcdf.py
@@ -57,6 +57,30 @@ ENV LD_LIBRARY_PATH=/usr/local/pnetcdf/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        p = pnetcdf(ldconfig=True, version='1.10.0')
+        self.assertEqual(str(p),
+r'''# PnetCDF version 1.10.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        m4 \
+        make \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/parallel-netcdf-1.10.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/parallel-netcdf-1.10.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/parallel-netcdf-1.10.0 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
+    sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/parallel-netcdf-1.10.0/libtool && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/pnetcdf/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/parallel-netcdf-1.10.0.tar.gz /var/tmp/parallel-netcdf-1.10.0
+ENV PATH=/usr/local/pnetcdf/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         p = pnetcdf()

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -152,6 +152,30 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        u = ucx(ldconfig=True, version='1.4.0')
+        self.assertEqual(str(u),
+r'''# UCX version 1.4.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        binutils-dev \
+        file \
+        libnuma-dev \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/ucx/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+ENV PATH=/usr/local/ucx/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         u = ucx()

--- a/test/test_xpmem.py
+++ b/test/test_xpmem.py
@@ -86,6 +86,33 @@ ENV CPATH=/usr/local/xpmem/include:$CPATH \
 
     @ubuntu
     @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        x = xpmem(ldconfig=True, branch='master')
+        self.assertEqual(str(x),
+r'''# XPMEM branch master
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        ca-certificates \
+        file \
+        git \
+        libtool \
+        make && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://gitlab.com/hjelmn/xpmem.git xpmem && cd - && \
+    cd /var/tmp/xpmem && autoreconf --install && \
+    cd /var/tmp/xpmem &&   ./configure --prefix=/usr/local/xpmem --disable-kernel-module && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/xpmem/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/xpmem
+ENV CPATH=/usr/local/xpmem/include:$CPATH \
+    LIBRARY_PATH=/usr/local/xpmem/lib:$LIBRARY_PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         x = xpmem()


### PR DESCRIPTION
Adds option to use `ldconfig` to update the dynamic linker cache rather than setting the `LD_LIBRARY_PATH` environment variable.  By default, the environment variable is used.