### PR TITLE
Remove the cmake buildling block runtime method

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -257,21 +257,6 @@ cmake(eula=True)
 cmake(eula=True, version='3.10.3')
 ```
 
-## runtime
-```python
-cmake.runtime(self, _from=u'0')
-```
-Generate the set of instructions to install the runtime specific
-components from a build in a previous stage.
-
-__Examples__
-
-```python
-cmake = cmake(...)
-Stage0 += cmake
-Stage1 += cmake.runtime()
-```
-
 # fftw
 ```python
 fftw(self, **kwargs)

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -129,16 +129,3 @@ class cmake(rm, wget):
         # Cleanup runfile
         self.__commands.append(self.cleanup_step(
             items=[os.path.join(self.__wd, runfile)]))
-
-    def runtime(self, _from='0'):
-        """Generate the set of instructions to install the runtime specific
-        components from a build in a previous stage.
-
-        # Examples
-        ```python
-        cmake = cmake(...)
-        Stage0 += cmake
-        Stage1 += cmake.runtime()
-        ```
-        """
-        return str(self)

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -89,19 +89,3 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh && \
     /bin/sh /var/tmp/cmake-3.10.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.10.3-Linux-x86_64.sh''')
-
-    @ubuntu
-    @docker
-    def test_runtime(self):
-        """Runtime"""
-        c = cmake(eula=True)
-        r = c.runtime()
-        self.assertEqual(r,
-r'''# CMake version 3.12.3
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')


### PR DESCRIPTION
When using the Stage level runtime method (#110), cmake should not be included.  cmake is a build tool, so it's not clear why it had a `runtime` method in the first place.