### PR TITLE
Simplify runtime recipes stages with a Stage runtime method

### DIFF
--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -86,3 +86,26 @@ __Returns__
 
 True if any layers have been added to the stage, otherwise False
 
+## runtime
+```python
+Stage.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a previous stage.
+
+This method invokes the runtime() method for every layer in
+the stage.  If a layer does not have a runtime() method, then
+it is skipped.
+
+__Examples__
+
+```python
+Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
+Stage0 += gnu()
+Stage0 += ofed()
+Stage0 += openmpi()
+...
+Stage1 += baseimage(image='nvidia/cuda:9.0-base')
+Stage1 += Stage0.runtime()
+```
+

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -208,17 +208,17 @@ automatically created for use in HPCCM recipes.
 
 Most [building blocks](/docs/building_blocks.md) provide a `runtime`
 method to install the corresponding runtime version of a component in
-another stage.  Building block settings defined in the first stage are
-automatically reflected in the second stage using the `runtime`
-method.
+another stage.  The `Stage` class also provides a `runtime` method
+that calls the `runtime` method of every building block.  Building
+block settings defined in the first stage are automatically reflected
+in the second stage using the `runtime` method.
 
 ```python
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel-centos7')
-ompi = openmpi(infiniband=False, prefix='/opt/openmpi')
-Stage0 += ompi
+Stage0 += openmpi(infiniband=False, prefix='/opt/openmpi')
 
 Stage1 += baseimage(image='nvidia/cuda:9.0-base-centos7')
-Stage1 += ompi.runtime()
+Stage1 += Stage0.runtime()
 ```
 
 ```

--- a/hpccm/Stage.py
+++ b/hpccm/Stage.py
@@ -82,3 +82,30 @@ class Stage(object):
         True if any layers have been added to the stage, otherwise False
         """
         return bool(self.__layers)
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a previous stage.
+
+        This method invokes the runtime() method for every layer in
+        the stage.  If a layer does not have a runtime() method, then
+        it is skipped.
+
+        # Examples
+        ```python
+        Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
+        Stage0 += gnu()
+        Stage0 += ofed()
+        Stage0 += openmpi()
+        ...
+        Stage1 += baseimage(image='nvidia/cuda:9.0-base')
+        Stage1 += Stage0.runtime()
+        ```
+        """
+        instructions = []
+        for layer in self.__layers:
+            runtime = getattr(layer, 'runtime', None)
+            if callable(runtime):
+                instructions.append(layer.runtime(_from=_from))
+
+        return self.__separator.join(instructions)

--- a/recipes/gromacs/gromacs.py
+++ b/recipes/gromacs/gromacs.py
@@ -20,20 +20,16 @@ Stage0 += comment(__doc__.strip(), reformat=False)
 Stage0.name = 'devel'
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel-ubuntu16.04', _as=Stage0.name)
 
-python = python(python3=False)
-Stage0 += python
+Stage0 += python(python3=False)
 
-gnu = gnu(fortran=False)
-Stage0 += gnu
+Stage0 += gnu(fortran=False)
 
 Stage0 += packages(ospackages=['ca-certificates', 'cmake', 'git'])
 
-ofed = ofed()
-Stage0 += ofed
+Stage0 += ofed()
 
