### PR TITLE
Add Intel PSXE runtime building block and refactor Intel PSXE building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -720,15 +720,42 @@ __Parameters__
 
 
 - __components__: List of Intel Parallel Studio XE components to
-install.  The default values are `intel-icc__x86_64` and
-`intel-ifort__x86_64`, i.e., install the Intel C++ and Fortran
-compilers only.  Please note that the values are not consistent
-between versions; for a list of components, extract
-`pset/mediaconfig.xml` from the tarball and grep for `Abbr`.  The
-default values correspond to Intel Parallel Studio XE 2018.
+install.  The default values is `DEFAULTS`.  If only the Intel C++
+and Fortran compilers are desired, then use `intel-icc__x86_64`
+and `intel-ifort__x86_64`.  Please note that the values are not
+consistent between versions; for a list of components, extract
+`pset/mediaconfig.xml` from the tarball and grep for `Abbr`.
+
+- __daal__: Boolean flag to specify whether the Intel Data Analytics
+Acceleration Library environment should be configured when
+`psxevars` is False.  This flag also controls whether to install
+- __the corresponding runtime in the `runtime` method.  Note__: this
+flag does not control whether the developer environment is
+installed; see `components`.  The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
 The default value is `False`.
+
+- __icc__: Boolean flag to specify whether the Intel C++ Compiler
+environment should be configured when `psxevars` is False.  This
+flag also controls whether to install the corresponding runtime in
+- __the `runtime` method.  Note__: this flag does not control whether
+the developer environment is installed; see `components`.  The
+default is True.
+
+- __ifort__: Boolean flag to specify whether the Intel Fortran Compiler
+environment should be configured when `psxevars` is False.  This
+flag also controls whether to install the corresponding runtime in
+- __the `runtime` method.  Note__: this flag does not control whether
+the developer environment is installed; see `components`.  The
+default is True.
+
+- __ipp__: Boolean flag to specify whether the Intel Integrated
+Performance Primitives environment should be configured when
+`psxevars` is False.  This flag also controls whether to install
+- __the corresponding runtime in the `runtime` method.  Note__: this
+flag does not control whether the developer environment is
+installed; see `components`.  The default is True.
 
 - __license__: The license to use to activate Intel Parallel Studio XE.
 If the string contains a `@` the license is interpreted as a
@@ -738,15 +765,61 @@ local build context.  The default value is empty.  While this
 value is not required, the installation is unlikely to be
 successful without a valid license.
 
+- __mkl__: Boolean flag to specify whether the Intel Math Kernel Library
+environment should be configured when `psxevars` is False.  This
+flag also controls whether to install the corresponding runtime in
+- __the `runtime` method.  Note__: this flag does not control whether
+the developer environment is installed; see `components`.  The
+default is True.
+
+- __mpi__: Boolean flag to specify whether the Intel MPI Library
+environment should be configured when `psxevars` is False.  This
+flag also controls whether to install the corresponding runtime in
+- __the `runtime` method.  Note__: this flag does not control whether
+the developer environment is installed; see `components`.  The
+default is True.
+
 - __ospackages__: List of OS packages to install prior to installing
-Intel Parallel Studio XE.  The default value is `cpio`.
+Intel MPI.  For Ubuntu, the default values are `build-essential`
+and `cpio`.  For RHEL-based Linux distributions, the default
+values are `gcc`, `gcc-c++`, `make`, and `which`.
 
 - __prefix__: The top level install location.  The default value is
 `/opt/intel`.
 
