### PR TITLE
pip: Fix empty self.__packages

### DIFF
--- a/hpccm/building_blocks/pip.py
+++ b/hpccm/building_blocks/pip.py
@@ -106,7 +106,8 @@ class pip(object):
             if self.__upgrade:
                 cmds.append('{0} install --upgrade pip'.format(self.__pip))
 
-            cmds.append('{0} install {1}'.format(self.__pip,
-                                                 ' '.join(self.__packages)))
+            if self.__packages:
+                cmds.append('{0} install {1}'.format(self.__pip,
+                                                     ' '.join(self.__packages)))
             instructions.append(shell(commands=cmds))
         return '\n'.join([str(x) for x in instructions])


### PR DESCRIPTION
When no packages were set (e.g. `pip(pip='pip3', upgrade=True)`) it resulted in the following command which is not a valid pip command:

```bash
pip install
```
