### PR TITLE
Adds __tarball_name to intel_psxe

### DIFF
--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -108,6 +108,7 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         self.__ospackages = kwargs.get('ospackages', ['cpio'])
         self.__prefix = kwargs.get('prefix', '/opt/intel')
         self.__tarball = kwargs.get('tarball', None)
+        self.__tarball_name = os.path.basename(self.__tarball)
         self.__wd = '/var/tmp' # working directory
 
         self.toolchain = toolchain(CC='icc', CXX='icpc', F77='ifort',
@@ -131,7 +132,7 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         self += comment('Intel Parallel Studio XE')
         self += packages(ospackages=self.__ospackages)
         self += copy(src=self.__tarball,
-                     dest=os.path.join(self.__wd, self.__tarball))
+                     dest=os.path.join(self.__wd, self.__tarball_name))
         if self.__license and not '@' in self.__license:
             # License file
             self += copy(src=self.__license,
@@ -150,11 +151,11 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         # Get the name of the directory that created when the tarball
         # is extracted.  Assume it is the same as the basename of the
         # tarball.
-        basedir = os.path.splitext(self.__tarball)[0]
+        basedir = os.path.splitext(self.__tarball_name)[0]
 
         # Untar
         self.__commands.append(self.untar_step(
-            tarball=os.path.join(self.__wd, self.__tarball),
+            tarball=os.path.join(self.__wd, self.__tarball_name),
             directory=(self.__wd)))
 
         # Configure silent install
@@ -201,7 +202,7 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
 
         # Cleanup runfile
         self.__commands.append(self.cleanup_step(
-            items=[os.path.join(self.__wd, self.__tarball),
+            items=[os.path.join(self.__wd, self.__tarball_name),
                    os.path.join(self.__wd, basedir)]))
 
     def runtime(self, _from='0'):

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -108,7 +108,6 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         self.__ospackages = kwargs.get('ospackages', ['cpio'])
         self.__prefix = kwargs.get('prefix', '/opt/intel')
         self.__tarball = kwargs.get('tarball', None)
-        self.__tarball_name = os.path.basename(self.__tarball)
         self.__wd = '/var/tmp' # working directory
 
         self.toolchain = toolchain(CC='icc', CXX='icpc', F77='ifort',
@@ -151,6 +150,7 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         # Get the name of the directory that created when the tarball
         # is extracted.  Assume it is the same as the basename of the
         # tarball.
+        self.__tarball_name = os.path.basename(self.__tarball)
         basedir = os.path.splitext(self.__tarball_name)[0]
 
         # Untar


### PR DESCRIPTION
This extracts the name of the tarball, without leading directories.
This allows the BB to be used with a tarball that isn't in the root of the build context.
Without this, the tarball is extracted to {__wd}/parallel-$VER but the BB thinks it is at {__wd}/parent_dir/parallel-$VER and the sed step fails.