### PR TITLE
Add SCI-F building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1971,6 +1971,63 @@ Stage0 += p
 Stage1 += p.runtime()
 ```
 
+# scif
+```python
+scif(self, **kwargs)
+```
+The `scif` building blocks installs components using the
+[Scientific Filesystem (SCI-F)](https://sci-f.github.io).
+
+Other building blocks and / or primitives should be added to
+the `scif` building block using the `+=` syntax.
+
+If not generating a Singularity definition file, SCI-F should be
+installed using the [`pip`](#pip) building block prior to this
+building block.
+
+If not generating a Singularity definition file, this module
+creates SCI-F recipe files in the current directory (see also the
+`file` parameter).
+
+__Parameters__
+
+
+- __file__: The SCI-F recipe file name.  The default value is the name
+parameter with the `.scif` suffix.
+
+- __name__: The name to use to label the SCI-F application.  This
+parameter is required.
+
+- ___native__: Boolean flag to specify whether to use the native
+Singularity support for SCI-F when generating Singularity
+definition files.  The default is True (Singularity specific).
+
+__Examples__
+
+
+```python
+pip(packages=['scif'])
+s = scif(name='example')
+s += openmpi(prefix='/scif/apps/example')
+s += shell(commands=[...])
+```
+
+
+## runtime
+```python
+scif.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+```python
+s = scif(...)
+Stage0 += s
+Stage1 += s.runtime()
+```
+
 # ucx
 ```python
 ucx(self, **kwargs)

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2020,6 +2020,9 @@ scif.runtime(self, _from=u'0')
 Generate the set of instructions to install the runtime specific
 components from a build in a previous stage.
 
+The entire `/scif` directory is copied into the runtime stage
+on the first call.  Subsequent calls do nothing.
+
 __Examples__
 
 ```python
@@ -2027,6 +2030,7 @@ s = scif(...)
 Stage0 += s
 Stage1 += s.runtime()
 ```
+
 
 # ucx
 ```python

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -250,6 +250,11 @@ when the container starts.
 __Parameters__
 
 
