### PR TITLE
ConfigureMake and CMakeBuild consistency

### DIFF
--- a/hpccm/building_blocks/catalyst.py
+++ b/hpccm/building_blocks/catalyst.py
@@ -221,9 +221,6 @@ class catalyst(CMakeBuild, ldconfig, rm, tar, wget):
         # Configure
         # Catalyst has a cmake.sh shell script that sets configuration
         # options.  Use that in place of cmake.
-        if self.prefix:
-            self.cmake_opts.append(
-                '-DCMAKE_INSTALL_PREFIX={}'.format(self.prefix))
         configure = self.configure_step(
             directory=os.path.join(self.__wd, self.__basename),
             opts=self.cmake_opts, toolchain=self.__toolchain)

--- a/hpccm/templates/CMakeBuild.py
+++ b/hpccm/templates/CMakeBuild.py
@@ -33,7 +33,11 @@ class CMakeBuild(object):
         """Documentation TBD"""
 
         #super(ConfigureMake, self).__init__()
+
         self.__build_directory = None
+        self.cmake_opts = kwargs.get('opts', [])
+        self.parallel = kwargs.get('parallel', '$(nproc)')
+        self.prefix = kwargs.get('prefix', '/usr/local')
 
         # Some components complain if some compiler variables are
         # enabled, e.g., MVAPICH2 with F90, so provide a way for the
@@ -43,93 +47,94 @@ class CMakeBuild(object):
                                              'F77': True, 'F90': True,
                                              'FC': True})
 
-    def build_step(self, target='all', parallel='$(nproc)'):
+    def build_step(self, target='all', parallel=None):
         """Documentation TBD"""
+        if not parallel:
+            parallel = self.parallel
         return 'cmake --build {0} --target {1} -- -j{2}'.format(
             self.__build_directory, target, parallel)
 
-    def configure_step(self, directory=None, build_directory='build',
-                       toolchain=None, opts=None):
+    def configure_step(self, build_directory='build', directory=None,
+                       environment=[], opts=None, toolchain=None):
         """Documentation TBD"""
 
-        if not directory:
-            raise ValueError("directory has to be given in CMakeBuild "
-                             "configure_step!")
-        if not os.path.isabs(directory):
-            raise ValueError("directory given in CMakeBuild configure_step"
-                             "has to be an absolute path!")
-
-        if not os.path.isabs(build_directory):
+        change_directory = ''
+        if directory:
+            src_directory = directory
             build_directory = os.path.join(directory, build_directory)
+            change_directory = "mkdir -p {0} && cd {0} && ".format(
+                build_directory)
+        else:
+            # Assume the build directory is a subdirectory of the source
+            # directory and we are already in the build directory
+            src_directory = '..'
 
+        # Cache this for the build step
         self.__build_directory = build_directory
 
-        change_directory = "mkdir -p {0} && cd {0} && ".format(
-            self.__build_directory)
-
-        prefix = []
+        e = []
+        e.extend(environment)
         if toolchain:
             if toolchain.CC and self.toolchain_control.get('CC'):
-                prefix.append('CC={}'.format(toolchain.CC))
+                e.append('CC={}'.format(toolchain.CC))
 
             if toolchain.CFLAGS:
-                prefix.append('CFLAGS={}'.format(shlex_quote(
-                    toolchain.CFLAGS)))
+                e.append('CFLAGS={}'.format(shlex_quote(toolchain.CFLAGS)))
 
             if toolchain.CPPFLAGS:
-                prefix.append('CPPFLAGS={}'.format(shlex_quote(
-                    toolchain.CPPFLAGS)))
+                e.append('CPPFLAGS={}'.format(shlex_quote(toolchain.CPPFLAGS)))
 
             if toolchain.CXX and self.toolchain_control.get('CXX'):
-                prefix.append('CXX={}'.format(toolchain.CXX))
+                e.append('CXX={}'.format(toolchain.CXX))
 
             if toolchain.CXXFLAGS:
