### PR TITLE
Fixed sourcing of Docker environment on Singularity 3

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -50,7 +50,7 @@ $ hpccm --recipe simple.py --format singularity
 BootStrap: docker
 From: centos:7
 %post
-    . /.singularity.d/env/10-docker.sh
+    . /.singularity.d/env/10-docker*.sh
 
 # GNU compiler
 %post

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -46,7 +46,7 @@ class baseimage(object):
 
     _docker_env: Boolean specifying whether to load the Docker base
      image environment, i.e., source
-     `/.singularity.d/env/10-docker.sh` (Singularity specific).  The
+     `/.singularity.d/env/10-docker*.sh` (Singularity specific).  The
      default value is True.
 
     image: The image identifier to use as the base image.  The default value is `nvidia/cuda:9.0-devel-ubuntu16.04`.
@@ -115,7 +115,7 @@ class baseimage(object):
             if self.__docker_env:
                 docker_env = shell(
                     chdir=False,
-                    commands=['. /.singularity.d/env/10-docker.sh'])
+                    commands=['. /.singularity.d/env/10-docker*.sh'])
                 image = image + '\n' + str(docker_env)
 
             return image

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -68,7 +68,7 @@ class Test_baseimage(unittest.TestCase):
 r'''BootStrap: docker
 From: foo
 %post
-    . /.singularity.d/env/10-docker.sh''')
+    . /.singularity.d/env/10-docker*.sh''')
 
     @singularity
     def test_false_docker_env_singularity(self):
@@ -92,7 +92,7 @@ From: foo''')
 r'''BootStrap: docker
 From: foo
 %post
-    . /.singularity.d/env/10-docker.sh''')
+    . /.singularity.d/env/10-docker*.sh''')
 
     @docker
     def test_as_docker(self):
@@ -108,7 +108,7 @@ From: foo
 r'''BootStrap: docker
 From: foo
 %post
-    . /.singularity.d/env/10-docker.sh''')
+    . /.singularity.d/env/10-docker*.sh''')
 
     @docker
     def test_detect_ubuntu(self):

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -75,7 +75,7 @@ RUN apt-get update -y && \
 r'''BootStrap: docker
 From: ubuntu:16.04
 %post
-    . /.singularity.d/env/10-docker.sh
+    . /.singularity.d/env/10-docker*.sh
 
 %post
     apt-get update -y
@@ -125,7 +125,7 @@ ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 r'''BootStrap: docker
 From: nvidia/cuda:9.0-devel-ubuntu16.04
 %post
-    . /.singularity.d/env/10-docker.sh
+    . /.singularity.d/env/10-docker*.sh
 
 # GNU compiler
 %post


### PR DESCRIPTION
The file to source is now (with Singularity 3.x) named
10-docker2singularity.sh. Fixes the issue described in #114.
Change is backwards-compatible with Singularity 2.