### PR TITLE
Add bash output format

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -82,6 +82,12 @@ $ sudo singularity build <image_file.sif> Singularity.def
 Other container builders that understand Dockerfiles or Singularity
 definition files may also be used.
 
+A bash script can also be generated from a recipe:
+
+```
+$ hpccm --recipe <recipe.py> --format bash > script.sh
+```
+
 ## Next Steps
 
 Go through the [tutorial](/docs/tutorial.md) for some more in depth

--- a/hpccm/cli.py
+++ b/hpccm/cli.py
@@ -44,7 +44,7 @@ def main(): # pragma: no cover
     parser = argparse.ArgumentParser(description='HPC Container Maker')
     parser.add_argument('--format', type=str, default='docker',
                         choices=[i.name.lower() for i in hpccm.container_type],
-                        help='select container format')
+                        help='select output format')
     parser.add_argument('--print-exceptions', action='store_true',
                         default=False,
                         help='print exceptions (stack traces)')

--- a/hpccm/common.py
+++ b/hpccm/common.py
@@ -22,6 +22,7 @@ class container_type(Enum):
     """Supported container types"""
     DOCKER = 1
     SINGULARITY = 2
+    BASH = 3
 
 class linux_distro(Enum):
     """Supported Linux distribution types"""

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -119,5 +119,7 @@ class baseimage(object):
                 image = image + '\n' + str(docker_env)
 
             return image
+        elif hpccm.config.g_ctype == container_type.BASH:
+            return '#!/bin/bash -ex'
         else:
             raise RuntimeError('Unknown container type')

--- a/hpccm/primitives/blob.py
+++ b/hpccm/primitives/blob.py
@@ -68,6 +68,8 @@ class blob(object):
             return self.__read_blob(self.__docker)
         if hpccm.config.g_ctype == container_type.SINGULARITY:
             return self.__read_blob(self.__singularity)
+        elif hpccm.config.g_ctype == container_type.BASH:
+            return ''
         else:
             raise RuntimeError('Unknown container type')
 

--- a/hpccm/primitives/copy.py
+++ b/hpccm/primitives/copy.py
@@ -157,7 +157,7 @@ class copy(object):
 
             return '\n'.join(instructions)
 
-        if hpccm.config.g_ctype == container_type.SINGULARITY:
+        elif hpccm.config.g_ctype == container_type.SINGULARITY:
             # Format:
             # %files
             #     src1 dest
@@ -228,6 +228,9 @@ class copy(object):
 
             return s
 
+        elif hpccm.config.g_ctype == container_type.BASH:
+            logging.warning('copy primitive does not map into bash')
+            return ''
         else:
             raise RuntimeError('Unknown container type')
 

--- a/hpccm/primitives/environment.py
+++ b/hpccm/primitives/environment.py
@@ -115,6 +115,8 @@ class environment(object):
                     environ.extend(['    export {}'.format(x)
                                     for x in keyvals])
                 return '\n'.join(environ)
+            elif hpccm.config.g_ctype == container_type.BASH:
+                return '\n'.join(['export {}'.format(x) for x in keyvals])
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/primitives/label.py
+++ b/hpccm/primitives/label.py
@@ -90,6 +90,9 @@ class label(object):
                     l = ['%labels']
                 l.extend(['    {}'.format(x) for x in keyvals])
                 return '\n'.join(l)
+            elif hpccm.config.g_ctype == container_type.BASH:
+                logging.warning('label primitive does not map into bash')
+                return ''
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/primitives/raw.py
+++ b/hpccm/primitives/raw.py
@@ -69,5 +69,7 @@ class raw(object):
             return str(self.__docker)
         elif hpccm.config.g_ctype == container_type.SINGULARITY:
             return str(self.__singularity)
+        elif hpccm.config.g_ctype == container_type.BASH:
+            return ''
         else:
             raise RuntimeError('Unknown container type')

--- a/hpccm/primitives/runscript.py
+++ b/hpccm/primitives/runscript.py
@@ -110,6 +110,9 @@ class runscript(object):
                     s = ['%runscript']
                 s.extend(['    {}'.format(x) for x in self.commands])
                 return '\n'.join(s)
+            elif hpccm.config.g_ctype == container_type.BASH:
+                logging.warning('runscript primitive does not map into bash')
+                return ''
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/primitives/shell.py
+++ b/hpccm/primitives/shell.py
@@ -126,6 +126,12 @@ class shell(object):
 
                 s.extend(['    {}'.format(x) for x in self.commands])
                 return '\n'.join(s)
