### PR TITLE
Declare missing package dependency in intel_psxe_runtime building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -907,9 +907,10 @@ However, the environment may differ slightly from that set by
 
 - __ospackages__: List of OS packages to install prior to installing
 Intel MPI.  For Ubuntu, the default values are
-`apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
-`openssh-client`, and `wget`.  For RHEL-based Linux distributions,
-the default values are `man-db`, `openssh-clients`, and `which`.
+`apt-transport-https`, `ca-certificates`, `gcc`, `gnupg`,
+`man-db`, `openssh-client`, and `wget`.  For RHEL-based Linux
+distributions, the default values are `man-db`, `openssh-clients`,
+and `which`.
 
 - __version__: The version of the Intel Parallel Studio XE runtime to
 install.  Due to issues in the Intel apt / yum repositories, only

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -94,9 +94,10 @@ class intel_psxe_runtime(bb_base):
 
     ospackages: List of OS packages to install prior to installing
     Intel MPI.  For Ubuntu, the default values are
-    `apt-transport-https`, `ca-certificates`, `gnupg`, `man-db`,
-    `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
-    the default values are `man-db`, `openssh-clients`, and `which`.
+    `apt-transport-https`, `ca-certificates`, `gcc`, `gnupg`,
+    `man-db`, `openssh-client`, and `wget`.  For RHEL-based Linux
+    distributions, the default values are `man-db`, `openssh-clients`,
+    and `which`.
 
     version: The version of the Intel Parallel Studio XE runtime to
     install.  Due to issues in the Intel apt / yum repositories, only
@@ -191,8 +192,8 @@ class intel_psxe_runtime(bb_base):
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
                 self.__ospackages = ['apt-transport-https', 'ca-certificates',
-                                     'gnupg', 'man-db', 'openssh-client',
-                                     'wget']
+                                     'gcc', 'gnupg', 'man-db',
+                                     'openssh-client', 'wget']
 
             self.__bashrc = '/etc/bash.bashrc'
 

--- a/test/test_intel_psxe.py
+++ b/test/test_intel_psxe.py
@@ -148,6 +148,7 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gcc \
         gnupg \
         man-db \
         openssh-client \

--- a/test/test_intel_psxe_runtime.py
+++ b/test/test_intel_psxe_runtime.py
@@ -50,6 +50,7 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gcc \
         gnupg \
         man-db \
         openssh-client \
@@ -74,6 +75,7 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
         ca-certificates \
+        gcc \
         gnupg \
         man-db \
         openssh-client \


### PR DESCRIPTION
The TBB runtime deb depends on gcc but the package does not actually declare that dependency.  So gcc must be installed prior to installing the Intel PSXE runtime on Ubuntu.