### PR TITLE
Add option to more easily exclude building block runtimes

### DIFF
--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -88,7 +88,7 @@ True if any layers have been added to the stage, otherwise False
 
 ## runtime
 ```python
-Stage.runtime(self, _from=u'0')
+Stage.runtime(self, _from=u'0', exclude=[])
 ```
 Generate the set of instructions to install the runtime specific
 components from a previous stage.
@@ -97,15 +97,26 @@ This method invokes the runtime() method for every layer in
 the stage.  If a layer does not have a runtime() method, then
 it is skipped.
 
+__Arguments__
+
+
+- ___from__: The name of the stage from which to copy the runtime.
+The default is `0`.
+
+- __exclude__: List of building blocks to exclude when generating
+the runtime. The default is an empty list.
+
 __Examples__
 
 ```python
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
 Stage0 += gnu()
+Stage0 += boost()
 Stage0 += ofed()
 Stage0 += openmpi()
 ...
 Stage1 += baseimage(image='nvidia/cuda:9.0-base')
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(exclude=['boost'])
 ```
+
 

--- a/hpccm/Stage.py
+++ b/hpccm/Stage.py
@@ -115,8 +115,7 @@ class Stage(object):
         instructions = []
         for layer in self.__layers:
             runtime = getattr(layer, 'runtime', None)
-            if (callable(runtime) and
-                runtime.__self__.__class__.__name__ not in exclude):
+            if callable(runtime) and layer.__class__.__name__ not in exclude:
                 instructions.append(layer.runtime(_from=_from))
 
         return self.__separator.join(instructions)

--- a/hpccm/Stage.py
+++ b/hpccm/Stage.py
@@ -83,7 +83,7 @@ class Stage(object):
         """
         return bool(self.__layers)
 
-    def runtime(self, _from='0'):
+    def runtime(self, _from='0', exclude=[]):
         """Generate the set of instructions to install the runtime specific
         components from a previous stage.
 
@@ -91,21 +91,32 @@ class Stage(object):
         the stage.  If a layer does not have a runtime() method, then
         it is skipped.
 
+        # Arguments
+
+        _from: The name of the stage from which to copy the runtime.
+        The default is `0`.
+
+        exclude: List of building blocks to exclude when generating
+        the runtime. The default is an empty list.
+
         # Examples
         ```python
         Stage0 += baseimage(image='nvidia/cuda:9.0-devel')
         Stage0 += gnu()
+        Stage0 += boost()
         Stage0 += ofed()
         Stage0 += openmpi()
         ...
         Stage1 += baseimage(image='nvidia/cuda:9.0-base')
-        Stage1 += Stage0.runtime()
+        Stage1 += Stage0.runtime(exclude=['boost'])
         ```
+
         """
         instructions = []
         for layer in self.__layers:
             runtime = getattr(layer, 'runtime', None)
-            if callable(runtime):
+            if (callable(runtime) and
+                runtime.__self__.__class__.__name__ not in exclude):
                 instructions.append(layer.runtime(_from=_from))
 
         return self.__separator.join(instructions)

--- a/test/test_Stage.py
+++ b/test/test_Stage.py
@@ -24,6 +24,7 @@ import unittest
 
 from helpers import centos, docker
 
+from hpccm.building_blocks import boost
 from hpccm.building_blocks import gnu
 from hpccm.primitives.shell import shell
 from hpccm.Stage import Stage
@@ -73,6 +74,22 @@ class Test_Stage(unittest.TestCase):
         s0 += shell(commands=['gcc -o hello hello.c'])
         s1 = Stage()
         s1 += s0.runtime()
+        self.assertEqual(str(s1),
+r'''# GNU compiler runtime
+RUN yum install -y \
+        libgomp \
+        libgfortran && \
+    rm -rf /var/cache/yum/*''')
+
+    @centos
+    @docker
+    def test_runtime_exclude(self):
+        """Runtime from a previous stage with exclude"""
+        s0 = Stage()
+        s0 += gnu()
+        s0 += boost()
+        s1 = Stage()
+        s1 += s0.runtime(exclude=['boost'])
         self.assertEqual(str(s1),
 r'''# GNU compiler runtime
 RUN yum install -y \


### PR DESCRIPTION
Adds the `exclude` parameter to the `Stage` `runtime` method to make it easier to exclude certain runtimes in a multistage recipe.

The following example would generate a runtime Stage containing the gnu and openmpi runtimes but not the boost runtime.
```
Stage0 += baseimage(...)
Stage0 += gnu()
Stage0 += boost()
Stage0 += openmpi()

Stage1 += baseimage(...)
Stage1 += Stage0.runtime(exclude=['boost'])
```