+- ___args__: Boolean flag to specify whether `"$@"` should be appended
+to the command.  If more than one command is specified, nothing is
+appended regardless of the value of this flag.  The default is
+True (Singularity specific).
+
 - ___app__: String containing the [SCI-F](https://www.sylabs.io/guides/2.6/user-guide/reproducible_scif_apps.html)
 identifier.  This also causes the Singularity block to named `%apprun`
 rather than `%runscript` (Singularity specific).

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -76,6 +76,11 @@ place in the container specification file.
 __Parameters__
 
 
+- ___app__: String containing the
+- __[SCI-F](https__://www.sylabs.io/guides/2.6/user-guide/reproducible_scif_apps.html)
+identifier.  This also causes the comment to be enclosed in a
+Singularity block to named `%apphelp` (Singularity specific).
+
 - __reformat__: Boolean flag to specify whether the comment string
 should be wrapped to fit into lines not exceeding 80 characters.
 The default is True.
@@ -86,6 +91,7 @@ __Examples__
 ```python
 comment('libfoo version X.Y')
 ```
+
 
 # copy
 ```python
@@ -102,6 +108,10 @@ identifier.  This also causes the Singularity block to named
 `%appfiles` rather than `%files` (Singularity specific).
 
 - __dest__: Path in the container image to copy the file(s)
+
+- __files__: A dictionary of file pairs, source and destination, to copy
+into the container image.  If specified, has precedence over
+`dest` and `src`.
 
 - ___from__: Set the source location to a previous build stage rather
 than the host filesystem (Docker specific).
@@ -130,6 +140,10 @@ copy(src='component', dest='/opt/component')
 
 ```python
 copy(src=['a', 'b', 'c'], dest='/tmp')
+```
+
+```python
+copy(files={'a': '/tmp/a', 'b': '/opt/b'})
 ```
 
 
@@ -243,6 +257,10 @@ rather than `%runscript` (Singularity specific).
 - __commands__: A list of commands to execute.  The default is an empty
 list.
 
+- ___exec__: Boolean flag to specify whether `exec` should be inserted
+to preface the final command.  The default is True (Singularity
+specific).
+
 __Examples__
 
 
@@ -282,6 +300,10 @@ True.
 
 - __commands__: A list of commands to execute.  The default is an empty
 list.
+
+- ___test__: Boolean flag to specify whether to use `%test` instead of
+`%post` and `%apptest` instead of `%appinstall` as the Singularity
+section headings (Singularity specific).
 
 __Examples__
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -4,6 +4,7 @@
 - [MPI Bandwidth](#mpi-bandwidth)
 - [User Arguments](#user-arguments)
 - [Multi-stage Recipes](#multi-stage-recipes)
+- [Scientific Filesystem (SCI-F)](#scientific-filesystem)
 
 ## Reproducing a bare metal environment
 
@@ -445,3 +446,168 @@ $ sudo docker run -t --rm --cap-add SYS_ADMIN -v /var/run/docker.sock:/var/run/d
 Singularity container built: /tmp/milc_multi-stage-2018-12-03-c2b47902c8a8.simg
 ...
 ```
+
+# Scientific Filesystem (SCI-F)
+
+The Scientific Filesystem (SCI-F) provides internal modularity of
+containers.  For example, a single container may need to include
+multiple builds of an application workload, each tuned for a
+particular hardware configuration, for the widest possible deployment.
+
+The `scif` building block provides an interface to SCI-F that is
+syntactically similar to Stages.  Other building blocks or primitives
+can be added to the SCI-F recipe using the `+=` syntax.
+
+To help understand where it can be useful to include multiple
+application binaries in the same container, consider the GPU [compute
+capability](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capabilities).
+The compute capability of a GPU specifies its available features.  A
+GPU cannot run code compiled for a higher compute capability, yet many
+optimizations and other advanced features are only available with
+higher compute capabilities.  Generally speaking, a GPU can run code
+built with an lower compute capability, but that would mean not being
+able to take advantage of some capabilities on more recent GPUs.
+
+One approach to resolve this tension is to build multiple versions of
+the binary, each for a specific compute capability, and choose the
+best version based on the available hardware when running the
+container.  (Better approaches are to build a single "fat" binary or
+to use PTX to enable just-in-time compilation, but some application
+build systems may not support those techniques.)
+
+The [CUDA-STREAM](https://github.com/bcumming/cuda-stream) benchmark
+will be used to illustrate how to use SCI-F with HPCCM.
+
+The following [recipe](/recipes/examples/scif.py) builds CUDA-STREAM
+for 3 different CUDA compute capabilities.
+
+```python
+Stage0 += baseimage(image='nvidia/cuda:9.1-devel-centos7')
+
+# Install the GNU compiler
+Stage0 += gnu(fortran=False)
+
+# Install SCI-F
+Stage0 += pip(packages=['scif'])
+
+# Download a single copy of the source code
+Stage0 += packages(ospackages=['ca-certificates', 'git'])
+Stage0 += shell(commands=['cd /var/tmp',
+                          'git clone --depth=1 https://github.com/bcumming/cuda-stream.git cuda-stream'])
+
+# Build CUDA-STREAM as a SCI-F application for each CUDA compute capability
+for cc in ['35', '60', '70']:
+  binpath = '/scif/apps/cc{}/bin'.format(cc)
+
+  stream = scif(name='cc{}'.format(cc))
+  stream += comment('CUDA-STREAM built for CUDA compute capability {}'.format(cc))
+  stream += shell(commands=['nvcc -std=c++11 -ccbin=g++ -gencode arch=compute_{0},code=\\"sm_{0},compute_{0}\\" -o {1}/stream /var/tmp/cuda-stream/stream.cu'.format(cc, binpath)])
+  stream += environment(variables={'PATH': '{}:$PATH'.format(binpath)})
+  stream += label(metadata={'COMPUTE_CAPABILITY': cc})
+  stream += runscript(commands=['stream'])
+
+  Stage0 += stream
+```
+
+When generating a Dockerfile for this recipe, HPCCM will also create 3
+SCI-F recipe files in the current directory.
+
+```
+$ hpccm --recipe scif.py --format docker > Dockerfile
+$ sudo docker build -t cuda-stream -f Dockerfile .
+```
+
+The CUDA-STREAM binary can be selected by specifying the SCI-F
+application, e.g.:
+
+```
+$ sudo nvidia-docker run --rm -it cuda-stream scif apps
+      cc35
+      cc60
+      cc70
+$ sudo nvidia-docker run --rm -it cuda-stream scif run cc60
+[cc60] executing /bin/bash /scif/apps/cc60/scif/runscript
+ STREAM Benchmark implementation in CUDA
+ Array size (double precision) = 536.87 MB
+ using 192 threads per block, 349526 blocks
+ output in IEC units (KiB = 1024 B)
+
+Function      Rate (GiB/s)  Avg time(s)  Min time(s)  Max time(s)
+-----------------------------------------------------------------
+Copy:         500.6928      0.00200073   0.00199723   0.00200891
+Scale:        501.2314      0.00200056   0.00199509   0.00200891
+Add:          514.9334      0.00291573   0.00291300   0.00291705
+Triad:        517.2619      0.00290324   0.00289989   0.00290990
+```
+
+Singularity has native support for SCI-F.  It is not necessary to
+install the `scif` PyPi package in this case, but is also okay to do
+so.
+
+```
+$ hpccm --recipe scif.py --format singularity > Singularity.def
+$ sudo singularity build cuda-stream.simg Singularity.def
+```
+
+The SCI-F application can be selected by using the `--app` command
+line option.
+
+```
+$ singularity apps cuda-stream.simg
+cc35
+cc60
+cc70
+$ singularity run --nv --app cc60 cuda-stream.simg
+ STREAM Benchmark implementation in CUDA
+ ...
+```
+
+The HPCCM `scif` module is not limited to applications.  Building
+blocks may also be installed inside SCI-F applications.  The following
+installs two versions of OpenMPI inside the container, one built with
+InfiniBand verbs and the other with UCX, and for each builds the MPI
+Bandwidth program.
+
+```python
+# CentOS base image
+Stage0 += baseimage(image='nvidia/cuda:9.1-devel-centos7')
+
+# GNU compilers
+Stage0 += gnu(fortran=False)
+
+# Mellanox OFED
+Stage0 += mlnx_ofed()
+
+# SCI-F
+Stage0 += pip(packages=['scif'])
+
+# Download MPI Bandwidth source code
+Stage0 += shell(commands=[
+    'wget --user-agent "" -q -nc --no-check-certificate -P /var/tmp https://computing.llnl.gov/tutorials/mpi/samples/C/mpi_bandwidth.c'])
+
+# OpenMPI 3.1 w/ InfiniBand verbs
+ompi31 = scif(name='ompi-3.1-ibverbs')
+ompi31 += comment('MPI Bandwidth built with OpenMPI 3.1 using InfiniBand verbs')
+ompi31 += openmpi(infiniband=True, prefix='/scif/apps/ompi-3.1-ibverbs',
+                  ucx=False, version='3.1.3')
+ompi31 += shell(commands=['cd /scif/apps/ompi-3.1-ibverbs/bin',
+                          './mpicc -o mpi_bandwidth /var/tmp/mpi_bandwidth.c'])
+Stage0 += ompi31
+
+# OpenMPI 4.0 w/ UCX
+ompi40 = scif(name='ompi-4.0-ucx')
+ompi40 += comment('MPI Bandwidth built with OpenMPI 4.0 using UCX')
+ompi40 += gdrcopy()
+ompi40 += knem()
+ompi40 += xpmem()
+ompi40 += ucx(knem='/usr/local/knem')
+ompi40 += openmpi(infiniband=False, prefix='/scif/apps/ompi-4.0-ucx',
+                  ucx='/usr/local/ucx', version='4.0.0')
+ompi40 += shell(commands=['cd /scif/apps/ompi-4.0-ucx/bin',
+                          './mpicc -o mpi_bandwidth /var/tmp/mpi_bandwidth.c'])
+Stage0 += ompi40
+```
+
+A more sophisticated container might include an entry point that
+detects the hardware configuration and automatically uses the most
+appropriate SCI-F application environment.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -449,10 +449,11 @@ Singularity container built: /tmp/milc_multi-stage-2018-12-03-c2b47902c8a8.simg
 
 # Scientific Filesystem (SCI-F)
 
-The Scientific Filesystem (SCI-F) provides internal modularity of
-containers.  For example, a single container may need to include
-multiple builds of an application workload, each tuned for a
-particular hardware configuration, for the widest possible deployment.
+The [Scientific Filesystem (SCI-F)](https://sci-f.github.io) provides
+internal modularity of containers.  For example, a single container
+may need to include multiple builds of an application workload, each
+tuned for a particular hardware configuration, for the widest possible
+deployment.
 
 The `scif` building block provides an interface to SCI-F that is
 syntactically similar to Stages.  Other building blocks or primitives

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -563,6 +563,16 @@ $ singularity run --nv --app cc60 cuda-stream.simg
  ...
 ```
 
+If the `scif` PyPi package is installed (optional for Singularity),
+then the `scif` program may also be used for equivalent functionality.
+
+```
+$ singularity run cuda-stream.simg scif apps
+...
+$ singularity run --nv cuda-stream.simg scif run cc60
+...
+```
+
 The HPCCM `scif` module is not limited to applications.  Building
 blocks may also be installed inside SCI-F applications.  The following
 installs two versions of OpenMPI inside the container, one built with

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -43,6 +43,7 @@ from hpccm.building_blocks.pgi import pgi
 from hpccm.building_blocks.pip import pip
 from hpccm.building_blocks.pnetcdf import pnetcdf
 from hpccm.building_blocks.python import python
+from hpccm.building_blocks.scif import scif
 from hpccm.building_blocks.ucx import ucx
 from hpccm.building_blocks.xpmem import xpmem
 from hpccm.building_blocks.yum import yum

--- a/hpccm/building_blocks/scif.py
+++ b/hpccm/building_blocks/scif.py
@@ -169,7 +169,7 @@ class scif(hpccm.base_object):
         else:
             # Shell one liner to run a command if specified,
             # otherwise start a shell
-            recipe.append(runscript(commands=['eval "if [[ $# -eq 0 ]]; then exec /bin/bash; else exec $@; fi"'], _app=self.__name, _exec=False))
+            recipe.append(runscript(commands=['eval "if [[ $# -eq 0 ]]; then exec /bin/bash; else exec $@; fi"'], _args=False, _app=self.__name, _exec=False))
 
         if self.__apptest:
             apptest = self.__apptest[0].merge(self.__apptest,

--- a/hpccm/building_blocks/scif.py
+++ b/hpccm/building_blocks/scif.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""SCI-F building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+
+import hpccm.base_object
+import hpccm.config
+
+from hpccm.common import container_type
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.runscript import runscript
+from hpccm.primitives.shell import shell
+
+class scif(hpccm.base_object):
+    """The `scif` building blocks installs components using the
+    [Scientific Filesystem (SCI-F)](https://sci-f.github.io).
+
+    Other building blocks and / or primitives should be added to
+    the `scif` building block using the `+=` syntax.
+
+    If not generating a Singularity definition file, SCI-F should be
+    installed using the [`pip`](#pip) building block prior to this
+    building block.
+
+    If not generating a Singularity definition file, this module
+    creates SCI-F recipe files in the current directory (see also the
+    `file` parameter).
+
+    # Parameters
+
+    file: The SCI-F recipe file name.  The default value is the name
+    parameter with the `.scif` suffix.
+
+    name: The name to use to label the SCI-F application.  This
+    parameter is required.
+
+    _native: Boolean flag to specify whether to use the native
+    Singularity support for SCI-F when generating Singularity
+    definition files.  The default is True (Singularity specific).
+
+    # Examples
+
+    ```python
+    pip(packages=['scif'])
+    s = scif(name='example')
+    s += openmpi(prefix='/scif/apps/example')
+    s += shell(commands=[...])
+    ```
+
+    """
+
+    __runtime_called = False
+
+    def __init__(self, **kwargs):
+        """Initialize scif building block"""
+
+        super(scif, self).__init__(**kwargs)
+
+        self.__appenv = []
+        self.__appfiles = []
+        self.__apphelp = []
+        self.__appinstall = []
+        self.__applabels = []
+        self.__apprun = []
+        self.__apptest = []
+        self.__name = kwargs.get('name', None)
+        if not self.__name:
+            raise RuntimeError('"name" must be defined')
+        self.__native = kwargs.get('_native', True)
+        self.__scif_file = kwargs.get('file', '{}.scif'.format(self.__name))
+
+    def __iadd__(self, item):
+        """Add the item to the corresponding type list.  Allows "+=" syntax."""
+        if isinstance(item, list):
+            for i in item:
+                self.__add(i)
+        else:
+            self.__add(item)
+        return self
+
+    def __add(self, item):
+        """Break the item down into its constituent primitives and append each
+        primitive to the appropriate list"""
+
+        primitives = self.__primitives(item)
+        for p in primitives:
+            ptype = p.__class__.__name__
+            if ptype == 'comment':
+                self.__apphelp.append(p)
+            elif ptype == 'copy':
+                self.__appfiles.append(p)
+            elif ptype == 'environment':
+                self.__appenv.append(p)
+            elif ptype == 'label':
+                self.__applabels.append(p)
+            elif ptype == 'runscript':
+                self.__apprun.append(p)
+            elif ptype == 'shell':
+                if p._test:
+                    self.__apptest.append(p)
+                else:
+                    self.__appinstall.append(p)
+            else:
+                raise RuntimeError('unrecognized primitive type: {}'.format(ptype))
+
+    def __scif_recipe(self):
+        """Generate the SCI-F recipe instructions, merging primitives of the
+        same type because SCI-F does not support duplicate
+        sections."""
+
+        recipe = []
+
+        if self.__appenv:
+            appenv = self.__appenv[0].merge(self.__appenv,
+                                            _app=self.__name)
+            recipe.append(appenv)
+
+        if self.__appfiles:
+            appfiles = self.__appfiles[0].merge(self.__appfiles,
+                                                _app=self.__name)
+            recipe.append(appfiles)
+
+        if self.__apphelp:
+            apphelp = self.__apphelp[0].merge(self.__apphelp,
+                                              _app=self.__name)
+            recipe.append(apphelp)
+
+        if self.__appinstall:
+            _appenv = False
+            if hpccm.config.g_ctype == container_type.SINGULARITY:
+                # If the container type is Singularity, load the
+                # general container environment
+                _appenv = True
+            appinstall = self.__appinstall[0].merge(self.__appinstall,
+                                                    _app=self.__name,
+                                                    _appenv=_appenv)
+            recipe.append(appinstall)
+
+        if self.__applabels:
+            applabels = self.__applabels[0].merge(self.__applabels,
+                                                  _app=self.__name)
+            recipe.append(applabels)
+
+        if self.__apprun:
+            apprun = self.__apprun[0].merge(self.__apprun,
+                                            _app=self.__name)
+            recipe.append(apprun)
+        else:
+            # Shell one liner to run a command if specified,
+            # otherwise start a shell
+            recipe.append(runscript(commands=['eval "if [[ $# -eq 0 ]]; then exec /bin/bash; else exec $@; fi"'], _app=self.__name, _exec=False))
+
+        if self.__apptest:
+            apptest = self.__apptest[0].merge(self.__apptest,
+                                              _app=self.__name, _test=True)
+            recipe.append(apptest)
+
+        return recipe
+
+    def __primitives(self, item):
+        """Item is a building block or a primitive.  A building block consists
+        of one or more other building blocks or primitives.
+        Ultimately, every building block consists of primitives.
+
+        "Flatten" the item to a list of its constituent primitives.
+
+        """
+        return [i for i in self.__iter_flatten(item)]
+
+    def __iter_flatten(self, iterable):
+        """Recursively flatten"""
+        try:
+            for i in iter(iterable):
+                for f in self.__iter_flatten(i):
+                    yield f
+        except:
+            # not iterable
+            yield iterable
+
+    def __str__(self):
+        """String representation of the building block"""
+
+        scif_recipe = self.__scif_recipe()
+
+        if (self.__native and
+            hpccm.config.g_ctype == container_type.SINGULARITY):
+            # Take advantage of Singularity's native support for SCI-F.
+            return '\n'.join(str(x) for x in scif_recipe)
+        else:
+            # Generate an external SCI-F recipe file and manually call scif
+
+            # Temporarily switch container format to Singularity to write
+            # the SCI-F recipe file
+            preserved_ctype = hpccm.config.g_ctype
+            hpccm.config.set_container_format('singularity')
+
+            logging.info('Writing {}'.format(self.__scif_file))
+            with open(self.__scif_file, 'w') as f:
+                f.write('\n\n'.join(str(x) for x in scif_recipe))
+
+            # Restore original container format
+            hpccm.config.g_ctype = preserved_ctype
+
+            # Container instructions to copy the SCI-F recipe file
+            # into the container and then run scif
+            c_scif_file = os.path.join('/scif/recipes',
+                                       os.path.basename(self.__scif_file))
+            instructions = []
+            instructions.append(comment('SCI-F "{}"'.format(self.__name)))
+            instructions.append(
+                copy(src=self.__scif_file, dest=c_scif_file))
+            instructions.append(
+                shell(chdir=False,
+                      commands=['scif install {}'.format(c_scif_file)]))
+
+            return '\n'.join(str(x) for x in instructions)
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+        ```python
+        s = scif(...)
+        Stage0 += s
+        Stage1 += s.runtime()
+        ```
+        """
+
+        if not scif.__runtime_called:
+            scif.__runtime_called = True
+            return str(copy(_from=_from, src='/scif', dest='/scif'))
+        else:
+            return ''

--- a/hpccm/building_blocks/scif.py
+++ b/hpccm/building_blocks/scif.py
@@ -240,12 +240,16 @@ class scif(hpccm.base_object):
         """Generate the set of instructions to install the runtime specific
         components from a build in a previous stage.
 
+        The entire `/scif` directory is copied into the runtime stage
+        on the first call.  Subsequent calls do nothing.
+
         # Examples
         ```python
         s = scif(...)
         Stage0 += s
         Stage1 += s.runtime()
         ```
+
         """
 
         if not scif.__runtime_called:

--- a/hpccm/primitives/environment.py
+++ b/hpccm/primitives/environment.py
@@ -119,3 +119,23 @@ class environment(object):
                 raise RuntimeError('Unknown container type')
         else:
             return ''
+
+    def merge(self, lst, _app=None):
+        """Merge one or more instances of the primitive into a single
+        instance.  Due to conflicts or option differences the merged
+        primitive may not be exact merger.
+
+        """
+
+        if not lst: # pragma: nocover
+            raise RuntimeError('no items provided to merge')
+
+        envs = {}
+        for item in lst:
+            if not item.__class__.__name__ == 'environment': # pragma: nocover
+                logging.warning('item is not the correct type, skipping...')
+                continue
+
+            envs.update(item._environment__variables)
+
+        return environment(variables=envs, _app=_app)

--- a/hpccm/primitives/label.py
+++ b/hpccm/primitives/label.py
@@ -94,3 +94,23 @@ class label(object):
                 raise RuntimeError('Unknown container type')
         else:
             return ''
+
+    def merge(self, lst, _app=None):
+        """Merge one or more instances of the primitive into a single
+        instance.  Due to conflicts or option differences the merged
+        primitive may not be exact.
+
+        """
+
+        if not lst: # pragma: nocover
+            raise RuntimeError('no items provided to merge')
+
+        labels = {}
+        for item in lst:
+            if not item.__class__.__name__ == 'label': # pragma: nocover
+                logging.warning('item is not the correct type, skipping...')
+                continue
+
+            labels.update(item._label__metadata)
+
+        return label(metadata=labels, _app=_app)

--- a/hpccm/primitives/runscript.py
+++ b/hpccm/primitives/runscript.py
@@ -34,6 +34,11 @@ class runscript(object):
 
     # Parameters
 
+    _args: Boolean flag to specify whether `"$@"` should be appended
+    to the command.  If more than one command is specified, nothing is
+    appended regardless of the value of this flag.  The default is
+    True (Singularity specific).
+
     _app: String containing the [SCI-F](https://www.sylabs.io/guides/2.6/user-guide/reproducible_scif_apps.html)
     identifier.  This also causes the Singularity block to named `%apprun`
     rather than `%runscript` (Singularity specific).
@@ -62,6 +67,7 @@ class runscript(object):
 
         #super(wget, self).__init__()
 
+        self._args = kwargs.get('_args', True) # Singularity specific
         self._app = kwargs.get('_app', '') # Singularity specific
         self._exec = kwargs.get('_exec', True) # Singularity specific
         self.commands = kwargs.get('commands', [])
@@ -90,6 +96,9 @@ class runscript(object):
                 if self._exec:
                     # prepend last command with exec
                     self.commands[-1] = 'exec {0}'.format(self.commands[-1])
+                if len(self.commands) == 1 and self._args:
+                    # append "$@" to singleton command
+                    self.commands[0] = '{} "$@"'.format(self.commands[0])
                 # Format:
                 # %runscript
                 #     cmd1

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -74,6 +74,7 @@ from hpccm.building_blocks.pgi import pgi
 from hpccm.building_blocks.pip import pip
 from hpccm.building_blocks.pnetcdf import pnetcdf
 from hpccm.building_blocks.python import python
+from hpccm.building_blocks.scif import scif
 from hpccm.building_blocks.ucx import ucx
 from hpccm.building_blocks.xpmem import xpmem
 from hpccm.building_blocks.yum import yum

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -33,21 +33,22 @@ generate:
   - hpccm.building_blocks.pip+
   - hpccm.building_blocks.pnetcdf+
   - hpccm.building_blocks.python+
+  - hpccm.building_blocks.scif+
   - hpccm.building_blocks.ucx+
   - hpccm.building_blocks.xpmem+
   - hpccm.building_blocks.yum+
 - primitives.md:
-  - hpccm.primitives.baseimage+
-  - hpccm.primitives.blob+
-  - hpccm.primitives.comment+
-  - hpccm.primitives.copy+
-  - hpccm.primitives.environment+
-  - hpccm.primitives.label+
-  - hpccm.primitives.raw+
-  - hpccm.primitives.runscript+
-  - hpccm.primitives.shell+
-  - hpccm.primitives.user+
-  - hpccm.primitives.workdir+
+  - hpccm.primitives.baseimage
+  - hpccm.primitives.blob
+  - hpccm.primitives.comment
+  - hpccm.primitives.copy
+  - hpccm.primitives.environment
+  - hpccm.primitives.label
+  - hpccm.primitives.raw
+  - hpccm.primitives.runscript
+  - hpccm.primitives.shell
+  - hpccm.primitives.user
+  - hpccm.primitives.workdir
 - misc_api.md:
   - hpccm.config+
   - hpccm.recipe+

--- a/recipes/examples/scif.py
+++ b/recipes/examples/scif.py
@@ -1,0 +1,40 @@
+"""
+Build the CUDA-STREAM benchmark for multiple CUDA compute capabilities.
+
+Make each build available as a SCI-F application.
+"""
+Stage0 += baseimage(image='nvidia/cuda:9.1-devel-centos7')
+
+# Install the GNU compiler
+Stage0 += gnu(fortran=False)
+
+# Install SCI-F
+Stage0 += pip(packages=['scif'])
+
+# Download a single copy of the source code
+Stage0 += packages(ospackages=['ca-certificates', 'git'])
+Stage0 += shell(commands=['cd /var/tmp',
+                          'git clone --depth=1 https://github.com/bcumming/cuda-stream.git cuda-stream'])
+
+# Build CUDA-STREAM as a SCI-F application for each CUDA compute capability
+for cc in ['35', '60', '70']:
+  binpath = '/scif/apps/cc{}/bin'.format(cc)
+
+  stream = scif(name='cc{}'.format(cc))
+  stream += comment('CUDA-STREAM built for CUDA compute capability {}'.format(cc))
+  stream += shell(commands=['nvcc -std=c++11 -ccbin=g++ -gencode arch=compute_{0},code=\\"sm_{0},compute_{0}\\" -o {1}/stream /var/tmp/cuda-stream/stream.cu'.format(cc, binpath)])
+  stream += environment(variables={'PATH': '{}:$PATH'.format(binpath)})
+  stream += label(metadata={'COMPUTE_CAPABILITY': cc})
+  stream += shell(commands=['stream'], _test=True)
+  stream += runscript(commands=['stream'])
+
+  Stage0 += stream
+
+# Runtime stage
+Stage1 += baseimage(image='nvidia/cuda:9.1-base-centos7')
+
+# Install SCI-F
+Stage1 += pip(packages=['scif'])
+
+# Install runtime components from the first stage
+Stage1 += Stage0.runtime()

--- a/test/test_comment.py
+++ b/test/test_comment.py
@@ -73,3 +73,24 @@ class Test_comment(unittest.TestCase):
         """Comment wrapping"""
         c = comment('foo\nbar')
         self.assertEqual(str(c), '# foo bar')
+
+    @docker
+    def test_merge_docker(self):
+        """Comment merge"""
+        c = []
+        c.append(comment('a'))
+        c.append(comment('b'))
+        merged = c[0].merge(c)
+        self.assertEqual(str(merged), '# a\n# b')
+
+    @singularity
+    def test_merge_singularity(self):
+        """Comment merge"""
+        c = []
+        c.append(comment('a'))
+        c.append(comment('b'))
+        merged = c[0].merge(c)
+        self.assertEqual(str(merged), '# a\n# b')
+
+        apphelp = c[0].merge(c, _app='foo')
+        self.assertEqual(str(apphelp), '%apphelp foo\na\nb')

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -110,3 +110,51 @@ class Test_environment(unittest.TestCase):
 '''ENV ONE=1 \\
     THREE=3 \\
     TWO=2''')
+
+    @docker
+    def test_merge_docker(self):
+        """merge primitives"""
+        e = []
+        e.append(environment(variables={'ONE': 1, 'TWO': 2}))
+        e.append(environment(variables={'THREE': 3}))
+        merged = e[0].merge(e)
+        self.assertEqual(str(merged),
+'''ENV ONE=1 \\
+    THREE=3 \\
+    TWO=2''')
+
+        e.append(environment(variables={'ONE': 'uno'}))
+        key_overwrite = e[0].merge(e)
+        self.assertEqual(str(key_overwrite),
+'''ENV ONE=uno \\
+    THREE=3 \\
+    TWO=2''')
+
+    @singularity
+    def test_merge_singularity(self):
+        """merge primitives"""
+        e = []
+        e.append(environment(variables={'ONE': 1, 'TWO': 2}))
+        e.append(environment(variables={'THREE': 3}))
+        merged = e[0].merge(e)
+        self.assertEqual(str(merged),
+'''%environment
+    export ONE=1
+    export THREE=3
+    export TWO=2
+%post
+    export ONE=1
+    export THREE=3
+    export TWO=2''')
+
+        e.append(environment(variables={'ONE': 'uno'}))
+        key_overwrite = e[0].merge(e)
+        self.assertEqual(str(key_overwrite),
+'''%environment
+    export ONE=uno
+    export THREE=3
+    export TWO=2
+%post
+    export ONE=uno
+    export THREE=3
+    export TWO=2''')

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -93,3 +93,43 @@ class Test_label(unittest.TestCase):
 '''LABEL ONE=1 \\
     THREE=3 \\
     TWO=2''')
+
+    @docker
+    def test_merge_docker(self):
+        """merge primitives"""
+        l = []
+        l.append(label(metadata={'ONE': 1, 'TWO': 2}))
+        l.append(label(metadata={'THREE': 3}))
+        merged = l[0].merge(l)
+        self.assertEqual(str(merged),
+'''LABEL ONE=1 \\
+    THREE=3 \\
+    TWO=2''')
+
+        l.append(label(metadata={'ONE': 'uno'}))
+        key_overwrite = l[0].merge(l)
+        self.assertEqual(str(key_overwrite),
+'''LABEL ONE=uno \\
+    THREE=3 \\
+    TWO=2''')
+
+    @singularity
+    def test_merge_singularity(self):
+        """merge primitives"""
+        l = []
+        l.append(label(metadata={'ONE': 1, 'TWO': 2}))
+        l.append(label(metadata={'THREE': 3}))
+        merged = l[0].merge(l)
+        self.assertEqual(str(merged),
+'''%labels
+    ONE 1
+    THREE 3
+    TWO 2''')
+
+        l.append(label(metadata={'ONE': 'uno'}))
+        key_overwrite = l[0].merge(l)
+        self.assertEqual(str(key_overwrite),
+'''%labels
+    ONE uno
+    THREE 3
+    TWO 2''')

--- a/test/test_runscript.py
+++ b/test/test_runscript.py
@@ -56,7 +56,7 @@ class Test_runscript(unittest.TestCase):
         """Single command specified"""
         cmd = ['z']
         s = runscript(commands=cmd)
-        self.assertEqual(str(s), '%runscript\n    exec z')
+        self.assertEqual(str(s), '%runscript\n    exec z "$@"')
 
     @docker
     def test_multiple_docker(self):

--- a/test/test_runscript.py
+++ b/test/test_runscript.py
@@ -86,3 +86,27 @@ class Test_runscript(unittest.TestCase):
         s = runscript(commands=cmds, _app='foo')
         self.assertEqual(str(s), 'ENTRYPOINT ["a"]')
 
+    @singularity
+    def test_multiple_noexec_singularity(self):
+        """exec option"""
+        cmds = ['a', 'b', 'c']
+        s = runscript(commands=cmds, _exec=False)
+        self.assertEqual(str(s), '%runscript\n    a\n    b\n    c')
+
+    @docker
+    def test_merge_docker(self):
+        """merge primitives"""
+        r = []
+        r.append(runscript(commands=['a', 'b']))
+        r.append(runscript(commands=['c']))
+        merged = r[0].merge(r)
+        self.assertEqual(str(merged), 'ENTRYPOINT ["a"]')
+
+    @singularity
+    def test_merge_singularity(self):
+        """merge primitives"""
+        r = []
+        r.append(runscript(commands=['a', 'b']))
+        r.append(runscript(commands=['c']))
+        merged = r[0].merge(r)
+        self.assertEqual(str(merged), '%runscript\n    a\n    b\n    exec c')

--- a/test/test_scif.py
+++ b/test/test_scif.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the scif module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import os
+import tempfile
+import unittest
+
+from helpers import centos, docker, singularity
+
+from hpccm.building_blocks.python import python
+from hpccm.building_blocks.scif import scif
+
+from hpccm.primitives.copy import copy
+from hpccm.primitives.comment import comment
+from hpccm.primitives.environment import environment
+from hpccm.primitives.label import label
+from hpccm.primitives.runscript import runscript
+from hpccm.primitives.shell import shell
+
+class Test_scif(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @docker
+    def test_noname_docker(self):
+        """Default scif building block, no name"""
+        with self.assertRaises(RuntimeError):
+            scif()
+
+    @docker
+    def test_defaults_docker(self):
+        """Default scif building block"""
+        # The scif module generates a SCI-F recipe file.  Use a
+        # temporary file location for it rather than polluting the
+        # test environment.  This is slightly unrealistic since the
+        # Docker build wold fail since the file is outside the Docker
+        # build environment, but go with it.
+        scif_file = tempfile.NamedTemporaryFile(delete=False, suffix='.scif')
+        s = scif(name='foo', file=scif_file.name)
+        self.assertEqual(str(s),
+r'''# SCI-F "foo"
+COPY {0} /scif/recipes/{1}
+RUN scif install /scif/recipes/{1}'''.format(scif_file.name,
+                                             os.path.basename(scif_file.name)))
+        os.unlink(scif_file.name)
+
+    @singularity
+    def test_defaults_singularity(self):
+        """Default scif building block"""
+        s = scif(name='foo')
+        self.assertEqual(str(s), '%apprun foo\n    eval "if [[ $# -eq 0 ]]; then exec /bin/bash; else exec $@; fi"')
+
+    @singularity
+    def test_allsections_singularity(self):
+        """One of each SCI-f section type"""
+        s = scif(name='foo')
+        s += copy(src='file', dest='/tmp/file')
+        s += comment('My app')
+        s += environment(variables={'ONE': '1'})
+        s += label(metadata={'A': 'B'})
+        s += runscript(commands=['default_program'])
+        s += shell(commands=['build_cmds'])
+        s += shell(commands=['test_program'], _test=True)
+        self.assertEqual(str(s), 
+r'''%appenv foo
+    export ONE=1
+%appfiles foo
+    file /tmp/file
+%apphelp foo
+My app
+%appinstall foo
+    for f in /.singularity.d/env/*; do . $f; done
+    build_cmds
+%applabels foo
+    A B
+%apprun foo
+    exec default_program
+%apptest foo
+    test_program''')
+
+    @docker
+    def test_allsections_docker(self):
+        """One of each SCI-f section type"""
+        # See comment in the test_defaults_docker test case
+        scif_file = tempfile.NamedTemporaryFile(delete=False, suffix='.scif')
+        s = scif(name='foo', file=scif_file.name)
+        s += copy(src='file', dest='/tmp/file')
+        s += comment('My app')
+        s += environment(variables={'ONE': '1'})
+        s += label(metadata={'A': 'B'})
+        s += runscript(commands=['default_program'])
+        s += shell(commands=['build_cmds'])
+        s += shell(commands=['test_program'], _test=True)
+
+        str(s) # Force writing the SCI-F recipe file
+
+        # slurp file content
+        with open(scif_file.name) as f:
+            content = f.read()
+        os.unlink(scif_file.name)
+        
+        self.assertEqual(content,
+r'''%appenv foo
+    export ONE=1
+
+%appfiles foo
+    file /tmp/file
+
+%apphelp foo
+My app
+
+%appinstall foo
+    build_cmds
+
+%applabels foo
+    A B
+
+%apprun foo
+    exec default_program
+
+%apptest foo
+    test_program''')
+
+    @centos
+    @singularity
+    def test_building_block_singularity(self):
+        """test building block"""
+        s = scif(name='foo')
+        s += [python()] # list not required, but tests a code branch
+        self.assertEqual(str(s),
+r'''%apphelp foo
+Python
+%appinstall foo
+    for f in /.singularity.d/env/*; do . $f; done
+    yum install -y epel-release
+    yum install -y \
+        python \
+        python34
+    rm -rf /var/cache/yum/*
+%apprun foo
+    eval "if [[ $# -eq 0 ]]; then exec /bin/bash; else exec $@; fi"''')
+
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        s = scif(name='foo')
+        r = s.runtime()
+        self.assertEqual(r, 'COPY --from=0 /scif /scif')

--- a/test/test_scif.py
+++ b/test/test_scif.py
@@ -53,7 +53,7 @@ class Test_scif(unittest.TestCase):
         # The scif module generates a SCI-F recipe file.  Use a
         # temporary file location for it rather than polluting the
         # test environment.  This is slightly unrealistic since the
-        # Docker build wold fail since the file is outside the Docker
+        # Docker build would fail since the file is outside the Docker
         # build environment, but go with it.
         scif_file = tempfile.NamedTemporaryFile(delete=False, suffix='.scif')
         s = scif(name='foo', file=scif_file.name)

--- a/test/test_scif.py
+++ b/test/test_scif.py
@@ -94,7 +94,7 @@ My app
 %applabels foo
     A B
 %apprun foo
-    exec default_program
+    exec default_program "$@"
 %apptest foo
     test_program''')
 
@@ -136,7 +136,7 @@ My app
     A B
 
 %apprun foo
-    exec default_program
+    exec default_program "$@"
 
 %apptest foo
     test_program''')

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -108,3 +108,33 @@ class Test_shell(unittest.TestCase):
         self.assertEqual(str(s), '%appinstall foo\n'
             '    for f in /.singularity.d/env/*; do . $f; done\n'
             '    a\n    b\n    c')
+
+    @singularity
+    def test_test_singularity(self):
+        """test option"""
+        cmds = ['a', 'b', 'c']
+        s = shell(commands=cmds, chdir=False, _test=True)
+        self.assertEqual(str(s), '%test\n    a\n    b\n    c')
+
+    @singularity
+    def test_apptest_singularity(self):
+        """test option"""
+        cmds = ['a', 'b', 'c']
+        s = shell(commands=cmds, _app='foo', chdir=False, _test=True)
+        self.assertEqual(str(s), '%apptest foo\n    a\n    b\n    c')
+
+    @docker
+    def test_merge_docker(self):
+        s = []
+        s.append(shell(commands=['a', 'b']))
+        s.append(shell(commands=['c']))
+        merged = s[0].merge(s)
+        self.assertEqual(str(merged), 'RUN a && \\\n    b && \\\n    c')
+
+    @singularity
+    def test_merge_singularity(self):
+        s = []
+        s.append(shell(commands=['a', 'b']))
+        s.append(shell(commands=['c']))
+        merged = s[0].merge(s)
+        self.assertEqual(str(merged), '%post\n    cd /\n    a\n    b\n    c')


### PR DESCRIPTION
Add first class support for [SCI-F](https://sci-f.github.io).  Prior to this PR, it was partially supported using the `_app` primitive parameter.  This PR supersedes #94.

The `scif` building block syntax is very similar to Stages.  Create a `scif` instance, then `+=` other building blocks or primitives.  See the tutorial section or the new example (`recipes/examples/scif.py`) for more information.

In order to implement the `scif` building block, the ability to "merge" primitives was needed.  This potentially has other uses, such as merging adjacent instructions of the same type to reduce the number of layers, or merging all layers to work around Singularity bugs (#95).

Also refactored and simplified the `copy` primitive to make merging possible.  Adds the `files` parameter to specify arbitrary source / destination pairs more flexibly than allowed with `src` and `dest`.  E.g., `copy(files={'a.tgz': '/var/tmp/a.tgz', 'b.data': '/data/b.data'})`.

@bilke, would you please review this?