-ompi = openmpi(configure_opts=['--enable-mpi-cxx'], parallel=32,
+Stage0 += openmpi(configure_opts=['--enable-mpi-cxx'], parallel=32,
                prefix="/opt/openmpi", version='3.0.0')
-Stage0 += ompi
 
 cm = CMakeBuild()
 build_cmds = [git().clone_step(
@@ -73,13 +69,7 @@ Stage0 += workdir(directory='/workspace')
 ######
 Stage1.baseimage('nvidia/cuda:9.0-runtime-ubuntu16.04')
 
-Stage1 += python.runtime(_from=Stage0.name)
-
-Stage1 += gnu.runtime(_from=Stage0.name)
-
-Stage1 += ofed.runtime(_from=Stage0.name)
-
-Stage1 += ompi.runtime(_from=Stage0.name)
+Stage1 += Stage0.runtime(_from=Stage0.name)
 
 Stage1 += copy(_from=Stage0.name, src='/gromacs/install',
                dest='/gromacs/install')

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -29,32 +29,23 @@ Stage0 += comment(__doc__, reformat=False)
 Stage0 += baseimage(image=devel_image, _as='devel')
 
 # Python
-python = python()
-Stage0 += python
+Stage0 += python()
 
 # GNU compilers
-gnu = gnu()
-Stage0 += gnu
-
-# Setup the toolchain.  Use the GNU compiler toolchain as the basis.
-tc = gnu.toolchain
-tc.CUDA_HOME = '/usr/local/cuda'
+compiler = gnu()
+Stage0 += compiler
 
 # Mellanox OFED
-ofed = mlnx_ofed(version='3.4-1.0.0.0')
-Stage0 += ofed
+Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
 
 # MVAPICH2
-mv2 = mvapich2(version='2.3', toolchain=tc)
-Stage0 += mv2
+Stage0 += mvapich2(version='2.3', toolchain=compiler.toolchain)
 
 # FFTW
-fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
-Stage0 += fftw
+Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-hdf5 = hdf5(version='1.10.4', toolchain=tc)
-Stage0 += hdf5
+Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 ######
 # Runtime image
@@ -62,20 +53,4 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image=runtime_image)
 
-# Python
-Stage1 += python.runtime()
-
-# GNU compiler
-Stage1 += gnu.runtime()
-
-# Mellanox OFED
-Stage1 += ofed.runtime()
-
-# MVAPICH2
-Stage1 += mv2.runtime()
-
-# FFTW
-Stage1 += fftw.runtime()
-
-# HDF5
-Stage1 += hdf5.runtime()
+Stage1 += Stage0.runtime()

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -29,32 +29,23 @@ Stage0 += comment(__doc__, reformat=False)
 Stage0 += baseimage(image=devel_image, _as='devel')
 
 # Python
-python = python()
-Stage0 += python
+Stage0 += python()
 
 # GNU compilers
-gnu = gnu()
-Stage0 += gnu
-
-# Setup the toolchain.  Use the GNU compiler toolchain as the basis.
-tc = gnu.toolchain
-tc.CUDA_HOME = '/usr/local/cuda'
+compiler = gnu()
+Stage0 += compiler
 
 # Mellanox OFED
-ofed = mlnx_ofed(version='3.4-1.0.0.0')
-Stage0 += ofed
+Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
 
 # OpenMPI
-ompi = openmpi(version='3.1.2', toolchain=tc)
-Stage0 += ompi
+Stage0 += openmpi(version='3.1.2', toolchain=compiler.toolchain)
 
 # FFTW
-fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
-Stage0 += fftw
+Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-hdf5 = hdf5(version='1.10.4', toolchain=tc)
-Stage0 += hdf5
+Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 ######
 # Runtime image
@@ -62,20 +53,4 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image=runtime_image)
 
-# Python
-Stage1 += python.runtime()
-
-# GNU compiler
-Stage1 += gnu.runtime()
-
-# Mellanox OFED
-Stage1 += ofed.runtime()
-
-# OpenMPI
-Stage1 += ompi.runtime()
-
-# FFTW
-Stage1 += fftw.runtime()
-
-# HDF5
-Stage1 += hdf5.runtime()
+Stage1 += Stage0.runtime()

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -37,32 +37,23 @@ Stage0 += comment(__doc__, reformat=False)
 Stage0 += baseimage(image=devel_image, _as='devel')
 
 # Python
-python = python()
-Stage0 += python
+Stage0 += python()
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='18.10')
-Stage0 += pgi
-
-# Setup the toolchain.  Use the PGI compiler toolchain as the basis.
-tc = pgi.toolchain
-tc.CUDA_HOME = '/usr/local/cuda'
+compiler = pgi(eula=pgi_eula, version='18.10')
+Stage0 += compiler
 
 # Mellanox OFED
-ofed = mlnx_ofed(version='3.4-1.0.0.0')
-Stage0 += ofed
+Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
 
 # MVAPICH2
-mv2 = mvapich2(version='2.3', toolchain=tc)
-Stage0 += mv2
+Stage0 += mvapich2(version='2.3', toolchain=compiler.toolchain)
 
 # FFTW
-fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
-Stage0 += fftw
+Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-hdf5 = hdf5(version='1.10.4', toolchain=tc)
-Stage0 += hdf5
+Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 ######
 # Runtime image
@@ -70,20 +61,4 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image=runtime_image)
 
