### PR TITLE
Add spec files for building a HPCCM container image

### DIFF
--- a/recipes/hpccm/Dockerfile
+++ b/recipes/hpccm/Dockerfile
@@ -1,0 +1,19 @@
+# 
+# Recipe to bootstrap HPC Container Maker (HPCCM) as a container
+# 
+# Docker:
+# $ sudo docker build -t hpccm -f Dockerfile .
+# $ sudo docker run --rm -v $(pwd):/recipes hpccm --recipe /recipes/...
+# 
+# Singularity:
+# $ sudo singularity build hpccm.simg Singularity.def
+# $ singularity exec hpccm.simg --recipe ...
+# 
+
+FROM python:3-slim
+
+RUN pip install --no-cache-dir hpccm
+
+ENTRYPOINT ["hpccm"]
+
+

--- a/recipes/hpccm/README.md
+++ b/recipes/hpccm/README.md
@@ -1,0 +1,28 @@
+# Running HPC Container Maker from a Container
+
+Please refer to the [Getting Started](/docs/getting_started.md) guide
+for more information on installing HPC Container Maker.
+
+If installing HPCCM on the host is not an option, then the
+files in this directory may be used to build a HPCCM container image.
+The HPCCM recipe used to generate the Dockerfile and Singularity
+definition file is also included.
+
+## Docker
+
+Use the provided Dockerfile to build a HPCCM container image.
+
+```
+$ sudo docker build -t hpccm -f Dockerfile .
+$ sudo docker run -rm -v $(pwd):/recipes hpccm --recipe /recipes/...
+```
+
+## Singularity
+
+Use the provided Singularity definition file to build a HPCCM container
+image.
+
+```
+$ sudo singularity build hpccm.simg Singularity.def
+$ ./hpccm.simg --recipe ...
+```

--- a/recipes/hpccm/Singularity.def
+++ b/recipes/hpccm/Singularity.def
@@ -1,0 +1,22 @@
+# 
+# Recipe to bootstrap HPC Container Maker (HPCCM) as a container
+# 
+# Docker:
+# $ sudo docker build -t hpccm -f Dockerfile .
+# $ sudo docker run --rm -v $(pwd):/recipes hpccm --recipe /recipes/...
+# 
+# Singularity:
+# $ sudo singularity build hpccm.simg Singularity.def
+# $ ./hpccm.simg --recipe ...
+# 
+
+BootStrap: docker
+From: python:3-slim
+
+%post
+    pip install --no-cache-dir hpccm
+
+%runscript
+    exec hpccm $@
+
+

--- a/recipes/hpccm/bootstrap.py
+++ b/recipes/hpccm/bootstrap.py
@@ -1,0 +1,25 @@
+"""
+Recipe for a HPC Container Maker (HPCCM) container image
+
+Docker:
+$ sudo docker build -t hpccm -f Dockerfile .
+$ sudo docker run --rm -v $(pwd):/recipes hpccm --recipe /recipes/...
+
+Singularity:
+$ sudo singularity build hpccm.simg Singularity.def
+$ ./hpccm.simg --recipe ...
+"""
+from hpccm.common import container_type
+
+Stage0 += comment(__doc__, reformat=False)
+
+Stage0 += baseimage(image='python:3-slim', _distro='ubuntu', _docker_env=False)
+
+Stage0 += shell(commands=['pip install --no-cache-dir hpccm'], chdir=False)
+
+if hpccm.config.g_ctype == container_type.DOCKER:
+  # Docker automatically passes through command line arguments
+  Stage0 += runscript(commands=['hpccm'])
+elif hpccm.config.g_ctype == container_type.SINGULARITY:
+  # Singularity does not automatically pass through command line arguments
+  Stage0 += runscript(commands=['hpccm $@'])


### PR DESCRIPTION
Adds a recipe (and generated Dockerfile and Singularity definition file) for HPCCM itself.  I.e., run hpccm from a container.