### PR TITLE
Add support for Singularity multi-stage builds

### DIFF
--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -34,9 +34,25 @@ __Arguments__
 `ubuntu18`.  `ubuntu` is an alias for `ubuntu16` and `centos` is an
 alias for `centos7`.
 
+## set_singularity_version
+```python
+set_singularity_version(ver)
+```
+Set the Singularity definition file format version
+
+The Singularity definition file format was extended in version 3.2
+to enable multi-stage builds.  However, these changes are not
+backwards compatible.
+
+__Arguments__
+
+
+- __ver (string)__: Singularity definition file format version.
+
+
 # recipe
 ```python
-recipe(recipe_file, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, userarg=None)
+recipe(recipe_file, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None)
 ```
 Recipe builder
 
@@ -53,6 +69,11 @@ exception is raised.  The default value is False.
 
 - __single_stage__: If True, only print the first stage of a multi-stage
 recipe.  The default is False.
+
+- __singularity_version__: Version of the Singularity definition file
+format to use.  Multi-stage support was added in version 3.2, but
+the changes are incompatible with earlier versions of Singularity.
+The default is '2.6'.
 
 - __userarg__: A dictionary of key / value pairs provided to the recipe
 as the `USERARG` dictionary.

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -7,8 +7,9 @@ The `baseimage` primitive defines the base image to be used.
 __Parameters__
 
 
-- ___as__: Name for the build stage (Docker specific).  The default
-value is empty.
+- ___as__: Name for the stage.  When using Singularity multi-stage
+recipes, this value must be specified.  The default value is
+empty.
 
 - ___distro__: The underlying Linux distribution of the base image.
 Valid values are `centos`, `redhat`, `rhel`, `ubuntu`, `ubuntu16`,

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -44,7 +44,7 @@ recipe is:
 Stage0 += baseimage(image='nvidia/cuda:9.0-devel-centos7')
 ```
 
-_Note_: `Stage0` refers to the first stage of a [multi-stage Docker
+_Note_: `Stage0` refers to the first stage of a [multi-stage
 build](https://docs.docker.com/develop/develop-images/multistage-build/).
 Multi-stage builds are a technique that can significantly reduce the
 size of container images.  This tutorial section will not use
@@ -203,7 +203,7 @@ Stage0 += mlnx_ofed()
 Stage0 += openmpi(cuda=False)
 ```
 