+            elif hpccm.config.g_ctype == container_type.BASH:
+                s = []
+                if self.chdir:
+                    s.insert(0, 'cd /')
+                s.extend(self.commands)
+                return '\n'.join(s)
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/primitives/user.py
+++ b/hpccm/primitives/user.py
@@ -55,6 +55,8 @@ class user(object):
                 return 'USER {}'.format(self.user)
             elif hpccm.config.g_ctype == container_type.SINGULARITY:
                 return ''
+            elif hpccm.config.g_ctype == container_type.BASH:
+                return ''
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/primitives/workdir.py
+++ b/hpccm/primitives/workdir.py
@@ -59,6 +59,9 @@ class workdir(object):
                 s = shell(commands=['mkdir -p {}'.format(self.directory),
                                     'cd {}'.format(self.directory)])
                 return str(s)
+            elif hpccm.config.g_ctype == container_type.BASH:
+                logging.warning('workdir primitive does not map into bash')
+                return ''
             else:
                 raise RuntimeError('Unknown container type')
         else:

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -133,9 +133,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
     else:
         # Singularity does not support multi-stage builds.  Ignore
         # anything beyond the first stage.
-        if ctype == container_type.SINGULARITY and len(Stage1) > 0:
+        if ctype != container_type.DOCKER and len(Stage1) > 0:
             logging.warning('This looks like a multi-stage recipe, but '
-                            'Singularity does not support multi-stage builds. '
+                            'only Docker supports multi-stage builds. '
                             'Use --single-stage to get rid of this warning. '
                             'Only processing the first stage...')
             del stages[1:]

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -26,6 +26,14 @@ import hpccm.config
 
 from hpccm.common import container_type, linux_distro
 
