### PR TITLE
Add prefix option to the mlnx_ofed building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1130,6 +1130,14 @@ RHEL-based Linux distributions, the default values are
 `libmlx4-devel`, `libmlx5`, `libmlx5-devel`, `librdmacm`, and
 `librdmacm-devel`.
 
+- __prefix__: The top level install location.  Instead of installing the
+packages via the package manager, they will be extracted to this
+location.  This option is useful if multiple versions of Mellanox
+OFED need to be installed.  The environment must be manually
+configured to recognize the Mellanox OFED location, e.g., in the
+container entry point.  The default value is empty, i.e., install
+via the package manager to the standard system locations.
+
 - __version__: The version of Mellanox OFED to download.  The default
 value is `4.5-1.0.1.0`.
 
@@ -1139,6 +1147,7 @@ __Examples__
 ```python
 mlnx_ofed(version='4.2-1.0.0.0')
 ```
+
 
 ## runtime
 ```python

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -89,6 +89,71 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 
     @ubuntu
     @docker
+    def test_prefix_ubuntu(self):
+        """Prefix option"""
+        mofed = mlnx_ofed(prefix='/opt/ofed')
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    mkdir -p /etc/libibverbs.d && \
+    mkdir -p /opt/ofed && cd /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+
+    @centos
+    @docker
+    def test_prefix_centos(self):
+        """Prefix option"""
+        mofed = mlnx_ofed(prefix='/opt/ofed')
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN yum install -y \
+        libnl \
+        libnl3 \
+        numactl-libs \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
+    mkdir -p /etc/libibverbs.d && \
+    mkdir -p /opt/ofed && cd /opt/ofed && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm | cpio -idm && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         mofed = mlnx_ofed()
@@ -105,4 +170,38 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
     dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+
+    @ubuntu
+    @docker
+    def test_prefix_runtime(self):
+        """Prefix runtime"""
+        mofed = mlnx_ofed(prefix='/opt/ofed')
+        r = mofed.runtime()
+        self.assertEqual(r,
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    mkdir -p /etc/libibverbs.d && \
+    mkdir -p /opt/ofed && cd /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')


### PR DESCRIPTION
Add the option to install Mellanox OFED at a non-default location.  This allows multiple OFED installations in the same container image.

```
Stage0 += mlnx_ofed(prefix='/opt/ofed/4.5-1', version='4.5-1.0.1.0')
Stage0 += mlnx_ofed(prefix='/opt/ofed/4.2-1', version='4.2-1.0.0.0')
```

Note that the user needs to manually set the environment to pick up the OFED install of their choice.  An entry point would be the natural place to do that.