### PR TITLE
Add building block base class

### DIFF
--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -26,14 +26,14 @@ from hpccm.building_blocks.gnu import gnu
 from hpccm.building_blocks.hdf5 import hdf5
 from hpccm.building_blocks.intel_mpi import intel_mpi
 from hpccm.building_blocks.intel_psxe import intel_psxe
-from hpccm.building_blocks.llvm import llvm
 from hpccm.building_blocks.knem import knem
 from hpccm.building_blocks.kokkos import kokkos
+from hpccm.building_blocks.llvm import llvm
 from hpccm.building_blocks.mkl import mkl
 from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
 from hpccm.building_blocks.mpich import mpich
-from hpccm.building_blocks.mvapich2 import mvapich2
 from hpccm.building_blocks.mvapich2_gdr import mvapich2_gdr
+from hpccm.building_blocks.mvapich2 import mvapich2
 from hpccm.building_blocks.netcdf import netcdf
 from hpccm.building_blocks.ofed import ofed
 from hpccm.building_blocks.openblas import openblas

--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -24,10 +24,11 @@ import logging # pylint: disable=unused-import
 
 import hpccm.config
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.common import linux_distro
 from hpccm.primitives.shell import shell
 
-class apt_get(object):
+class apt_get(bb_base):
     """The `apt_get` building block specifies the set of operating system
     packages to install.  This building block should only be used on
     images that use the Debian package manager (e.g., Ubuntu).
@@ -58,7 +59,7 @@ class apt_get(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
-        #super(apt_get, self).__init__()
+        super(apt_get, self).__init__()
 
         self.__commands = []
         self.__keys = kwargs.get('keys', [])
@@ -73,9 +74,12 @@ class apt_get(object):
         # block
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        return str(shell(chdir=False, commands=self.__commands))
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+        self += shell(chdir=False, commands=self.__commands)
 
     def __setup(self):
         """Construct the series of commands to execute"""

--- a/hpccm/building_blocks/base.py
+++ b/hpccm/building_blocks/base.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Building block base class"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+import hpccm.base_object
+
+class bb_base(hpccm.base_object):
+    """Base class for building blocks."""
+
+    def __init__(self, **kwargs):
+        """Initialize building block base class"""
+
+        super(bb_base, self).__init__(**kwargs)
+
+        self.__instructions = []
+
+    def __iadd__(self, instruction):
+        """Add the instruction to the list of instructions.  Allows "+="
+        syntax."""
+
+        if isinstance(instruction, list):
+            self.__instructions.extend(instruction)
+        else:
+            self.__instructions.append(instruction)
+        return self
+
+    def __getitem__(self, key):
+        """Return the specified element from the list of instructions"""
+        return self.__instructions[key]
+
+    def __len__(self):
+        """Return the size of the list of instructions"""
+        return len(self.__instructions)
+
+    def __str__(self):
+        """String representation of the building block"""
+        return '\n'.join(str(x) for x in self.__instructions)

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -31,6 +31,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -38,8 +39,8 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class boost(hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
-            hpccm.templates.wget):
+class boost(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
+            hpccm.templates.tar, hpccm.templates.wget):
     """The `boost` building block downloads and installs the
     [Boost](https://www.boost.org) component.
 
@@ -115,18 +116,17 @@ class boost(hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'Boost version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Boost version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/catalyst.py
+++ b/hpccm/building_blocks/catalyst.py
@@ -32,6 +32,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -40,7 +41,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class catalyst(hpccm.templates.CMakeBuild, hpccm.templates.ldconfig,
+class catalyst(bb_base, hpccm.templates.CMakeBuild, hpccm.templates.ldconfig,
                hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `catalyst` building block configures, builds, and installs the
     [ParaView Catalyst](https://www.paraview.org/in-situ/) component.
@@ -144,19 +145,17 @@ class catalyst(hpccm.templates.CMakeBuild, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'ParaView Catalyst version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('ParaView Catalyst version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/cgns.py
+++ b/hpccm/building_blocks/cgns.py
@@ -32,6 +32,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -39,7 +40,7 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class cgns(hpccm.templates.ConfigureMake, hpccm.templates.rm,
+class cgns(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.rm,
            hpccm.templates.tar, hpccm.templates.wget):
     """The `cgns` building block downloads and installs the
     [CGNS](https://cgns.github.io/index.html) component.
@@ -103,16 +104,15 @@ class cgns(hpccm.templates.ConfigureMake, hpccm.templates.rm,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'CGNS version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
 
-        return '\n'.join(str(x) for x in instructions)
+        self += comment('CGNS version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/charm.py
+++ b/hpccm/building_blocks/charm.py
@@ -30,14 +30,15 @@ import hpccm.templates.sed
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class charm(hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.sed,
-            hpccm.templates.tar, hpccm.templates.wget):
+class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
+            hpccm.templates.sed, hpccm.templates.tar, hpccm.templates.wget):
     """The `charm` building block downloads and install the
     [Charm++](http://charm.cs.illinois.edu/research/charm) component.
 
@@ -115,18 +116,17 @@ class charm(hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.sed,
         # Construct series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(
-            comment('Charm++ version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
-        if self.__environment_variables:
-            instructions.append(
-                environment(variables=self.__environment_variables))
+        # Fill in container instructions
+        self.__instructions()
 
-        return '\n'.join(str(x) for x in instructions)
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Charm++ version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
+        if self.__environment_variables:
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -28,11 +28,12 @@ import re
 import hpccm.templates.rm
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.shell import shell
 
-class cmake(hpccm.templates.rm, hpccm.templates.wget):
+class cmake(bb_base, hpccm.templates.rm, hpccm.templates.wget):
     """The `cmake` building block downloads and installs the
     [CMake](https://cmake.org) component.
 
@@ -83,15 +84,15 @@ class cmake(hpccm.templates.rm, hpccm.templates.wget):
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(comment(
-            'CMake version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+        # Fill in container instructions
+        self.__instructions()
 
-        return '\n'.join(str(x) for x in instructions)
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('CMake version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -30,6 +30,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
@@ -37,7 +38,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class fftw(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class fftw(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
            hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `fftw` building block downloads, configures, builds, and
     installs the [FFTW](http://www.fftw.org) component.  Depending on
@@ -127,27 +128,25 @@ class fftw(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
         if self.__directory:
-            instructions.append(comment('FFTW'))
+            self += comment('FFTW')
         else:
-            instructions.append(
-                comment('FFTW version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
+            self += comment('FFTW version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
         if self.__directory:
             # Use source from local build context
-            instructions.append(
-                copy(src=self.__directory,
-                     dest=os.path.join(self.__wd,
-                                       self.__directory)))
-        instructions.append(shell(commands=self.__commands))
+            self += copy(src=self.__directory,
+                         dest=os.path.join(self.__wd,
+                                           self.__directory))
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(
-                environment(variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -29,13 +29,14 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class gdrcopy(hpccm.templates.ldconfig, hpccm.templates.rm,
+class gdrcopy(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
               hpccm.templates.tar, hpccm.templates.wget):
     """The `gdrcopy` building block builds and installs the user space
     library from the [gdrcopy](https://github.com/NVIDIA/gdrcopy)
@@ -88,19 +89,17 @@ class gdrcopy(hpccm.templates.ldconfig, hpccm.templates.rm,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'GDRCOPY version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('GDRCOPY version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(
-                environment(variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -32,6 +32,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -40,7 +41,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class hdf5(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
            hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `hdf5` building block downloads, configures, builds, and
     installs the [HDF5](http://www.hdfgroup.org) component.  Depending
@@ -136,30 +137,27 @@ class hdf5(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
+    def __instructions(self):
+        """Fill in container instructions"""
+
         if self.__directory:
-            instructions.append(comment('HDF5'))
+            self += comment('HDF5')
         else:
-            instructions.append(comment(
-                'HDF5 version {}'.format(self.__version)))
+            self += comment('HDF5 version {}'.format(self.__version))
 
-        instructions.append(packages(ospackages=self.__ospackages))
+        self += packages(ospackages=self.__ospackages)
 
         if self.__directory:
             # Use source from local build context
-            instructions.append(
-                copy(src=self.__directory,
-                     dest=os.path.join(self.__wd, self.__directory)))
+            self += copy(src=self.__directory,
+                         dest=os.path.join(self.__wd, self.__directory))
 
-        instructions.append(shell(commands=self.__commands))
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -29,6 +29,7 @@ import hpccm.templates.rm
 import hpccm.templates.sed
 import hpccm.templates.tar
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
@@ -36,7 +37,8 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class intel_psxe(hpccm.templates.rm, hpccm.templates.sed, hpccm.templates.tar):
+class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
+                 hpccm.templates.tar):
     """The `intel_psxe` building block installs [Intel Parallel Studio
     XE](https://software.intel.com/en-us/parallel-studio-xe).
 
@@ -120,23 +122,22 @@ class intel_psxe(hpccm.templates.rm, hpccm.templates.sed, hpccm.templates.tar):
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(comment('Intel Parallel Studio XE'))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(copy(src=self.__tarball,
-                                 dest=os.path.join(self.__wd, self.__tarball)))
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Intel Parallel Studio XE')
+        self += packages(ospackages=self.__ospackages)
+        self += copy(src=self.__tarball,
+                     dest=os.path.join(self.__wd, self.__tarball))
         if self.__license and not '@' in self.__license:
             # License file
-            instructions.append(
-                copy(src=self.__license,
-                     dest=os.path.join(self.__wd, 'license.lic')))
-        instructions.append(shell(commands=self.__commands))
-        instructions.append(
-            environment(variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += copy(src=self.__license,
+                         dest=os.path.join(self.__wd, 'license.lic'))
+        self += shell(commands=self.__commands)
+        self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/knem.py
+++ b/hpccm/building_blocks/knem.py
@@ -30,6 +30,7 @@ import hpccm.config
 import hpccm.templates.git
 import hpccm.templates.rm
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -37,7 +38,7 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class knem(hpccm.templates.git, hpccm.templates.rm):
+class knem(bb_base, hpccm.templates.git, hpccm.templates.rm):
     """The `knem` building block install the headers from the
     [KNEM](http://knem.gforge.inria.fr) component.
 
@@ -81,18 +82,16 @@ class knem(hpccm.templates.git, hpccm.templates.rm):
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'KNEM version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
-        instructions.append(
-            environment(variables=self.__environment_variables))
+    def __instructions(self):
+        """Fill in container instructions"""
 
-        return '\n'.join(str(x) for x in instructions)
+        self += comment('KNEM version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
+        self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/kokkos.py
+++ b/hpccm/building_blocks/kokkos.py
@@ -31,6 +31,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -38,7 +39,8 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class kokkos(hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
+class kokkos(bb_base, hpccm.templates.rm, hpccm.templates.tar,
+             hpccm.templates.wget):
     """The `kokkos` building block downloads and installs the
     [Kokkos](https://github.com/kokkos/kokkos) component.
 
@@ -111,18 +113,17 @@ class kokkos(hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'Kokkos version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Kokkos version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -33,6 +33,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -41,7 +42,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class mpich(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `mpich` building block configures, builds, and installs the
     [MPICH](https://www.mpich.org) component.
@@ -128,19 +129,17 @@ class mpich(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'MPICH version {}'.format(self.version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('MPICH version {}'.format(self.version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/mvapich2_gdr.py
+++ b/hpccm/building_blocks/mvapich2_gdr.py
@@ -30,6 +30,7 @@ import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -38,7 +39,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class mvapich2_gdr(hpccm.templates.ldconfig, hpccm.templates.rm,
+class mvapich2_gdr(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
                    hpccm.templates.wget):
     """The `mvapich2_gdr` building blocks installs the
     [MVAPICH2-GDR](http://mvapich.cse.ohio-state.edu) component.
@@ -168,18 +169,16 @@ class mvapich2_gdr(hpccm.templates.ldconfig, hpccm.templates.rm,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'MVAPICH2-GDR version {}'.format(self.version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
-        instructions.append(environment(
-            variables=self.__environment_variables))
+    def __instructions(self):
+        """Fill in container instructions"""
 
-        return '\n'.join(str(x) for x in instructions)
+        self += comment('MVAPICH2-GDR version {}'.format(self.version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
+        self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -32,6 +32,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -40,7 +41,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class netcdf(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
              hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `netcdf` building block downloads, configures, builds, and
     installs the
@@ -151,28 +152,26 @@ class netcdf(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             self.__setup_optional(pkg='netcdf-fortran',
                                   version=self.__version_fortran)
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
+    def __instructions(self):
+        """Fill in container instructions"""
 
         comments = ['NetCDF version {}'.format(self.__version)]
         if self.__cxx:
             comments.append('NetCDF C++ version {}'.format(self.__version_cxx))
         if self.__fortran:
             comments.append('NetCDF Fortran version {}'.format(self.__version_fortran))
-        instructions.append(comment(', '.join(comments)))
+        self += comment(', '.join(comments))
 
         if self.__ospackages:
-            instructions.append(packages(ospackages=self.__ospackages))
+            self += packages(ospackages=self.__ospackages)
 
-        instructions.append(shell(commands=self.__commands))
+        self += shell(commands=self.__commands)
 
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -25,11 +25,12 @@ import logging # pylint: disable=unused-import
 
 import hpccm.config
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
 
-class ofed(object):
+class ofed(bb_base):
     """The `ofed` building block installs the OpenFabrics Enterprise
     Distribution packages that are part of the Linux distribution.
 
@@ -67,6 +68,8 @@ class ofed(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
+        super(ofed, self).__init__(**kwargs)
+
         if (hpccm.config.g_linux_distro == linux_distro.UBUNTU and
             hpccm.config.g_linux_version >= StrictVersion('18.0')):
             self.__ospackages_deb = ['dapl2-utils', 'ibutils', 'ibverbs-utils',
@@ -92,13 +95,13 @@ class ofed(object):
                                  'librdmacm', 'opensm', 'rdma-core',
                                  'rdma-core-devel']
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(comment('OFED'))
-        instructions.append(packages(apt=self.__ospackages_deb,
-                                     yum=self.__ospackages_rpm))
-        return '\n'.join(str(x) for x in instructions)
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+        self += comment('OFED')
+        self += packages(apt=self.__ospackages_deb, yum=self.__ospackages_rpm)
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -29,6 +29,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
@@ -36,7 +37,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class openblas(hpccm.templates.ldconfig, hpccm.templates.rm,
+class openblas(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
                hpccm.templates.tar, hpccm.templates.wget):
     """The `openblas` building block builds and installs the
     [OpenBLAS](https://www.openblas.net) component.
@@ -96,18 +97,17 @@ class openblas(hpccm.templates.ldconfig, hpccm.templates.rm,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'OpenBLAS version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('OpenBLAS version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -33,6 +33,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -41,7 +42,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class openmpi(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
               hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `openmpi` building block configures, builds, and installs the
     [OpenMPI](https://www.open-mpi.org) component.  Depending on the
@@ -169,27 +170,24 @@ class openmpi(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
+    def __instructions(self):
+        """Fill in container instructions"""
+
         if self.directory:
-            instructions.append(comment('OpenMPI'))
+            self += comment('OpenMPI')
         else:
-            instructions.append(comment(
-                'OpenMPI version {}'.format(self.version)))
-        instructions.append(packages(ospackages=self.__ospackages))
+            self += comment('OpenMPI version {}'.format(self.version))
+        self += packages(ospackages=self.__ospackages)
         if self.directory:
             # Use source from local build context
-            instructions.append(
-                copy(src=self.directory,
-                     dest=os.path.join(self.__wd, self.directory)))
-        instructions.append(shell(commands=self.__commands))
+            self += copy(src=self.directory,
+                         dest=os.path.join(self.__wd, self.directory))
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -25,10 +25,11 @@ import logging # pylint: disable=unused-import
 import hpccm.config
 
 from hpccm.building_blocks.apt_get import apt_get
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.yum import yum
 from hpccm.common import linux_distro
 
-class packages(object):
+class packages(bb_base):
     """The `packages` building block specifies the set of operating system
     packages to install.  Based on the Linux distribution, the
     building block invokes either `apt-get` (Ubuntu) or `yum`
@@ -93,7 +94,7 @@ class packages(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
-        #super(packages, self).__init__()
+        super(packages, self).__init__()
 
         self.__apt = kwargs.get('apt', [])
         self.__apt_keys = kwargs.get('apt_keys', [])
@@ -106,26 +107,29 @@ class packages(object):
         self.__yum_keys = kwargs.get('yum_keys', [])
         self.__yum_repositories = kwargs.get('yum_repositories', [])
 
-    def __str__(self):
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
         """String representation of the building block"""
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if self.__apt:
-                return str(apt_get(keys=self.__apt_keys, ospackages=self.__apt,
-                                   ppas=self.__apt_ppas,
-                                   repositories=self.__apt_repositories))
+                self += apt_get(keys=self.__apt_keys, ospackages=self.__apt,
+                                ppas=self.__apt_ppas,
+                                repositories=self.__apt_repositories)
             else:
-                return str(apt_get(keys=self.__apt_keys,
-                                   ospackages=self.__ospackages,
-                                   ppas=self.__apt_ppas,
-                                   repositories=self.__apt_repositories))
+                self += apt_get(keys=self.__apt_keys,
+                                ospackages=self.__ospackages,
+                                ppas=self.__apt_ppas,
+                                repositories=self.__apt_repositories)
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if self.__yum:
-                return str(yum(epel=self.__epel, keys=self.__yum_keys,
-                               ospackages=self.__yum, scl=self.__scl,
-                               repositories=self.__yum_repositories))
+                self += yum(epel=self.__epel, keys=self.__yum_keys,
+                            ospackages=self.__yum, scl=self.__scl,
+                            repositories=self.__yum_repositories)
             else:
-                return str(yum(epel=self.__epel, keys=self.__yum_keys,
-                               ospackages=self.__ospackages, scl=self.__scl,
-                               repositories=self.__yum_repositories))
+                self += yum(epel=self.__epel, keys=self.__yum_keys,
+                            ospackages=self.__ospackages, scl=self.__scl,
+                            repositories=self.__yum_repositories)
         else:
             raise RuntimeError('Unknown Linux distribution')

--- a/hpccm/building_blocks/pip.py
+++ b/hpccm/building_blocks/pip.py
@@ -23,11 +23,12 @@ from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.shell import shell
 
-class pip(object):
+class pip(bb_base):
     """The `pip` building block installs Python packages from PyPi.
 
     # Parameters
@@ -64,6 +65,8 @@ class pip(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
+        super(pip, self).__init__(**kwargs)
+
         self.__epel = False
         self.__ospackages = kwargs.get('ospackages', None)
         self.__packages = kwargs.get('packages', [])
@@ -88,13 +91,16 @@ class pip(object):
             self.__debs = self.__ospackages
             self.__rpms = self.__ospackages
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(comment('pip'))
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('pip')
         if self.__debs or self.__rpms:
-            instructions.append(packages(apt=self.__debs, epel=self.__epel,
-                                         yum=self.__rpms))
+            self += packages(apt=self.__debs, epel=self.__epel,
+                             yum=self.__rpms)
 
         if self.__pip:
             cmds = []
@@ -105,5 +111,4 @@ class pip(object):
             if self.__packages:
                 cmds.append('{0} install {1}'.format(self.__pip,
                                                      ' '.join(self.__packages)))
-            instructions.append(shell(commands=cmds))
-        return '\n'.join([str(x) for x in instructions])
+            self += shell(commands=cmds)

--- a/hpccm/building_blocks/pnetcdf.py
+++ b/hpccm/building_blocks/pnetcdf.py
@@ -30,6 +30,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
@@ -37,7 +38,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class pnetcdf(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
               hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `pnetcdf` building block downloads, configures, builds, and
     installs the
@@ -112,19 +113,17 @@ class pnetcdf(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'PnetCDF version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('PnetCDF version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/python.py
+++ b/hpccm/building_blocks/python.py
@@ -23,10 +23,11 @@ from __future__ import print_function
 
 import logging # pylint: disable=unused-import
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 
-class python(object):
+class python(bb_base):
     """The `python` building block installs Python from the upstream Linux
     distribution.
 
@@ -56,6 +57,8 @@ class python(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
+        super(python, self).__init__(**kwargs)
+
         self.__devel = kwargs.get('devel', False)
         self.__epel = False
         self.__python2 = kwargs.get('python2', True)
@@ -79,13 +82,14 @@ class python(object):
                 self.__debs.append('libpython3-dev')
                 self.__rpms.append('python34-devel')  # EPEL package
 
-    def __str__(self):
-        """String representation of the building block"""
-        instructions = []
-        instructions.append(comment('Python'))
-        instructions.append(packages(apt=self.__debs, epel=self.__epel,
-                                     yum=self.__rpms))
-        return '\n'.join([str(x) for x in instructions])
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Python')
+        self += packages(apt=self.__debs, epel=self.__epel, yum=self.__rpms)
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -33,6 +33,7 @@ import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
@@ -41,7 +42,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class ucx(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
           hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `ucx` building block configures, builds, and installs the
     [UCX](https://github.com/openucx/ucx) component.
@@ -163,19 +164,17 @@ class ucx(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'UCX version {}'.format(self.__version)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('UCX version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(
-                environment(variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/xpmem.py
+++ b/hpccm/building_blocks/xpmem.py
@@ -30,6 +30,7 @@ import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
@@ -37,7 +38,7 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class xpmem(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
+class xpmem(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             hpccm.templates.git, hpccm.templates.rm, hpccm.templates.tar):
     """The `xpmem` building block builds and installs the user space
     library from the [XPMEM](https://gitlab.com/hjelmn/xpmem)
@@ -106,19 +107,17 @@ class xpmem(hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # Construct the series of steps to execute
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
+        # Fill in container instructions
+        self.__instructions()
 
-        instructions = []
-        instructions.append(comment(
-            'XPMEM branch {}'.format(self.__branch)))
-        instructions.append(packages(ospackages=self.__ospackages))
-        instructions.append(shell(commands=self.__commands))
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('XPMEM branch {}'.format(self.__branch))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
         if self.__environment_variables:
-            instructions.append(
-                environment(variables=self.__environment_variables))
-
-        return '\n'.join(str(x) for x in instructions)
+            self += environment(variables=self.__environment_variables)
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -24,10 +24,11 @@ import logging # pylint: disable=unused-import
 
 import hpccm.config
 
+from hpccm.building_blocks.base import bb_base
 from hpccm.common import linux_distro
 from hpccm.primitives.shell import shell
 
-class yum(object):
+class yum(bb_base):
     """The `yum` building block specifies the set of operating system
     packages to install.  This building block should only be used on
     images that use the Red Hat package manager (e.g., CentOS).
@@ -62,7 +63,7 @@ class yum(object):
     def __init__(self, **kwargs):
         """Initialize building block"""
 
-        #super(yum, self).__init__()
+        super(yum, self).__init__()
 
         self.__commands = []
         self.__epel = kwargs.get('epel', False)
@@ -78,9 +79,12 @@ class yum(object):
         # block
         self.__setup()
 
-    def __str__(self):
-        """String representation of the building block"""
-        return str(shell(chdir=False, commands=self.__commands))
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+        self += shell(chdir=False, commands=self.__commands)
 
     def __setup(self):
         """Construct the series of commands to execute"""

--- a/test/test_bb_base.py
+++ b/test/test_bb_base.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the building block base class"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.primitives import shell
+
+class Test_bb_base(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @ubuntu
+    @docker
+    def test_defaults(self):
+        """Default building block base class"""
+        b = bb_base()
+        self.assertEqual(str(b), '')
+
+    @ubuntu
+    @docker
+    def test_instruction_manipulations(self):
+        """Instruction manipulations"""
+        b = bb_base()
+
+        # Append instructions
+        b += shell(commands=['echo a'])
+        # Append directly to "private" class variable (not recommended)
+        b._bb_base__instructions.append(shell(commands=['echo b']))
+        self.assertEqual(len(b), 2)
+        self.assertEqual(str(b), 'RUN echo a\nRUN echo b')
+
+        # Direct element access
+        self.assertEqual(str(b[0]), 'RUN echo a')
+        self.assertEqual(str(b[1]), 'RUN echo b')
+
+        # Iterators
+        i = iter(b)
+        self.assertEqual(str(next(i)), 'RUN echo a')
+        self.assertEqual(str(next(i)), 'RUN echo b')
+
+        # Insertion, using "private" class variable (not recommended)
+        b._bb_base__instructions.insert(0, shell(commands=['echo c']))
+        self.assertEqual(len(b), 3)
+        self.assertEqual(str(b), 'RUN echo c\nRUN echo a\nRUN echo b')
+
+        # Deletion (not allowed)
+        with self.assertRaises(TypeError):
+            del(b[1])
+
+        # Deletion via "private" class variable (not recommended)
+        del(b._bb_base__instructions[1])
+        self.assertEqual(len(b), 2)
+        self.assertEqual(str(b), 'RUN echo c\nRUN echo b')

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -35,9 +35,8 @@ class Test_intel_mpi(unittest.TestCase):
     @docker
     def test_defaults(self):
         """Default intel_mpi building block, no eula agreement"""
-        impi = intel_mpi()
         with self.assertRaises(RuntimeError):
-            str(impi)
+            intel_mpi()
 
     @ubuntu
     @docker

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -35,9 +35,8 @@ class Test_mkl(unittest.TestCase):
     @docker
     def test_defaults(self):
         """Default mkl building block, no eula agreement"""
-        m = mkl()
         with self.assertRaises(RuntimeError):
-            str(m)
+            mkl()
 
     @ubuntu
     @docker

--- a/test/test_packages.py
+++ b/test/test_packages.py
@@ -59,6 +59,5 @@ r'''RUN yum install -y \
     @invalid_distro
     def test_invalid_distro(self):
         """Invalid package type specified"""
-        p = packages(ospackages=['gcc', 'g++', 'gfortran'])
         with self.assertRaises(RuntimeError):
-            str(p)
+            packages(ospackages=['gcc', 'g++', 'gfortran'])


### PR DESCRIPTION
This is an internals enhancement that creates a building block base class.  All building blocks have been updated to inherit from the new base class.  The base class centralizes the method to convert a building block into a string, so `__str__` methods have been removed from each individual building block.

Besides removing lots of redundant code, this also turns building blocks from strings into a list of primitive objects.  This would allow potential optimizations such as merging sections to reduce the number of layers or work around Singularity builder bugs / limitations.

It also makes some concepts and syntax more consistent.

It is now possible to create a pseudo building block in a recipe (note that the building block `+=` syntax is analogous to the Stage syntax):

```
Stage0 += baseimage(image='centos:7')

from hpccm.building_blocks.base import bb_base
bb = bb_base()

bb += comment('My component')
bb += packages(ospackages=['make', 'wget'])
bb += shell(commands=['wget', 'tar', 'make', 'rm'])
bb += environment(variables={'PATH': '/usr/local/foo:$PATH'})

Stage0 += bb
```

You can also "monkey patch" building blocks:

```
g = gnu()
g += shell(commands=['additional_configuration'])
Stage0 += g
```