-                prefix.append('CXXFLAGS={}'.format(shlex_quote(
+                e.append('CXXFLAGS={}'.format(shlex_quote(
                     toolchain.CXXFLAGS)))
 
             if toolchain.F77 and self.toolchain_control.get('F77'):
-                prefix.append('F77={}'.format(toolchain.F77))
+                e.append('F77={}'.format(toolchain.F77))
 
             if toolchain.F90 and self.toolchain_control.get('F90'):
-                prefix.append('F90={}'.format(toolchain.F90))
+                e.append('F90={}'.format(toolchain.F90))
 
             if toolchain.FC and self.toolchain_control.get('FC'):
-                prefix.append('FC={}'.format(toolchain.FC))
+                e.append('FC={}'.format(toolchain.FC))
 
             if toolchain.FCFLAGS:
-                prefix.append('FCFLAGS={}'.format(shlex_quote(
-                    toolchain.FCFLAGS)))
+                e.append('FCFLAGS={}'.format(shlex_quote(toolchain.FCFLAGS)))
 
             if toolchain.FFLAGS:
-                prefix.append('FFLAGS={}'.format(shlex_quote(
-                    toolchain.FFLAGS)))
+                e.append('FFLAGS={}'.format(shlex_quote(toolchain.FFLAGS)))
 
             if toolchain.FLIBS:
-                prefix.append('FLIBS={}'.format(shlex_quote(
-                    toolchain.FLIBS)))
+                e.append('FLIBS={}'.format(shlex_quote(toolchain.FLIBS)))
 
             if toolchain.LD_LIBRARY_PATH:
-                prefix.append('LD_LIBRARY_PATH={}'.format(shlex_quote(
+                e.append('LD_LIBRARY_PATH={}'.format(shlex_quote(
                     toolchain.LD_LIBRARY_PATH)))
 
             if toolchain.LDFLAGS:
-                prefix.append('LDFLAGS={}'.format(shlex_quote(
-                    toolchain.LDFLAGS)))
+                e.append('LDFLAGS={}'.format(shlex_quote(toolchain.LDFLAGS)))
 
             if toolchain.LIBS:
-                prefix.append('LIBS={}'.format(shlex_quote(
-                    toolchain.LIBS)))
+                e.append('LIBS={}'.format(shlex_quote(toolchain.LIBS)))
 
-        configure_prefix = ' '.join(prefix)
-        if configure_prefix != '':
-            configure_prefix += ' '
+        configure_env = ' '.join(e)
+        if configure_env:
+            configure_env += ' '
         
         configure_opts = ''
+        if not opts and self.cmake_opts:
+            opts = self.cmake_opts
         if opts:
             configure_opts = ' '.join(opts)
             configure_opts += ' '
 
-        cmd = '{0}{1}cmake {2}{3}'.format(
-            change_directory, configure_prefix, configure_opts, directory)
+        if self.prefix:
+            configure_opts = '-DCMAKE_INSTALL_PREFIX={0:s} {1}'.format(
+                self.prefix, configure_opts)
 
-        return cmd.strip()  # trim whitespace
+        cmd = '{0}{1}cmake {2}{3}'.format(
+            change_directory, configure_env, configure_opts, src_directory)
+
+        return cmd.strip() # trim whitespace

--- a/hpccm/templates/ConfigureMake.py
+++ b/hpccm/templates/ConfigureMake.py
@@ -45,15 +45,20 @@ class ConfigureMake(object):
                                              'F77': True, 'F90': True,
                                              'FC': True})
 
-    def build_step(self):
+    def build_step(self, parallel=None):
         """Documentation TBD"""
-        return 'make -j{}'.format(self.parallel)
+        if not parallel:
+            parallel = self.parallel
+        return 'make -j{}'.format(parallel)
 
-    def check_step(self):
+    def check_step(self, parallel=None):
         """Documentation TBD"""
-        return 'make -j{} check'.format(self.parallel)
+        if not parallel:
+            parallel = self.parallel
+        return 'make -j{} check'.format(parallel)
 
-    def configure_step(self, directory=None, environment=[], toolchain=None):
+    def configure_step(self, directory=None, environment=[], opts=[],
+                       toolchain=None):
         """Documentation TBD"""
 
         change_directory = ''
@@ -116,15 +121,20 @@ class ConfigureMake(object):
 
         configure_env = ' '.join(e)
 
-        opts = ' '.join(self.configure_opts)
+        if not opts and self.configure_opts:
+            opts = self.configure_opts
+        configure_opts = ' '.join(opts)
         if self.prefix:
-            opts = '--prefix={0:s} {1}'.format(self.prefix, opts)
+            configure_opts = '--prefix={0:s} {1}'.format(self.prefix,
+                                                         configure_opts)
 
         cmd = '{0} {1} ./configure {2}'.format(change_directory,
-                                               configure_env, opts)
+                                               configure_env, configure_opts)
 
         return cmd.strip() # trim whitespace
 
-    def install_step(self):
+    def install_step(self, parallel=None):
         """Documentation TBD"""
-        return 'make -j{} install'.format(self.parallel)
+        if not parallel:
+            parallel = self.parallel
+        return 'make -j{} install'.format(parallel)

--- a/test/test_ConfigureMake.py
+++ b/test/test_ConfigureMake.py
@@ -77,6 +77,11 @@ class Test_ConfigureMake(unittest.TestCase):
         """Parallel count specified"""
         cm = ConfigureMake(parallel=7)
 
+        # Function arguments override constructor
+        build = cm.build_step(parallel=11)
+        self.assertEqual(build, 'make -j11')
+
+        # Use constructor arguments
         build = cm.build_step()
         self.assertEqual(build, 'make -j7')
 
@@ -91,5 +96,10 @@ class Test_ConfigureMake(unittest.TestCase):
         """Configure options specified"""
         cm = ConfigureMake(opts=['--with-foo', '--without-bar'])
 
+        # Function arguments override constructor
+        configure = cm.configure_step(opts=['--without-foo', '--with-bar'])
+        self.assertEqual(configure, './configure --prefix=/usr/local --without-foo --with-bar')
+
+        # Use constructor arguments
         configure = cm.configure_step()
         self.assertEqual(configure, './configure --prefix=/usr/local --with-foo --without-bar')


### PR DESCRIPTION
@IlyaKuksenok pointed out that the the ConfigureMake and CMakeBuild templates are inconsistent.  E.g.,

```
cm = ConfigureMake(opts=[...])
shell(commands=[cm.configure_step(), ...])

cmb = CMakeBuild()
shell(commands=[cmb.configure_step(opts=[...]), ...])
```

Arguably, the `ConfigureMake` style is more "natural" when inheriting in a building block, while the `CMakeBuild` style is more "natural" when writing an application recipe.  Regardless, the approaches should be consistent.

For both builder templates, this PR provides 2 ways to specify options, via the constructor or as function arguments.  The function arguments have precedence.

@bilke, does this look okay to you?