-_Note_: `Stage0` refers to the first stage of a [multi-stage Docker
+_Note_: `Stage0` refers to the first stage of a [multi-stage
 build](https://docs.docker.com/develop/develop-images/multistage-build/).
 Multi-stage builds are a technique that can significantly reduce the
 size of container images.  This tutorial section will not use
@@ -243,7 +243,7 @@ Stage0 += shell(commands=[
 
 _Note_: In a production container image, a cleanup step would
 typically also be performed to remove the source code and any other
-build artifacts.  That step is skipped here.  [Multi-stage Docker
+build artifacts.  That step is skipped here.  [Multi-stage
 builds](https://docs.docker.com/develop/develop-images/multistage-build/)
 are another approach that separates the application build process from
 the application deployment.
@@ -390,7 +390,7 @@ surface of this powerful HPCCM capability.
 
 ## Multi-stage Recipes
 
-[Multi-stage Docker
+[Multi-stage
 builds](https://docs.docker.com/develop/develop-images/multistage-build/)
 are a very useful capability that separates the application build step
 from the deployment step.  The development toolchain, application
@@ -435,10 +435,33 @@ milc:multi-stage: 429MB
 milc:single-stage: 5.93GB
 ```
 
-The Singularity definition file format and image builder do not
-support multi-stage builds.  However, Docker images can be easily
-converted to Singularity images so Singularity can also (indirectly)
-take advantage of multi-stage builds.
+Singularity version 3.2 and later supports multi-stage Singularity
+definition files.  However, the multi-stage definition file syntax is
+incompatible with earlier versions of Singularity.  Use the HPCCM
+`--singularity-version <version>` command line option to specify the
+Singularity definition file version to generate.  A `version` of 3.2
+or later will generate a multi-stage definition file that will only
+build with Singularity version 3.2 or later.  A `version` less than
+3.2 will generate a portable definition file that works with any
+version of Singularity, but will not support multi-stage builds.
+
+```
+$ wget https://raw.githubusercontent.com/NVIDIA/hpc-container-maker/master/recipes/milc/milc.py
+$ hpccm --recipe milc.py --format singularity --single-stage > Singularity.single-stage
+$ sudo singularity build milc-single-stage.sif Singularity.single-stage
+
+$ hpccm --recipe milc.py --format singularity --singularity-version 3.2 > Singularity.multi-stage
+$ sudo singularity build milc-multi-stage.sif Singularity.multi-stage
+
+$ ls -1sh milc*.sif
+143M milc-multi-stage.sif
+2.4G milc-single-stage.sif
+```
+
+If Singularity version 3.2 or later is not an option, Docker images
+can be easily converted to Singularity images so older versions of
+Singularity can also (indirectly) take advantage of multi-stage
+builds.
 
 ```
 $ sudo docker run -t --rm --cap-add SYS_ADMIN -v /var/run/docker.sock:/var/run/docker.sock -v /tmp:/output singularityware/docker2singularity milc:multi-stage

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -12,7 +12,7 @@ expressed as a HPCCM recipe.  Examples are also included for
 [MILC](/recipes/milc/milc.py).
 
 The GROMACS and MILC recipes demonstrate how to use [multi-stage
-Docker builds](/docs/recipes.md#multi-stage-recipes) to minimize the
+builds](/docs/recipes.md#multi-stage-recipes) to minimize the
 size of the resulting container image.  The first stage includes the
 required building blocks and GROMACS source code and then builds the
 application binary.  Build artifacts such as the application source

--- a/hpccm/cli.py
+++ b/hpccm/cli.py
@@ -53,6 +53,8 @@ def main(): # pragma: no cover
                         'recipe')
     parser.add_argument('--recipe', required=True,
                         help='generate a container spec for the RECIPE file')
+    parser.add_argument('--singularity-version', type=str, default='2.6',
+                        help='set Singularity definition file format version')
     parser.add_argument('--userarg', action=KeyValue, metavar='key=value',
                         nargs='+', help='specify user parameters')
     parser.add_argument('--version', action='version', version=__version__)
@@ -65,6 +67,7 @@ def main(): # pragma: no cover
                           ctype=hpccm.container_type[args.format.upper()],
                           raise_exceptions=args.print_exceptions,
                           single_stage=args.single_stage,
+                          singularity_version=args.singularity_version,
                           userarg=args.userarg)
     print(recipe)
 

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -33,6 +33,7 @@ from hpccm.common import linux_distro
 g_ctype = container_type.DOCKER      # Container type
 g_linux_distro = linux_distro.UBUNTU # Linux distribution
 g_linux_version = StrictVersion('16.04') # Linux distribution version
+g_singularity_version = StrictVersion('2.6') # Singularity version
 
 def set_container_format(ctype):
   """Set the container format
@@ -87,3 +88,18 @@ def set_linux_distro(distro):
     logging.warning('Unable to determine the Linux distribution, defaulting to Ubuntu')
     this.g_linux_distro = linux_distro.UBUNTU
     this.g_linux_version = StrictVersion('16.04')
+
+def set_singularity_version(ver):
+  """Set the Singularity definition file format version
+
+  The Singularity definition file format was extended in version 3.2
+  to enable multi-stage builds.  However, these changes are not
+  backwards compatible.
+
+  # Arguments
+
+  ver (string): Singularity definition file format version.
+
+  """
+  this = sys.modules[__name__]
+  this.g_singularity_version = StrictVersion(ver)

--- a/hpccm/primitives/copy.py
+++ b/hpccm/primitives/copy.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import logging  # pylint: disable=unused-import
 import os
 
@@ -167,14 +168,13 @@ class copy(object):
             #     src1 dest1
             #     src2 dest2
             #     src3 dest3
-            if self.__from:
-                logging.warning('The Docker specific "COPY --from" '
-                                'syntax was requested.  Singularity does '
-                                'not have an equivalent, so this is '
-                                'probably not going to do what you want.')
-
             section = '%files'
+            if (self.__from and
+                hpccm.config.g_singularity_version >= StrictVersion('3.2')):
+                section = section + ' from {}'.format(self.__from)
+
             if self._app:
+                # SCIF appfiles does not support "from"
                 section = '%appfiles {0}'.format(self._app)
 
             # Singularity will error if the destination does not

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -146,7 +146,7 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
             # Singularity prior to version 3.2 did not support
             # multi-stage builds.  If the Singularity version is not
             # sufficient to support multi-stage, provide advice to
-            # specific a sufficient Singularity version or disable
+            # specify a sufficient Singularity version or disable
             # multi-stage.
             if hpccm.config.g_singularity_version < StrictVersion('3.2'):
                 logging.warning('This looks like a multi-stage recipe. '

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -53,4 +53,4 @@ Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 Stage1 += baseimage(image=runtime_image)
 
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(_from='devel')

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -53,4 +53,4 @@ Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 Stage1 += baseimage(image=runtime_image)
 
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(_from='devel')

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -61,4 +61,4 @@ Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 Stage1 += baseimage(image=runtime_image)
 
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(_from='devel')

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -61,4 +61,4 @@ Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
 
 Stage1 += baseimage(image=runtime_image)
 
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(_from='devel')

--- a/recipes/milc/milc.py
+++ b/recipes/milc/milc.py
@@ -99,7 +99,7 @@ Stage0 += workdir(directory='/workspace')
 ###############################################################################
 Stage1 += baseimage(image='nvidia/cuda:9.0-base-ubuntu16.04')
 
-Stage1 += Stage0.runtime()
+Stage1 += Stage0.runtime(_from=Stage0.name)
 
 Stage1 += copy(_from=Stage0.name,
                src='/milc/milc_qcd-{}/ks_imp_rhmc/su3_rhmd_hisq'.format(

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -67,6 +67,20 @@ def singularity(function):
 
     return wrapper
 
+def singularity26(function):
+    """Decorator to set the global singularity version"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_ctype = container_type.SINGULARITY
+        hpccm.config.g_singularity_version = StrictVersion('2.6')
+        return function(*args, **kwargs)
+
+def singularity32(function):
+    """Decorator to set the global singularity version"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_ctype = container_type.SINGULARITY
+        hpccm.config.g_singularity_version = StrictVersion('3.2')
+        return function(*args, **kwargs)
+
 def ubuntu(function):
     """Decorator to set the Linux distribution to Ubuntu 16.04"""
     def wrapper(*args, **kwargs):

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import docker, invalid_ctype, singularity, singularity26, singularity32
 
 from distutils.version import StrictVersion
 import hpccm.config
@@ -84,7 +84,7 @@ From: foo''')
         b = baseimage(image='foo', AS='dev')
         self.assertEqual(str(b), 'FROM foo AS dev')
 
-    @singularity
+    @singularity26
     def test_as_deprecated_singularity(self):
         """Docker specified image naming"""
         b = baseimage(image='foo', AS='dev')
@@ -100,13 +100,24 @@ From: foo
         b = baseimage(image='foo', _as='dev')
         self.assertEqual(str(b), 'FROM foo AS dev')
 
-    @singularity
-    def test_as_singularity(self):
+    @singularity26
+    def test_as_singularity26(self):
         """Docker specified image naming"""
         b = baseimage(image='foo', _as='dev')
         self.assertEqual(str(b),
 r'''BootStrap: docker
 From: foo
+%post
+    . /.singularity.d/env/10-docker*.sh''')
+
+    @singularity32
+    def test_as_singularity32(self):
+        """Docker specified image naming"""
+        b = baseimage(image='foo', _as='dev')
+        self.assertEqual(str(b),
+r'''BootStrap: docker
+From: foo
+Stage: dev
 %post
     . /.singularity.d/env/10-docker*.sh''')
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -88,3 +88,10 @@ class Test_config(unittest.TestCase):
         self.assertEqual(hpccm.config.g_linux_distro,
                          hpccm.linux_distro.UBUNTU)
         self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+
+    @singularity
+    def test_set_singularity_version(self):
+        """Set Singularity version"""
+        hpccm.config.set_singularity_version('10.0')
+        self.assertEqual(hpccm.config.g_singularity_version,
+                         StrictVersion('10.0'))

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import docker, invalid_ctype, singularity, singularity26, singularity32
 
 from hpccm.primitives.copy import copy
 
@@ -86,11 +86,17 @@ class Test_copy(unittest.TestCase):
         c = copy(src='a', dest='b', _from='dev')
         self.assertEqual(str(c), 'COPY --from=dev a b')
 
-    @singularity
-    def test_from_singularity(self):
-        """Docker --from syntax"""
+    @singularity26
+    def test_from_singularity26(self):
+        """Singularity from syntax"""
         c = copy(src='a', dest='b', _from='dev')
         self.assertEqual(str(c), '%files\n    a b')
+
+    @singularity32
+    def test_from_singularity32(self):
+        """Singularity from syntax"""
+        c = copy(src='a', dest='b', _from='dev')
+        self.assertEqual(str(c), '%files from dev\n    a b')
 
     @singularity
     def test_appfiles_multiple_singularity(self):

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -116,11 +116,12 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
-    def test_multistage_example_singularity(self):
+    def test_multistage_example_singularity26(self):
         """Multi-stage recipe with Singularity container type"""
         path = os.path.dirname(__file__)
         rf = os.path.join(path, '..', 'recipes', 'examples', 'multistage.py')
-        r = recipe(rf, ctype=container_type.SINGULARITY)
+        r = recipe(rf, ctype=container_type.SINGULARITY,
+                   singularity_version='2.6')
         self.assertEqual(r.strip(),
 r'''BootStrap: docker
 From: nvidia/cuda:9.0-devel-ubuntu16.04
@@ -152,6 +153,72 @@ From: nvidia/cuda:9.0-devel-ubuntu16.04
     make -j$(nproc)
     make -j$(nproc) install
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
+%environment
+    export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH
+%post
+    export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
+
+    def test_multistage_example_singularity32(self):
+        """Multi-stage recipe with Singularity container type"""
+        path = os.path.dirname(__file__)
+        rf = os.path.join(path, '..', 'recipes', 'examples', 'multistage.py')
+        r = recipe(rf, ctype=container_type.SINGULARITY,
+                   singularity_version='3.2')
+        self.assertEqual(r.strip(),
+r'''# NOTE: this definition file depends on features only available in
+# Singularity 3.2 and later.
+BootStrap: docker
+From: nvidia/cuda:9.0-devel-ubuntu16.04
+Stage: devel
+%post
+    . /.singularity.d/env/10-docker*.sh
+
+# GNU compiler
+%post
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        gcc \
+        g++ \
+        gfortran
+    rm -rf /var/lib/apt/lists/*
+
+# FFTW version 3.3.8
+%post
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget
+    rm -rf /var/lib/apt/lists/*
+%post
+    cd /
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads --enable-sse2
+    make -j$(nproc)
+    make -j$(nproc) install
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
+%environment
+    export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH
+%post
+    export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH
+
+BootStrap: docker
+From: nvidia/cuda:9.0-runtime-ubuntu16.04
+%post
+    . /.singularity.d/env/10-docker*.sh
+
+# GNU compiler runtime
+%post
+    apt-get update -y
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libgomp1 \
+        libgfortran3
+    rm -rf /var/lib/apt/lists/*
+
+# FFTW
+%files from devel
+    /usr/local/fftw /usr/local/fftw
 %environment
     export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH
 %post


### PR DESCRIPTION
[Singularity 3.2](https://github.com/sylabs/singularity/releases/tag/v3.2.0-rc1) will introduce support for multi-stage builds.  The Singularity definition file format for multi-stage builds is incompatible with previous versions of Singularity.

Adds a new CLI option `--singularity-version` to specify the Singularity definition file format.  If the value is 3.2 or later, then Singularity multi-stage build sections will be included when processing a multi-stage HPCCM recipe.  A note about compatibility is also added to the resulting Singularity definition file.   If the value is less than 3.2, then a single-stage Singularity definition file will be generated, as before, with a modified warning message.  When processing a single-stage recipe, the value has no effect.  The current default Singularity version is 2.6, but envisioning updating this to 3.2 at some point in the future.

The `hpccm.config.set_singularity_version()` call is the API analogue of `--singularity-version`.

Examples:
- `hpccm --recipe recipes/milc/milc.py --format singularity` -> single-stage definition file, warning printed to stderr
- `hpccm --recipe recipes/milc/milc.py --format singularity --single-stage` -> single-stage definition file
- `hpccm --recipe recipes/milc/milc.py --format singularity --singularity-version 3.2` -> multi-stage definition file, note in the file about incompatibility with older Singularity versions

Merge is pending release of Singularity 3.2.