+- __psxevars__: Intel Parallel Studio XE provides an environment script
+(`compilervars.sh`) to setup the environment.  If this value is
+`True`, the bashrc is modified to automatically source this
+environment script.  However, the Intel runtime environment is not
+automatically available to subsequent container image build steps;
+the environment is available when the container image is run.  To
+set the Intel Parallel Studio XE environment in subsequent build
+steps you can explicitly call `source
+/opt/intel/compilers_and_libraries/linux/bin/compilervars.sh
+intel64` in each build step.  If this value is to set `False`,
+then the environment is set such that the environment is visible
+to both subsequent container image build steps and when the
+container image is run.  However, the environment may differ
+slightly from that set by `compilervars.sh`.  The default value is
+`True`.
+
+- __runtime_version__: The version of Intel Parallel Studio XE runtime
+to install via the `runtime` method.  The runtime is installed
+using the [intel_psxe_runtime](#intel_psxe_runtime) building
+block.  This value is passed as its `version` parameter.  In
+general, the major version of the runtime should correspond to the
+tarball version.
+
 - __tarball__: Path to the Intel Parallel Studio XE tarball relative to
 the local build context.  The default value is empty.  This
 parameter is required.
+
+- __tbb__: Boolean flag to specify whether the Intel Threading Building
+Blocks environment should be configured when `psxevars` is False.
+This flag also controls whether to install the corresponding
+- __runtime in the `runtime` method.  Note__: this flag does not control
+whether the developer environment is installed; see `components`.
+The default is True.
 
 __Examples__
 
@@ -761,11 +834,116 @@ i = intel_psxe(...)
 openmpi(..., toolchain=i.toolchain, ...)
 ```
 
+
 ## runtime
 ```python
 intel_psxe.runtime(self, _from=u'0')
 ```
 Install the runtime from a full build in a previous stage
+# intel_psxe_runtime
+```python
+intel_psxe_runtime(self, **kwargs)
+```
+The `intel_mpi` building block downloads and installs the [Intel
+Parallel Studio XE runtime](https://software.intel.com/en-us/articles/intel-parallel-studio-xe-runtime-by-version).
+
+You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
+to use this building block.
+
+As a side effect, this building block modifies `PATH`,
+`LD_LIBRARY_PATH`, and other environment variables to include the
+Intel Parallel Studio XE runtime.  Please see the `psxevars`
+parameter for more information.
+
+Note: this building block does *not* install development versions
+of the Intel software tools.  Please see the
+[intel_psxe](#intel_psxe), [intel_mpi](#intel_mpi), or [mkl](#mkl)
+building blocks for development environments.
+
+__Parameters__
+
+
+- __daal__: Boolean flag to specify whether the Intel Data Analytics
+Acceleration Library runtime should be installed.  The default is
+True.
+
+- __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
+The default value is `False`.
+
+- __icc__: Boolean flag to specify whether the Intel C++ Compiler
+runtime should be installed.  The default is True.
+
+- __ifort__: Boolean flag to specify whether the Intel Fortran Compiler
+runtime should be installed.  The default is True.
+
+- __ipp__: Boolean flag to specify whether the Intel Integrated
+Performance Primitives runtime should be installed.  The default
+is True.
+
+- __mkl__: Boolean flag to specify whether the Intel Math Kernel Library
+runtime should be installed.  The default is True.
+
+- __mpi__: Boolean flag to specify whether the Intel MPI Library runtime
+should be installed.  The default is True.
+
+- __psxevars__: Intel Parallel Studio XE provides an environment script
+(`psxevars.sh`) to setup the environment.  If this value is
+`True`, the bashrc is modified to automatically source this
+environment script.  However, the Intel runtime environment is not
+automatically available to subsequent container image build steps;
+the environment is available when the container image is run.  To
+set the Intel Parallel Studio XE runtime environment in subsequent
+build steps you can explicitly call `source
+/opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64` in each
+build step.  If this value is to set `False`, then the environment
+is set such that the environment is visible to both subsequent
+container image build steps and when the container image is run.
+However, the environment may differ slightly from that set by
+`psxevars.sh`.  The default value is `True`.
+
+- __ospackages__: List of OS packages to install prior to installing
+Intel MPI.  For Ubuntu, the default values are
+`apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
+`openssh-client`, and `wget`.  For RHEL-based Linux distributions,
+the default values are `man-db`, `openssh-clients`, and `which`.
+
+- __version__: The version of the Intel Parallel Studio XE runtime to
+install.  Due to issues in the Intel apt / yum repositories, only
+the major version is used; within a major version, the most recent
+minor version will be installed.  The default value is
+`2019.3-199`.
+
+- __tbb__: Boolean flag to specify whether the Intel Threading Building
+Blocks runtime should be installed.  The default is True.
+
+__Examples__
+
+
+```python
+intel_psxe_runtime(eula=True, version='2018.4-274')
+```
+
+```python
+intel_psxe_runtime(daal=False, eula=True, ipp=False, psxevars=False)
+```
+
+
+## runtime
+```python
+intel_psxe_runtime.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+
+```python
+i = intel_psxe_runtime(...)
+Stage0 += i
+Stage1 += i.runtime()
+```
+
 # knem
 ```python
 knem(self, **kwargs)

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -26,6 +26,7 @@ from hpccm.building_blocks.gnu import gnu
 from hpccm.building_blocks.hdf5 import hdf5
 from hpccm.building_blocks.intel_mpi import intel_mpi
 from hpccm.building_blocks.intel_psxe import intel_psxe
+from hpccm.building_blocks.intel_psxe_runtime import intel_psxe_runtime
 from hpccm.building_blocks.knem import knem
 from hpccm.building_blocks.kokkos import kokkos
 from hpccm.building_blocks.libsim import libsim

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -138,7 +138,7 @@ class intel_psxe_runtime(bb_base):
         self.__psxevars = kwargs.get('psxevars', True)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__tbb = kwargs.get('tbb', True)
-        self.__version = kwargs.get('version', '2019.1-144')
+        self.__version = kwargs.get('version', '2019.3-199')
         self.__year = self.__version.split('.')[0]
 
         self.__bashrc = ''            # Filled in by __distro()

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -1,0 +1,305 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""Intel Parallel Studio XE runtime building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+from distutils.version import LooseVersion
+import logging # pylint: disable=unused-import
+import os
+
+import hpccm.config
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.building_blocks.packages import packages
+from hpccm.common import linux_distro
+from hpccm.primitives.comment import comment
+from hpccm.primitives.environment import environment
+from hpccm.primitives.shell import shell
+from hpccm.toolchain import toolchain
+
+class intel_psxe_runtime(bb_base):
+    """The `intel_mpi` building block downloads and installs the [Intel
+    Parallel Studio XE runtime](https://software.intel.com/en-us/articles/intel-parallel-studio-xe-runtime-by-version).
+
+    You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
+    to use this building block.
+
+    As a side effect, this building block modifies `PATH`,
+    `LD_LIBRARY_PATH`, and other environment variables to include the
+    Intel Parallel Studio XE runtime.  Please see the `psxevars`
+    parameter for more information.
+
+    Note: this building block does *not* install development versions
+    of the Intel software tools.  Please see the
+    [intel_psxe](#intel_psxe), [intel_mpi](#intel_mpi), or [mkl](#mkl)
+    building blocks for development environments.
+
+    # Parameters
+
+    daal: Boolean flag to specify whether the Intel Data Analytics
+    Acceleration Library runtime should be installed.  The default is
+    True.
+
+    eula: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
+    The default value is `False`.
+
+    icc: Boolean flag to specify whether the Intel C++ Compiler
+    runtime should be installed.  The default is True.
+
+    ifort: Boolean flag to specify whether the Intel Fortran Compiler
+    runtime should be installed.  The default is True.
+
+    ipp: Boolean flag to specify whether the Intel Integrated
+    Performance Primitives runtime should be installed.  The default
+    is True.
+
+    mkl: Boolean flag to specify whether the Intel Math Kernel Library
+    runtime should be installed.  The default is True.
+
+    mpi: Boolean flag to specify whether the Intel MPI Library runtime
+    should be installed.  The default is True.
+
+    psxevars: Intel Parallel Studio XE provides an environment script
+    (`psxevars.sh`) to setup the environment.  If this value is
+    `True`, the bashrc is modified to automatically source this
+    environment script.  However, the Intel runtime environment is not
+    automatically available to subsequent container image build steps;
+    the environment is available when the container image is run.  To
+    set the Intel Parallel Studio XE runtime environment in subsequent
+    build steps you can explicitly call `source
+    /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64` in each
+    build step.  If this value is to set `False`, then the environment
+    is set such that the environment is visible to both subsequent
+    container image build steps and when the container image is run.
+    However, the environment may differ slightly from that set by
+    `psxevars.sh`.  The default value is `True`.
+
+    ospackages: List of OS packages to install prior to installing
+    Intel MPI.  For Ubuntu, the default values are
+    `apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
+    `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
+    the default values are `man-db`, `openssh-clients`, and `which`.
+
+    version: The version of the Intel Parallel Studio XE runtime to
+    install.  Due to issues in the Intel apt / yum repositories, only
+    the major version is used; within a major version, the most recent
+    minor version will be installed.  The default value is
+    `2019.3-199`.
+
+    tbb: Boolean flag to specify whether the Intel Threading Building
+    Blocks runtime should be installed.  The default is True.
+
+    # Examples
+
+    ```python
+    intel_psxe_runtime(eula=True, version='2018.4-274')
+    ```
+
+    ```python
+    intel_psxe_runtime(daal=False, eula=True, ipp=False, psxevars=False)
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(intel_psxe_runtime, self).__init__(**kwargs)
+
+        # By setting this value to True, you agree to the
+        # corresponding Intel End User License Agreement
+        # (https://software.intel.com/en-us/articles/end-user-license-agreement)
+        self.__eula = kwargs.get('eula', False)
+
+        self.__daal = kwargs.get('daal', True)
+        self.__icc = kwargs.get('icc', True)
+        self.__ifort = kwargs.get('ifort', True)
+        self.__ipp = kwargs.get('ipp', True)
+        self.__mkl = kwargs.get('mkl', True)
+        self.__mpi = kwargs.get('mpi', True)
+        self.__psxevars = kwargs.get('psxevars', True)
+        self.__ospackages = kwargs.get('ospackages', [])
+        self.__tbb = kwargs.get('tbb', True)
+        self.__version = kwargs.get('version', '2019.1-144')
+        self.__year = self.__version.split('.')[0]
+
+        self.__bashrc = ''            # Filled in by __distro()
+        self.__runtime_packages = []  # Filled in by __setup()
+
+        # Set the Linux distribution specific parameters
+        self.__distro()
+
+        # Construct the list of runtime packages to install
+        self.__setup()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('Intel Parallel Studio XE runtime version {}'.format(self.__year))
+
+        if self.__ospackages:
+            self += packages(ospackages=self.__ospackages)
+
+        if not self.__eula:
+            raise RuntimeError('Intel EULA was not accepted.  To accept, see the documentation for this building block')
+
+        self += packages(
+            apt_keys=['https://apt.repos.intel.com/{0}/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-{0}'.format(self.__year)],
+            apt_repositories=['deb https://apt.repos.intel.com/{0} intel-psxe-runtime main'.format(self.__year)],
+            ospackages=self.__runtime_packages,
+            yum_keys=['https://yum.repos.intel.com/{0}/setup/RPM-GPG-KEY-intel-psxe-runtime-{0}'.format(self.__year)],
+            yum_repositories=['https://yum.repos.intel.com/{0}/setup/intel-psxe-runtime-{0}.repo'.format(self.__year)])
+
+        # Set the environment
+        if self.__psxevars:
+            # Source the psxevars environment script when starting the
+            # container, but the variables not be available for any
+            # subsequent build steps.
+            self += shell(commands=['echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> {}'.format(self.__bashrc)])
+        else:
+            # Set the environment so that it will be available to
+            # subsequent build steps and when starting the container,
+            # but this may miss some things relative to the psxevars
+            # environment script.
+            self += environment(variables=self.__environment())
+
+    def __distro(self):
+        """Based on the Linux distribution, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+            if not self.__ospackages:
+                self.__ospackages = ['apt-transport-https', 'ca-certificates',
+                                     'gnupg', 'man-db', 'openssh-client',
+                                     'wget']
+
+            self.__bashrc = '/etc/bash.bashrc'
+
+        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+            if not self.__ospackages:
+                self.__ospackages = ['man-db', 'openssh-clients', 'which']
+
+            self.__bashrc = '/etc/bashrc'
+
+        else: # pragma: no cover
+            raise RuntimeError('Unknown Linux distribution')
+
+    def __environment(self):
+        """Manually set the environment as an alternative to psxevars.sh"""
+
+        basepath = '/opt/intel/psxe_runtime/linux'
+
+        ld_library_path = []
+        path = []
+        env = {}
+
+        if self.__daal:
+            env['DAALROOT'] = os.path.join(basepath, 'daal')
+            ld_library_path.append(os.path.join(basepath, 'daal', 'lib',
+                                                'intel64'))
+
+        if self.__icc:
+            ld_library_path.append(os.path.join(basepath, 'compiler', 'lib',
+                                                'intel64_lin'))
+
+        if self.__ifort:
+            ld_library_path.append(os.path.join(basepath, 'compiler', 'lib',
+                                                'intel64_lin'))
+
+        if self.__ipp:
+            env['IPPROOT' ] = os.path.join(basepath, 'ipp')
+            ld_library_path.append(os.path.join(basepath, 'ipp', 'lib',
+                                                'intel64'))
+
+        if self.__mkl:
+            env['MKLROOT'] = os.path.join(basepath, 'mkl')
+            ld_library_path.append(os.path.join(basepath, 'mkl', 'lib',
+                                                'intel64'))
+
+        if self.__mpi:
+            env['I_MPI_ROOT'] = os.path.join(basepath, 'mpi')
+            ld_library_path.append(os.path.join(basepath, 'mpi', 'intel64',
+                                                'lib'))
+            path.append(os.path.join(basepath, 'mpi', 'intel64', 'bin'))
+
+            if LooseVersion(self.__version) >= LooseVersion('2019'):
+                env['FI_PROVIDER_PATH'] = os.path.join(basepath, 'mpi',
+                                                       'intel64', 'libfabric',
+                                                       'lib', 'prov')
+                ld_library_path.append(os.path.join(basepath, 'mpi', 'intel64',
+                                                    'libfabric', 'lib'))
+                path.append(os.path.join(basepath, 'mpi', 'intel64',
+                                         'libfabric', 'bin'))
+
+        if self.__tbb:
+            ld_library_path.append(os.path.join(basepath, 'tbb', 'lib',
+                                                'intel64', 'gcc4.7'))
+
+        if ld_library_path:
+            ld_library_path.append('$LD_LIBRARY_PATH')
+            env['LD_LIBRARY_PATH'] = ':'.join(ld_library_path)
+
+        if path:
+            path.append('$PATH')
+            env['PATH'] = ':'.join(path)
+
+        return env
+
+    def __setup(self):
+        """Construct the list of packages, i.e., fill in
+           self.__runtime_packages"""
+
+        if (self.__daal and self.__icc and self.__ifort and self.__ipp
+            and self.__mkl and self.__mpi and self.__tbb):
+            # Everything selected, so install the omnibus runtime package
+            self.__runtime_packages = ['intel-psxe-runtime']
+        else:
+            if self.__daal:
+                self.__runtime_packages.append('intel-daal-runtime')
+            if self.__icc:
+                self.__runtime_packages.append('intel-icc-runtime')
+            if self.__ifort:
+                self.__runtime_packages.append('intel-ifort-runtime')
+            if self.__ipp:
+                self.__runtime_packages.append('intel-ipp-runtime')
+            if self.__mkl:
+                self.__runtime_packages.append('intel-mkl-runtime')
+            if self.__mpi:
+                self.__runtime_packages.append('intel-mpi-runtime')
+            if self.__tbb:
+                self.__runtime_packages.append('intel-tbb-runtime')
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+
+        ```python
+        i = intel_psxe_runtime(...)
+        Stage0 += i
+        Stage1 += i.runtime()
+        ```
+        """
+        return str(self)

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -57,6 +57,7 @@ from hpccm.building_blocks.gnu import gnu
 from hpccm.building_blocks.hdf5 import hdf5
 from hpccm.building_blocks.intel_mpi import intel_mpi
 from hpccm.building_blocks.intel_psxe import intel_psxe
+from hpccm.building_blocks.intel_psxe_runtime import intel_psxe_runtime
 from hpccm.building_blocks.kokkos import kokkos
 from hpccm.building_blocks.knem import knem
 from hpccm.building_blocks.libsim import libsim

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -16,6 +16,7 @@ generate:
   - hpccm.building_blocks.hdf5+
   - hpccm.building_blocks.intel_mpi+
   - hpccm.building_blocks.intel_psxe+
+  - hpccm.building_blocks.intel_psxe_runtime+
   - hpccm.building_blocks.knem+
   - hpccm.building_blocks.kokkos+
   - hpccm.building_blocks.libsim+

--- a/test/test_intel_psxe.py
+++ b/test/test_intel_psxe.py
@@ -48,21 +48,42 @@ class Test_intel_psxe(unittest.TestCase):
 r'''# Intel Parallel Studio XE
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
         cpio && \
     rm -rf /var/lib/apt/lists/*
 COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz
 COPY XXXXXXXX.lic /var/tmp/license.lic
 RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz -C /var/tmp -z && \
-    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64/g' \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=DEFAULTS/g' \
         -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
         -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' \
         -e 's/^#\?\(ACTIVATION_TYPE\)=.*/\1=license_file/g' \
         -e 's|^#\?\(ACTIVATION_LICENSE_FILE\)=.*|\1=/var/tmp/license.lic|g' /var/tmp/parallel_studio_xe_2018_update1_professional_edition/silent.cfg && \
     cd /var/tmp/parallel_studio_xe_2018_update1_professional_edition && ./install.sh --silent=silent.cfg && \
-    mkdir -p /var/tmp/intel_psxe_runtime && cp -a /opt/intel/lib/intel64/*.so* /var/tmp/intel_psxe_runtime && \
     rm -rf /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition
-ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
-    PATH=/opt/intel/bin:$PATH''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bash.bashrc''')
+
+    @centos
+    @docker
+    def test_centos(self):
+        """centos"""
+        psxe = intel_psxe(eula=True, tarball='parallel_studio_xe_2018_update1_professional_edition.tgz')
+        self.assertEqual(str(psxe),
+r'''# Intel Parallel Studio XE
+RUN yum install -y \
+        gcc \
+        gcc-c++ \
+        make \
+        which && \
+    rm -rf /var/cache/yum/*
+COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz -C /var/tmp -z && \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=DEFAULTS/g' \
+        -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
+        -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' /var/tmp/parallel_studio_xe_2018_update1_professional_edition/silent.cfg && \
+    cd /var/tmp/parallel_studio_xe_2018_update1_professional_edition && ./install.sh --silent=silent.cfg && \
+    rm -rf /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition
+RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bashrc''')
 
     @ubuntu
     @docker
@@ -73,20 +94,47 @@ ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
 r'''# Intel Parallel Studio XE
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
         cpio && \
     rm -rf /var/lib/apt/lists/*
 COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz
 RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz -C /var/tmp -z && \
-    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=intel-icc__x86_64;intel-ifort__x86_64/g' \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=DEFAULTS/g' \
         -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
         -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' \
         -e 's/^#\?\(ACTIVATION_TYPE\)=.*/\1=license_server/g' \
         -e 's/^#\?\(ACTIVATION_LICENSE_FILE\)=.*/\1=12345@server-lic/g' /var/tmp/parallel_studio_xe_2018_update1_professional_edition/silent.cfg && \
     cd /var/tmp/parallel_studio_xe_2018_update1_professional_edition && ./install.sh --silent=silent.cfg && \
-    mkdir -p /var/tmp/intel_psxe_runtime && cp -a /opt/intel/lib/intel64/*.so* /var/tmp/intel_psxe_runtime && \
     rm -rf /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition
-ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
-    PATH=/opt/intel/bin:$PATH''')
+RUN echo "source /opt/intel/compilers_and_libraries/linux/bin/compilervars.sh intel64" >> /etc/bash.bashrc''')
+
+    @ubuntu
+    @docker
+    def test_psxevars_false(self):
+        """psxevars is false"""
+        psxe = intel_psxe(eula=True, psxevars=False, tarball='parallel_studio_xe_2018_update1_professional_edition.tgz')
+        self.assertEqual(str(psxe),
+r'''# Intel Parallel Studio XE
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        cpio && \
+    rm -rf /var/lib/apt/lists/*
+COPY parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz -C /var/tmp -z && \
+    sed -i -e 's/^#\?\(COMPONENTS\)=.*/\1=DEFAULTS/g' \
+        -e 's|^#\?\(PSET_INSTALL_DIR\)=.*|\1=/opt/intel|g' \
+        -e 's/^#\?\(ACCEPT_EULA\)=.*/\1=accept/g' /var/tmp/parallel_studio_xe_2018_update1_professional_edition/silent.cfg && \
+    cd /var/tmp/parallel_studio_xe_2018_update1_professional_edition && ./install.sh --silent=silent.cfg && \
+    rm -rf /var/tmp/parallel_studio_xe_2018_update1_professional_edition.tgz /var/tmp/parallel_studio_xe_2018_update1_professional_edition
+ENV CPATH=/opt/intel/compilers_and_libraries/linux/daal/include:/opt/intel/compilers_and_libraries/linux/pstl/include:/opt/intel/compilers_and_libraries/linux/ipp/include:/opt/intel/compilers_and_libraries/linux/mkl/include:/opt/intel/compilers_and_libraries/linux/mpi/include:/opt/intel/compilers_and_libraries/linux/tbb/include:$CPATH \
+    DAALROOT=/opt/intel/compilers_and_libraries/linux/daal \
+    IPPROOT=/opt/intel/compilers_and_libraries/linux/ipp \
+    I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
+    LD_LIBRARY_PATH=/opt/intel/compilers_and_libraries/linux/daal/lib/intel64:/opt/intel/compilers_and_libraries/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries/linux/compiler/lib/intel64:/opt/intel/compilers_and_libraries/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries/linux/mkl/lib/intel64:/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib:/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.7:$LD_LIBRARY_PATH \
+    LIBRARY_PATH=/opt/intel/compilers_and_libraries/linux/daal/lib/intel64:/opt/intel/compilers_and_libraries/linux/ipp/lib/intel64:/opt/intel/compilers_and_libraries/linux/mkl/lib/intel64:/opt/intel/compilers_and_libraries/linux/tbb/lib/intel64/gcc4.7:$LIBRARY_PATH \
+    MKLROOT=/opt/intel/compilers_and_libraries/linux/mkl \
+    PATH=/opt/intel/compilers_and_libraries/linux/bin/intel64:/opt/intel/compilers_and_libraries/linux/bin/intel64:/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -95,9 +143,23 @@ ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
         psxe = intel_psxe(eula=True, tarball='parallel_studio_xe_2018_update1_professional_edition.tgz')
         r = psxe.runtime()
         self.assertEqual(r,
-r'''# Intel Parallel Studio XE
-COPY --from=0 /var/tmp/intel_psxe_runtime/* /opt/intel/lib/intel64/
-ENV LD_LIBRARY_PATH=/opt/intel/lib/intel64:$LD_LIBRARY_PATH''')
+r'''# Intel Parallel Studio XE runtime version 2019
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        man-db \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN wget -qO - https://apt.repos.intel.com/2019/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-2019 | apt-key add - && \
+    echo "deb https://apt.repos.intel.com/2019 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        intel-psxe-runtime && \
+    rm -rf /var/lib/apt/lists/*
+RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/bash.bashrc''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_intel_psxe_runtime.py
+++ b/test/test_intel_psxe_runtime.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the intel_psxe_runtime module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu
+
+from hpccm.building_blocks.intel_psxe_runtime import intel_psxe_runtime
+
+class Test_intel_psxe_runtime(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @ubuntu
+    @docker
+    def test_defaults(self):
+        """Default intel_psxe_runtime building block, no eula agreement"""
+        with self.assertRaises(RuntimeError):
+            psxe_rt = intel_psxe_runtime()
+            str(psxe_rt)
+
+    @ubuntu
+    @docker
+    def test_defaults_eula(self):
+        """eula"""
+        psxe_rt = intel_psxe_runtime(eula=True)
+        self.assertEqual(str(psxe_rt),
+r'''# Intel Parallel Studio XE runtime version 2019
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        man-db \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN wget -qO - https://apt.repos.intel.com/2019/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-2019 | apt-key add - && \
+    echo "deb https://apt.repos.intel.com/2019 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        intel-psxe-runtime && \
+    rm -rf /var/lib/apt/lists/*
+RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/bash.bashrc''')
+
+    @ubuntu
+    @docker
+    def test_psxevars_false(self):
+        """psxevars is false"""
+        psxe_rt = intel_psxe_runtime(eula=True, psxevars=False)
+        self.assertEqual(str(psxe_rt),
+r'''# Intel Parallel Studio XE runtime version 2019
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
+        gnupg \
+        man-db \
+        openssh-client \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN wget -qO - https://apt.repos.intel.com/2019/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-2019 | apt-key add - && \
+    echo "deb https://apt.repos.intel.com/2019 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        intel-psxe-runtime && \
+    rm -rf /var/lib/apt/lists/*
+ENV DAALROOT=/opt/intel/psxe_runtime/linux/daal \
+    FI_PROVIDER_PATH=/opt/intel/psxe_runtime/linux/mpi/intel64/libfabric/lib/prov \
+    IPPROOT=/opt/intel/psxe_runtime/linux/ipp \
+    I_MPI_ROOT=/opt/intel/psxe_runtime/linux/mpi \
+    LD_LIBRARY_PATH=/opt/intel/psxe_runtime/linux/daal/lib/intel64:/opt/intel/psxe_runtime/linux/compiler/lib/intel64_lin:/opt/intel/psxe_runtime/linux/compiler/lib/intel64_lin:/opt/intel/psxe_runtime/linux/ipp/lib/intel64:/opt/intel/psxe_runtime/linux/mkl/lib/intel64:/opt/intel/psxe_runtime/linux/mpi/intel64/lib:/opt/intel/psxe_runtime/linux/mpi/intel64/libfabric/lib:/opt/intel/psxe_runtime/linux/tbb/lib/intel64/gcc4.7:$LD_LIBRARY_PATH \
+    MKLROOT=/opt/intel/psxe_runtime/linux/mkl \
+    PATH=/opt/intel/psxe_runtime/linux/mpi/intel64/bin:/opt/intel/psxe_runtime/linux/mpi/intel64/libfabric/bin:$PATH''')
+
+    @centos
+    @docker
+    def test_component_off(self):
+        """disable one of the runtimes"""
+        psxe_rt = intel_psxe_runtime(daal=False, eula=True)
+        self.assertEqual(str(psxe_rt),
+r'''# Intel Parallel Studio XE runtime version 2019
+RUN yum install -y \
+        man-db \
+        openssh-clients \
+        which && \
+    rm -rf /var/cache/yum/*
+RUN rpm --import https://yum.repos.intel.com/2019/setup/RPM-GPG-KEY-intel-psxe-runtime-2019 && \
+    yum-config-manager --add-repo https://yum.repos.intel.com/2019/setup/intel-psxe-runtime-2019.repo && \
+    yum install -y \
+        intel-icc-runtime \
+        intel-ifort-runtime \
+        intel-ipp-runtime \
+        intel-mkl-runtime \
+        intel-mpi-runtime \
+        intel-tbb-runtime && \
+    rm -rf /var/cache/yum/*
+RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/bashrc''')


### PR DESCRIPTION
Adds the `intel_psxe_runtime` building block to install the Intel Parallel Studio XE runtime (https://software.intel.com/en-us/articles/intel-parallel-studio-xe-runtime-by-version).

Modify the `intel_psxe` building block to use the new building block for it's runtime.  Also modified it to install the entire PSXE, rather than just the Intel compilers by default.

The Intel PSXE runtime repository has some technical issues.  I have observed that the Ubuntu + PSXE Runtime 2019 does not work (Ubuntu + 2018 does work), and that neither Ubuntu or CentOS works when trying to pin a specific PSXE Runtime version.  In the latter case, the best that can be done is to pin the major version and just get the most recent minor version.