### PR TITLE
Added gcov alias in gnu() building block.

### DIFF
--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -159,6 +159,7 @@ class gnu(object):
                     self.__commands.append('update-alternatives --install /usr/bin/g++ g++ $(which g++-{}) 30'.format(self.__version))
                 if self.__fortran:
                     self.__commands.append('update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-{}) 30'.format(self.__version))
+                self.__commands.append('update-alternatives --install /usr/bin/gcov gcov $(which gcov-{}) 30'.format(self.__version))
             elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
                 self.__environment = {'PATH': '/opt/rh/devtoolset-{}/root/usr/bin:$PATH'.format(self.__version)}
             else: # pragma: no cover

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -76,7 +76,8 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-7) 30 && \
     update-alternatives --install /usr/bin/g++ g++ $(which g++-7) 30 && \
-    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-7) 30''')
+    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-7) 30 && \
+    update-alternatives --install /usr/bin/gcov gcov $(which gcov-7) 30''')
 
     @centos
     @docker


### PR DESCRIPTION
gcov is a tool which comes with gcc but was not properly aliased (via `update-alternative`).