-# Python
-Stage1 += python.runtime()
-
-# PGI compiler
-Stage1 += pgi.runtime()
-
-# Mellanox OFED
-Stage1 += ofed.runtime()
-
-# MVAPICH2
-Stage1 += mv2.runtime()
-
-# FFTW
-Stage1 += fftw.runtime()
-
-# HDF5
-Stage1 += hdf5.runtime()
+Stage1 += Stage0.runtime()

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -37,32 +37,23 @@ Stage0 += comment(__doc__, reformat=False)
 Stage0 += baseimage(image=devel_image, _as='devel')
 
 # Python
-python = python()
-Stage0 += python
+Stage0 += python()
 
 # PGI compilers
-pgi = pgi(eula=pgi_eula, version='18.10')
-Stage0 += pgi
-
-# Setup the toolchain.  Use the PGI compiler toolchain as the basis.
-tc = pgi.toolchain
-tc.CUDA_HOME = '/usr/local/cuda'
+compiler = pgi(eula=pgi_eula, version='18.10')
+Stage0 += compiler
 
 # Mellanox OFED
-ofed = mlnx_ofed(version='3.4-1.0.0.0')
-Stage0 += ofed
+Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
 
 # OpenMPI
-ompi = openmpi(version='3.1.2', toolchain=tc)
-Stage0 += ompi
+Stage0 += openmpi(version='3.1.2', toolchain=compiler.toolchain)
 
 # FFTW
-fftw = fftw(version='3.3.8', mpi=True, toolchain=tc)
-Stage0 += fftw
+Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-hdf5 = hdf5(version='1.10.4', toolchain=tc)
-Stage0 += hdf5
+Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 ######
 # Runtime image
@@ -70,20 +61,4 @@ Stage0 += hdf5
 
 Stage1 += baseimage(image=runtime_image)
 
-# Python
-Stage1 += python.runtime()
-
-# PGI compiler
-Stage1 += pgi.runtime()
-
-# Mellanox OFED
-Stage1 += ofed.runtime()
-
-# OpenMPI
-Stage1 += ompi.runtime()
-
-# FFTW
-Stage1 += fftw.runtime()
-
-# HDF5
-Stage1 += hdf5.runtime()
+Stage1 += Stage0.runtime()

--- a/recipes/milc/milc.py
+++ b/recipes/milc/milc.py
@@ -32,12 +32,10 @@ Stage0 += baseimage(image='nvidia/cuda:9.0-devel-ubuntu16.04', _as=Stage0.name)
 Stage0 += packages(ospackages=['autoconf', 'automake', 'ca-certificates',
                                'cmake', 'git'])
 
-ofed = ofed()
-Stage0 += ofed
+Stage0 += ofed()
 
-ompi = openmpi(configure_opts=['--enable-mpi-cxx'], prefix='/opt/openmpi',
-               parallel=32, version='3.0.0')
-Stage0 += ompi
+Stage0 += openmpi(configure_opts=['--enable-mpi-cxx'], prefix='/opt/openmpi',
+                  parallel=32, version='3.0.0')
 
 # build QUDA
 g = git()
@@ -101,9 +99,7 @@ Stage0 += workdir(directory='/workspace')
 ###############################################################################
 Stage1 += baseimage(image='nvidia/cuda:9.0-base-ubuntu16.04')
 
-Stage1 += ofed.runtime()
-
-Stage1 += ompi.runtime()
+Stage1 += Stage0.runtime()
 
 Stage1 += copy(_from=Stage0.name,
                src='/milc/milc_qcd-{}/ks_imp_rhmc/su3_rhmd_hisq'.format(


### PR DESCRIPTION
This change significantly simplifies multistage recipes.  It adds a `runtime` method to the `Stage` class that invokes the `runtime` method for every layer in the stage (skipping layers that do not have `runtime` methods defined).  This eliminates the need for intermediate variables for the building blocks and the need to enumerate each building block in the runtime stage.

Before:

```
Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
compiler = gnu(...)
Stage0 += compiler
mofed = mlnx_ofed(...)
Stage0 += mofed
ompi = openmpi(...)
Stage0 += ompi
Stage0 += shell(commands=[...]) # build app

Stage1 += baseimage(image='nvidia/cuda:9.0-base')
Stage1 += gnu.runtime()
Stage1 += mofed.runtime()
Stage1 += ompi.runtime()
Stage1 += copy(...) # copy app
```

After:
```
Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
Stage0 += gnu(...)
Stage0 += mlnx_ofed(...)
Stage0 += openmpi(...)
Stage0 += shell(commands=[...]) # build app

Stage1 += baseimage(image='nvidia/cuda:9.0-base')
Stage1 += Stage0.runtime()
Stage1 += copy(...) # copy app
```