### PR TITLE
Setup OpenMPI build included with PGI compiler and other fixes

### DIFF
--- a/hpccm/building_blocks/pgi.py
+++ b/hpccm/building_blocks/pgi.py
@@ -181,11 +181,19 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
                 self.__ospackages = ['gcc', 'g++', 'libnuma1', 'perl']
-                self.__runtime_ospackages = ['libnuma1']
+                if self.__mpi:
+                    self.__ospackages.append('openssh-client')
+            self.__runtime_ospackages = ['libnuma1']
+            if self.__mpi:
+                self.__runtime_ospackages.append('openssh-client')
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
                 self.__ospackages = ['gcc', 'gcc-c++', 'numactl-libs', 'perl']
-                self.__runtime_ospackages = ['numactl-libs']
+                if self.__mpi:
+                    self.__ospackages.append('openssh-clients')
+            self.__runtime_ospackages = ['numactl-libs']
+            if self.__mpi:
+                self.__runtime_ospackages.append('openssh-clients')
         else:
             raise RuntimeError('Unknown Linux distribution')
 
@@ -198,8 +206,17 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
 
         if runtime:
             # Runtime environment
-            e = {'LD_LIBRARY_PATH': '{}:$LD_LIBRARY_PATH'.format(
-                os.path.join(pgi_path, 'lib'))}
+            if self.__mpi:
+                # PGI MPI component is selected
+                e['LD_LIBRARY_PATH'] = '{}:{}:$LD_LIBRARY_PATH'.format(
+                    os.path.join(mpi_path, 'lib'),
+                    os.path.join(pgi_path, 'lib'))
+                e['PATH'] = '{}:$PATH'.format(
+                    os.path.join(mpi_path, 'bin'))
+            else:
+                # PGI MPI component is not selected
+                e['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(
+                    os.path.join(pgi_path, 'lib'))
         else:
             # Development environment
             if self.__extended_environment:
@@ -232,9 +249,19 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                         os.path.join(pgi_path, 'bin'))
             else:
                 # Basic environment only
-                e = {'PATH': '{}:$PATH'.format(os.path.join(pgi_path, 'bin')),
-                     'LD_LIBRARY_PATH': '{}:$LD_LIBRARY_PATH'.format(
-                         os.path.join(pgi_path, 'lib'))}
+                if self.__mpi:
+                    e['LD_LIBRARY_PATH'] = '{}:{}:$LD_LIBRARY_PATH'.format(
+                        os.path.join(mpi_path, 'lib'),
+                        os.path.join(pgi_path, 'lib'))
+                    e['PATH'] = '{}:{}:$PATH'.format(
+                        os.path.join(mpi_path, 'bin'),
+                        os.path.join(pgi_path, 'bin'))
+                else:
+                    # PGI MPI component is not selected
+                    e = {'PATH': '{}:$PATH'.format(os.path.join(pgi_path,
+                                                                'bin')),
+                         'LD_LIBRARY_PATH': '{}:$LD_LIBRARY_PATH'.format(
+                             os.path.join(pgi_path, 'lib'))}
 
         return e
 
@@ -301,6 +328,7 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__commands.append(r'echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> {}'.format(siterc))
         self.__commands.append(r'echo "append LDLIBARGS=\$library_path;" >> {}'.format(siterc))
 
+        # Cleanup
         self.__commands.append(self.cleanup_step(
             items=[os.path.join(self.__wd, tarball),
                    os.path.join(self.__wd, 'pgi')]))
@@ -313,7 +341,6 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                 '/usr/lib/x86_64-linux-gnu/libnuma.so.1',
                 os.path.join(self.__basepath, self.__version, 'lib',
                              'libnuma.so')))
-
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -338,6 +365,25 @@ class pgi(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                                  dest=os.path.join(self.__basepath,
                                                    self.__version,
                                                    'lib', '')))
+
+        # REDIST workaround for incorrect libcudaforwrapblas.so
+        # symlink impacting version 18.10
+        if self.__version == '18.10':
+            instructions.append(
+                copy(_from=_from,
+                     src=os.path.join(self.__basepath, self.__version,
+                                      'lib', 'libcudaforwrapblas.so'),
+                     dest=os.path.join(self.__basepath, self.__version,
+                                       'lib', 'libcudaforwrapblas.so')))
+
+        if self.__mpi:
+            instructions.append(copy(_from=_from,
+                                     src=os.path.join(self.__basepath,
+                                                      self.__version,
+                                                      'mpi', 'openmpi'),
+                                     dest=os.path.join(self.__basepath,
+                                                       self.__version,
+                                                       'mpi', 'openmpi')))
         if self.__runtime_commands:
             instructions.append(shell(commands=self.__runtime_commands))
 

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -215,6 +215,7 @@ RUN apt-get update -y && \
         g++ \
         libnuma1 \
         perl \
+        openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
@@ -224,8 +225,8 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-comm
     echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/18.10/bin/siterc && \
     rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/18.10/bin:$PATH''')
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/mpi/openmpi/lib:/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/18.10/mpi/openmpi/bin:/opt/pgi/linux86-64/18.10/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -272,6 +273,7 @@ RUN apt-get update -y && \
         g++ \
         libnuma1 \
         perl \
+        openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
@@ -306,6 +308,7 @@ RUN apt-get update -y && \
         libnuma1 && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /opt/pgi/linux86-64/18.10/REDIST/*.so /opt/pgi/linux86-64/18.10/lib/
+COPY --from=0 /opt/pgi/linux86-64/18.10/lib/libcudaforwrapblas.so /opt/pgi/linux86-64/18.10/lib/libcudaforwrapblas.so
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -320,6 +323,7 @@ RUN yum install -y \
         numactl-libs && \
     rm -rf /var/cache/yum/*
 COPY --from=0 /opt/pgi/linux86-64/18.10/REDIST/*.so /opt/pgi/linux86-64/18.10/lib/
+COPY --from=0 /opt/pgi/linux86-64/18.10/lib/libcudaforwrapblas.so /opt/pgi/linux86-64/18.10/lib/libcudaforwrapblas.so
 ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.10/lib:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):


### PR DESCRIPTION
1. Redistribute and setup (PATH, install openssh client, etc.) the OpenMPI build included with the PGI compiler if `mpi=True`.
2. Work around an incorrect symlink (`/opt/pgi/linux86-64/18.10/REDIST/libcudaforwrapblas.so` -> `../lib/libjpgdbg64.so`) in version 18.10.
3. Copy `REDIST/*.so*` instead of `REDIST/*.so`.  As a consequence, enforce that `libnuma.so.1` is a symlink to the system library in the runtime stage.  The PGI installer does the "right thing", but the Docker multi-stage builder copies the file the symlink is pointing to, so the symlinks must be recreated.