+def bash(function):
+    """Decorator to set the global container type to bash"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_ctype = container_type.BASH
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def centos(function):
     """Decorator to set the Linux distribution to CentOS 7"""
     def wrapper(*args, **kwargs):

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from distutils.version import StrictVersion
 import hpccm.config
@@ -69,6 +69,12 @@ r'''BootStrap: docker
 From: foo
 %post
     . /.singularity.d/env/10-docker*.sh''')
+
+    @bash
+    def test_value_bash(self):
+        """Image name is specified"""
+        b = baseimage(image='foo')
+        self.assertEqual(str(b), '#!/bin/bash -ex')
 
     @singularity
     def test_false_docker_env_singularity(self):

--- a/test/test_blob.py
+++ b/test/test_blob.py
@@ -23,7 +23,7 @@ import logging # pylint: disable=unused-import
 import os
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.blob import blob
 
@@ -106,3 +106,11 @@ class Test_blob(unittest.TestCase):
 %post
     bar
 ''')
+
+    @bash
+    def test_all_bash(self):
+        """Both Docker and Singularity blobs specified"""
+        path = os.path.dirname(__file__)
+        b = blob(docker=os.path.join(path, 'docker.blob'),
+                 singularity=os.path.join(path, 'singularity.blob'))
+        self.assertEqual(str(b), '')

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.copy import copy
 
@@ -55,6 +55,12 @@ class Test_copy(unittest.TestCase):
         """Single source file specified"""
         c = copy(src='a', dest='b')
         self.assertEqual(str(c), '%files\n    a b')
+
+    @bash
+    def test_single_bash(self):
+        """Single source file specified"""
+        c = copy(src='a', dest='b')
+        self.assertEqual(str(c), '')
 
     @docker
     def test_multiple_docker(self):

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.environment import environment
 
@@ -56,6 +56,12 @@ class Test_environment(unittest.TestCase):
         e = environment(variables={'A': 'B'}, _export=False)
         self.assertEqual(str(e), '%environment\n    export A=B')
 
+    @bash
+    def test_single_bash(self):
+        """Single environment variable specified"""
+        e = environment(variables={'A': 'B'}, _export=False)
+        self.assertEqual(str(e), 'export A=B')
+
     @docker
     def test_single_export_docker(self):
         """Single environment variable specified"""
@@ -68,6 +74,12 @@ class Test_environment(unittest.TestCase):
         e = environment(variables={'A': 'B'})
         self.assertEqual(str(e),
                          '%environment\n    export A=B\n%post\n    export A=B')
+
+    @bash
+    def test_single_export_bash(self):
+        """Single environment variable specified"""
+        e = environment(variables={'A': 'B'})
+        self.assertEqual(str(e), 'export A=B')
 
     @docker
     def test_multiple_docker(self):
@@ -89,6 +101,16 @@ class Test_environment(unittest.TestCase):
     export ONE=1
     export THREE=3
     export TWO=2''')
+
+    @bash
+    def test_multiple_bash(self):
+        """Multiple environment variables specified"""
+        e = environment(variables={'ONE': 1, 'TWO': 2, 'THREE': 3},
+                        _export=False)
+        self.assertEqual(str(e),
+'''export ONE=1
+export THREE=3
+export TWO=2''')
 
     @singularity
     def test_appenv_multiple_singularity(self):

--- a/test/test_label.py
+++ b/test/test_label.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.label import label
 
@@ -55,6 +55,12 @@ class Test_label(unittest.TestCase):
         """Single label specified"""
         l = label(metadata={'A': 'B'})
         self.assertEqual(str(l), '%labels\n    A B')
+
+    @bash
+    def test_single_bash(self):
+        """Single label specified"""
+        l = label(metadata={'A': 'B'})
+        self.assertEqual(str(l), '')
 
     @docker
     def test_multiple_docker(self):

--- a/test/test_raw.py
+++ b/test/test_raw.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.raw import raw
 
@@ -79,3 +79,9 @@ class Test_raw(unittest.TestCase):
         """Both Docker and Singularity strings specified"""
         r = raw(docker='RAW string', singularity='%raw\n    string')
         self.assertEqual(str(r), '%raw\n    string')
+
+    @bash
+    def test_all_bash(self):
+        """Both Docker and Singularity strings specified"""
+        r = raw(docker='RAW string', singularity='%raw\n    string')
+        self.assertEqual(str(r), '')

--- a/test/test_runscript.py
+++ b/test/test_runscript.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.runscript import runscript
 
@@ -110,3 +110,10 @@ class Test_runscript(unittest.TestCase):
         r.append(runscript(commands=['c']))
         merged = r[0].merge(r)
         self.assertEqual(str(merged), '%runscript\n    a\n    b\n    exec c')
+
+    @bash
+    def test_bash(self):
+        """Single command specified"""
+        cmd = ['z']
+        s = runscript(commands=cmd)
+        self.assertEqual(str(s), '')

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.shell import shell
 
@@ -58,6 +58,13 @@ class Test_shell(unittest.TestCase):
         s = shell(commands=cmd)
         self.assertEqual(str(s), '%post\n    cd /\n    z')
 
+    @bash
+    def test_single_bash(self):
+        """Single command specified"""
+        cmd = ['z']
+        s = shell(commands=cmd)
+        self.assertEqual(str(s), 'cd /\nz')
+
     @docker
     def test_nochdir_docker(self):
         """chdir disable"""
@@ -72,6 +79,13 @@ class Test_shell(unittest.TestCase):
         s = shell(chdir=False, commands=cmd)
         self.assertEqual(str(s), '%post\n    z')
 
+    @bash
+    def test_nochdir_bash(self):
+        """chdir disable"""
+        cmd = ['z']
+        s = shell(chdir=False, commands=cmd)
+        self.assertEqual(str(s), 'z')
+
     @docker
     def test_multiple_docker(self):
         """List of commands specified"""
@@ -85,6 +99,13 @@ class Test_shell(unittest.TestCase):
         cmds = ['a', 'b', 'c']
         s = shell(commands=cmds)
         self.assertEqual(str(s), '%post\n    cd /\n    a\n    b\n    c')
+
+    @bash
+    def test_multiple_bash(self):
+        """List of commands specified"""
+        cmds = ['a', 'b', 'c']
+        s = shell(commands=cmds)
+        self.assertEqual(str(s), 'cd /\na\nb\nc')
 
     @singularity
     def test_appinstall_multiple_singularity(self):

--- a/test/test_user.py
+++ b/test/test_user.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.user import user
 
@@ -52,6 +52,12 @@ class Test_user(unittest.TestCase):
 
     @singularity
     def test_singularity(self):
+        """User specified"""
+        u = user(user='root')
+        self.assertEqual(str(u), '')
+
+    @bash
+    def test_bash(self):
         """User specified"""
         u = user(user='root')
         self.assertEqual(str(u), '')

--- a/test/test_workdir.py
+++ b/test/test_workdir.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, invalid_ctype, singularity
+from helpers import bash, docker, invalid_ctype, singularity
 
 from hpccm.primitives.workdir import workdir
 
@@ -55,3 +55,9 @@ class Test_workdir(unittest.TestCase):
         """Working directory specified"""
         w = workdir(directory='foo')
         self.assertEqual(str(w), '%post\n    cd /\n    mkdir -p foo\n    cd foo')
+
+    @bash
+    def test_dir_bash(self):
+        """Working directory specified"""
+        w = workdir(directory='foo')
+        self.assertEqual(str(w), '')


### PR DESCRIPTION
Generate a bash script from a HPCCM recipe.  

Note that not all container constructs, such as copying files into the container, have bash analogues and thus are omitted.