### PR TITLE
Add option to build GNU compilers from source, optionally enabling OpenACC

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -495,6 +495,10 @@ __Parameters__
 - __cc__: Boolean flag to specify whether to install `gcc`.  The default
 is True.
 
+- __configure_opts__: List of options to pass to `configure`.  The
+default value is `--disable-multilib`. This option is only
+recognized if a source build is enabled.
+
 - __cxx__: Boolean flag to specify whether to install `g++`.  The
 default is True.
 
@@ -508,6 +512,35 @@ Collections (SCL) repository.  The default is False.
 - __fortran__: Boolean flag to specify whether to install `gfortran`.
 The default is True.
 
+- __ldconfig__: Boolean flag to specify whether the GNU library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the GNU library
+directory. The default value is False. This option is only
+recognized if a source build is enabled.
+
+- __openacc__: Boolean flag to control whether a OpenACC enabled
+compiler is built. If True, adds `--with-cuda-driver` and
+`--enable-offload-targets=nvptx-none` to the list of host compiler
+`configure` options and also builds the accelerator compiler and
+dependencies (`nvptx-tools` and `nvptx-newlib`). The default value
+is False. This option is only recognized if a source build is
+enabled.
+
+- __ospackages__: List of OS packages to install prior to configuring
+and building.  For Ubuntu, the default values are `bzip2`, `file`,
+`gcc`, `g++`, `git`, `make`, `perl`, `tar`, `wget`, and
+`xz-utils`.  For RHEL-based Linux distributions, the default
+values are `bzip2`, `file`, `gcc`, `gcc-c++`, `git`, `make`,
+`perl`, `tar`, `wget`, and `xz`. This option is only recognized if
+a source build is enabled.
+
+- __prefix__: The top level install location.  The default value is
+`/usr/local/gnu`. This option is only recognized if a source build
+is enabled.
+
+- __source__: Boolean flag to control whether to build the GNU compilers
+from source. The default value is False.
+
 - __version__: The version of the GNU compilers to install.  Note that
 the version refers to the Linux distribution packaging, not the
 actual compiler version.  For Ubuntu, the version is appended to
@@ -515,7 +548,9 @@ the default package name, e.g., `gcc-7`.  For RHEL-based Linux
 distributions, the version is inserted into the SCL Developer
 Toolset package name, e.g., `devtoolset-7-gcc`.  For RHEL-based
 Linux distributions, specifying the version automatically sets
-`extra_repository` to True.  The default is an empty value.
+`extra_repository` to True.  If a source build is enabled, the
+version is the compiler tarball version on the GNU FTP site and
+the version must be specified. The default is an empty value.
 
 __Examples__
 
@@ -533,9 +568,14 @@ gnu(extra_repository=True, version='7')
 ```
 
 ```python
+gnu(openacc=True, source=True, version='9.1.0')
+```
+
+```python
 g = gnu()
 openmpi(..., toolchain=g.toolchain, ...)
 ```
+
 
 ## runtime
 ```python

--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -181,6 +181,9 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.git,
     def __build(self):
         """Build compilers from source"""
 
+        if not self.__version:
+            raise RuntimeError('The compiler version must be specified when performing a source build')
+
         # Determine which compiler frontends to build
         languages = []
         if self.__cc:
@@ -191,9 +194,6 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.git,
             languages.append('fortran')
         if self.__openacc:
             languages.append('lto')
-
-        if not self.__version:
-            raise RuntimeError('The compiler must be specified when performing a source build')
 
         # Download source from web
         tarball = 'gcc-{0}.tar.xz'.format(self.__version)
@@ -213,7 +213,7 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.git,
 
         # Configure accelerator compiler and dependencies
         if self.__openacc:
-            # nvptx-none
+            # Build nvptx-tools
             # Download
             self.__commands.append(
                 self.clone_step(repository='https://github.com/MentorEmbedded/nvptx-tools.git',

--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -286,7 +286,7 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.git,
             self.__commands.append(self.ldcache_step(
                 directory=posixpath.join(self.prefix, 'lib64')))
         else:
-            self.__environment['LD_LIBARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(posixpath.join(self.prefix, 'lib64'))
+            self.__environment['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(posixpath.join(self.prefix, 'lib64'))
 
         # Cleanup
         self.__commands.append(self.cleanup_step(

--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -21,18 +21,28 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import logging # pylint: disable=unused-import
+import posixpath
 
 import hpccm.config
+import hpccm.templates.ConfigureMake
+import hpccm.templates.git
+import hpccm.templates.ldconfig
+import hpccm.templates.rm
+import hpccm.templates.tar
+import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class gnu(bb_base):
+class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.git,
+          hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
+          hpccm.templates.wget):
     """The `gnu` building block installs the GNU compilers from the
     upstream Linux distribution.
 
@@ -44,6 +54,10 @@ class gnu(bb_base):
 
     cc: Boolean flag to specify whether to install `gcc`.  The default
     is True.
+
+    configure_opts: List of options to pass to `configure`.  The
+    default value is `--disable-multilib`. This option is only
+    recognized if a source build is enabled.
 
     cxx: Boolean flag to specify whether to install `g++`.  The
     default is True.
@@ -58,6 +72,35 @@ class gnu(bb_base):
     fortran: Boolean flag to specify whether to install `gfortran`.
     The default is True.
 
+    ldconfig: Boolean flag to specify whether the GNU library
+    directory should be added dynamic linker cache.  If False, then
+    `LD_LIBRARY_PATH` is modified to include the GNU library
+    directory. The default value is False. This option is only
+    recognized if a source build is enabled.
+
+    openacc: Boolean flag to control whether a OpenACC enabled
+    compiler is built. If True, adds `--with-cuda-driver` and
+    `--enable-offload-targets=nvptx-none` to the list of host compiler
+    `configure` options and also builds the accelerator compiler and
+    dependencies (`nvptx-tools` and `nvptx-newlib`). The default value
+    is False. This option is only recognized if a source build is
+    enabled.
+
+    ospackages: List of OS packages to install prior to configuring
+    and building.  For Ubuntu, the default values are `bzip2`, `file`,
+    `gcc`, `g++`, `git`, `make`, `perl`, `tar`, `wget`, and
+    `xz-utils`.  For RHEL-based Linux distributions, the default
+    values are `bzip2`, `file`, `gcc`, `gcc-c++`, `git`, `make`,
+    `perl`, `tar`, `wget`, and `xz`. This option is only recognized if
+    a source build is enabled.
+
+    prefix: The top level install location.  The default value is
+    `/usr/local/gnu`. This option is only recognized if a source build
+    is enabled.
+
+    source: Boolean flag to control whether to build the GNU compilers
+    from source. The default value is False.
+
     version: The version of the GNU compilers to install.  Note that
     the version refers to the Linux distribution packaging, not the
     actual compiler version.  For Ubuntu, the version is appended to
@@ -65,7 +108,9 @@ class gnu(bb_base):
     distributions, the version is inserted into the SCL Developer
     Toolset package name, e.g., `devtoolset-7-gcc`.  For RHEL-based
     Linux distributions, specifying the version automatically sets
-    `extra_repository` to True.  The default is an empty value.
+    `extra_repository` to True.  If a source build is enabled, the
+    version is the compiler tarball version on the GNU FTP site and
+    the version must be specified. The default is an empty value.
 
     # Examples
 
@@ -82,9 +127,14 @@ class gnu(bb_base):
     ```
 
     ```python
+    gnu(openacc=True, source=True, version='9.1.0')
+    ```
+
+    ```python
     g = gnu()
     openmpi(..., toolchain=g.toolchain, ...)
     ```
+
     """
 
     def __init__(self, **kwargs):
@@ -92,11 +142,19 @@ class gnu(bb_base):
 
         super(gnu, self).__init__(**kwargs)
 
+        self.__baseurl = kwargs.get('baseurl', 'http://ftpmirror.gnu.org/gcc')
         self.__cc = kwargs.get('cc', True)
+        self.configure_opts = kwargs.get('configure_opts',
+                                         ['--disable-multilib'])
         self.__cxx = kwargs.get('cxx', True)
         self.__extra_repo = kwargs.get('extra_repository', False)
         self.__fortran = kwargs.get('fortran', True)
+        self.__openacc = kwargs.get('openacc', False)
+        self.__ospackages = kwargs.get('ospackages', [])
+        self.prefix = kwargs.get('prefix', '/usr/local/gnu')
+        self.__source = kwargs.get('source', False)
         self.__version = kwargs.get('version', None)
+        self.__wd = '/var/tmp' # working directory
 
         self.__commands = []       # Filled in below
         self.__compiler_debs = []  # Filled in below
@@ -108,6 +166,188 @@ class gnu(bb_base):
 
         # Output toolchain
         self.toolchain = toolchain()
+
+        if self.__source:
+            self.__build()
+        else:
+            self.__repository()
+
+        # Set the Linux distribution specific parameters
+        self.__distro()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __build(self):
+        """Build compilers from source"""
+
+        # Determine which compiler frontends to build
+        languages = []
+        if self.__cc:
+            languages.append('c')
+        if self.__cxx:
+            languages.append('c++')
+        if self.__fortran:
+            languages.append('fortran')
+        if self.__openacc:
+            languages.append('lto')
+
+        if not self.__version:
+            raise RuntimeError('The compiler must be specified when performing a source build')
+
+        # Download source from web
+        tarball = 'gcc-{0}.tar.xz'.format(self.__version)
+        url = '{0}/gcc-{1}/{2}'.format(self.__baseurl, self.__version, tarball)
+        self.__commands.append(self.download_step(url=url,
+                                                  directory=self.__wd))
+
+        # Unpackage
+        self.__commands.append(self.untar_step(
+            tarball=posixpath.join(self.__wd, tarball),
+            directory=self.__wd))
+
+        # Download prerequisites
+        self.__commands.append(
+            'cd {} && ./contrib/download_prerequisites'.format(
+                posixpath.join(self.__wd, 'gcc-{}'.format(self.__version))))
+
+        # Configure accelerator compiler and dependencies
+        if self.__openacc:
+            # nvptx-none
+            # Download
+            self.__commands.append(
+                self.clone_step(repository='https://github.com/MentorEmbedded/nvptx-tools.git',
+                                branch='master', path=self.__wd))
+
+            # Configure
+            nvptx_tools = hpccm.templates.ConfigureMake(prefix=self.prefix)
+            self.__commands.append(nvptx_tools.configure_step(
+                directory=posixpath.join(self.__wd, 'nvptx-tools')))
+            # Build
+            self.__commands.append(nvptx_tools.build_step())
+            self.__commands.append(nvptx_tools.install_step())
+            # Cleanup
+            self.__commands.append(self.cleanup_step(
+                items=[posixpath.join(self.__wd, 'nvptx-tools')]))
+
+            # Setup nvptx-newlib
+            self.__commands.append('cd {}'.format(self.__wd))
+            self.__commands.append(
+                self.clone_step(repository='https://github.com/MentorEmbedded/nvptx-newlib',
+                                branch='master', path=self.__wd))
+            self.__commands.append('ln -s {0} {1}'.format(
+                posixpath.join(self.__wd, 'nvptx-newlib', 'newlib'),
+                posixpath.join(self.__wd, 'gcc-{}'.format(self.__version),
+                               'newlib')))
+
+            # Accelerator compiler
+
+            # Configure
+            accel = hpccm.templates.ConfigureMake(prefix=self.prefix)
+            self.__commands.append(accel.configure_step(
+                build_directory=posixpath.join(self.__wd, 'accel_objdir'),
+                directory=posixpath.join(self.__wd,
+                                         'gcc-{}'.format(self.__version)),
+                opts=['--enable-languages={}'.format(','.join(languages)),
+                      '--target=nvptx-none',
+                      '--enable-as-accelerator-for=x86_64-pc-linux-gnu',
+                      '--disable-sjlj-exceptions',
+                      '--enable-newlib-io-long-long',
+                      '--disable-multilib']))
+
+            # Build
+            self.__commands.append(accel.build_step())
+
+            # Install
+            self.__commands.append(accel.install_step())
+
+        # Configure host compiler
+        if self.__openacc:
+            self.configure_opts.extend(['--with-cuda-driver=/usr/local/cuda',
+                                        '--enable-offload-targets=nvptx-none={}/nvptx-none'.format(self.prefix)])
+
+        self.configure_opts.append('--enable-languages={}'.format(','.join(languages)))
+
+        self.__commands.append(self.configure_step(
+            build_directory=posixpath.join(self.__wd, 'objdir'),
+            directory=posixpath.join(self.__wd,
+                                     'gcc-{}'.format(self.__version))))
+
+        # Build
+        self.__commands.append(self.build_step())
+
+        # Install
+        self.__commands.append(self.install_step())
+
+        # Environment
+        self.__environment = {'PATH': '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))}
+        if self.ldconfig:
+            self.__commands.append(self.ldcache_step(
+                directory=posixpath.join(self.prefix, 'lib64')))
+        else:
+            self.__environment['LD_LIBARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(posixpath.join(self.prefix, 'lib64'))
+
+        # Cleanup
+        self.__commands.append(self.cleanup_step(
+            items=[posixpath.join(self.__wd, tarball),
+                   posixpath.join(self.__wd, 'gcc-{}'.format(self.__version)),
+                   posixpath.join(self.__wd, 'objdir')]))
+        if self.__openacc:
+            self.__commands.append(self.cleanup_step(
+                items=[posixpath.join(self.__wd, 'accel_objdir'),
+                       posixpath.join(self.__wd, 'nvptx-newlib')]))
+
+    def __distro(self):
+        """Based on the Linux distribution, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if self.__source:
+            # Build dependencies
+            if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+                self.__ospackages = ['bzip2', 'file', 'gcc', 'g++', 'git',
+                                     'make', 'perl', 'tar', 'wget', 'xz-utils']
+            elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+                self.__ospackages = ['bzip2', 'file', 'gcc', 'gcc-c++', 'git',
+                                     'make', 'perl', 'tar', 'wget', 'xz']
+            else: # pragma: no cover
+                raise RuntimeError('Unknown Linux distribution')
+
+        elif self.__version and not self.__source:
+            # Setup the environment so that the alternate compiler version
+            # is the new default
+            if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+                if self.__cc:
+                    self.__commands.append('update-alternatives --install /usr/bin/gcc gcc $(which gcc-{}) 30'.format(self.__version))
+                if self.__cxx:
+                    self.__commands.append('update-alternatives --install /usr/bin/g++ g++ $(which g++-{}) 30'.format(self.__version))
+                if self.__fortran:
+                    self.__commands.append('update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-{}) 30'.format(self.__version))
+                self.__commands.append('update-alternatives --install /usr/bin/gcov gcov $(which gcov-{}) 30'.format(self.__version))
+            elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+                self.__environment = {'PATH': '/opt/rh/devtoolset-{}/root/usr/bin:$PATH'.format(self.__version)}
+            else: # pragma: no cover
+                raise RuntimeError('Unknown Linux distribution')
+
+    def __instructions(self):
+        """Fill in container instructions"""
+        self += comment('GNU compiler')
+        if self.__source:
+            # Installing from source
+            self += packages(ospackages=self.__ospackages)
+        else:
+            # Installing from package repository
+            self += packages(apt=self.__compiler_debs,
+                             apt_ppas=self.__extra_repo_apt,
+                             scl=bool(self.__version), # True / False
+                             yum=self.__compiler_rpms)
+        if self.__commands:
+            self += shell(commands=self.__commands)
+        if self.__environment:
+            self += environment(variables=self.__environment)
+
+    def __repository(self):
+        """Setup installation from a package repository"""
 
         if self.__cc:
             self.__compiler_debs.append('gcc')
@@ -142,44 +382,6 @@ class gnu(bb_base):
                 'devtoolset-{1}-{0}'.format(x, self.__version)
                 for x in self.__compiler_rpms]
 
-        # Set the Linux distribution specific parameters
-        self.__distro()
-
-        # Fill in container instructions
-        self.__instructions()
-
-    def __distro(self):
-        """Based on the Linux distribution, set values accordingly.  A user
-        specified value overrides any defaults."""
-
-        # Setup the environment so that the alternate compiler version
-        # is the new default
-        if self.__version:
-            if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
-                if self.__cc:
-                    self.__commands.append('update-alternatives --install /usr/bin/gcc gcc $(which gcc-{}) 30'.format(self.__version))
-                if self.__cxx:
-                    self.__commands.append('update-alternatives --install /usr/bin/g++ g++ $(which g++-{}) 30'.format(self.__version))
-                if self.__fortran:
-                    self.__commands.append('update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-{}) 30'.format(self.__version))
-                self.__commands.append('update-alternatives --install /usr/bin/gcov gcov $(which gcov-{}) 30'.format(self.__version))
-            elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
-                self.__environment = {'PATH': '/opt/rh/devtoolset-{}/root/usr/bin:$PATH'.format(self.__version)}
-            else: # pragma: no cover
-                raise RuntimeError('Unknown Linux distribution')
-
-    def __instructions(self):
-        """Fill in container instructions"""
-        self += comment('GNU compiler')
-        self += packages(apt=self.__compiler_debs,
-                         apt_ppas=self.__extra_repo_apt,
-                         scl=bool(self.__version), # True / False
-                         yum=self.__compiler_rpms)
-        if self.__commands:
-            self += shell(commands=self.__commands)
-        if self.__environment:
-            self += environment(variables=self.__environment)
-
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
         components from a build in a previous stage.
@@ -194,8 +396,24 @@ class gnu(bb_base):
         """
         instructions = []
         instructions.append(comment('GNU compiler runtime'))
-        instructions.append(packages(apt=self.__runtime_debs,
-                                     apt_ppas=self.__extra_repo_apt,
-                                     scl=bool(self.__version), # True / False
-                                     yum=self.__runtime_rpms))
+        if self.__source:
+            instructions.append(copy(_from=_from,
+                                     dest=posixpath.join(self.prefix, 'lib64'),
+                                     src=posixpath.join(self.prefix, 'lib64')))
+            if self.ldconfig:
+                instructions.append(shell(
+                    commands=[self.ldcache_step(
+                        directory=posixpath.join(self.prefix, 'lib64'))]))
+            else:
+                instructions.append(environment(
+                    variables={'LD_LIBRARY_PATH':
+                               '{}:$LD_LIBRARY_PATH'.format(
+                                   posixpath.join(self.prefix, 'lib64'))}))
+        else:
+            instructions.append(
+                packages(apt=self.__runtime_debs,
+                         apt_ppas=self.__extra_repo_apt,
+                         scl=bool(self.__version), # True / False
+                         yum=self.__runtime_rpms))
+
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/templates/ConfigureMake.py
+++ b/hpccm/templates/ConfigureMake.py
@@ -59,13 +59,19 @@ class ConfigureMake(hpccm.base_object):
             parallel = self.parallel
         return 'make -j{} check'.format(parallel)
 
-    def configure_step(self, directory=None, environment=[], opts=[],
-                       toolchain=None):
+    def configure_step(self, build_directory=None, directory=None,
+                       environment=[], opts=[], toolchain=None):
         """Generate configure command line string"""
 
         change_directory = ''
+        src_directory = '.'
         if directory:
-            change_directory = 'cd {} && '.format(directory)
+            if build_directory:
+                src_directory = directory
+                change_directory = 'mkdir -p {0} && cd {0} && '.format(
+                    build_directory)
+            else:
+                change_directory = 'cd {} && '.format(directory)
 
         e = []
         e.extend(environment)
@@ -130,8 +136,9 @@ class ConfigureMake(hpccm.base_object):
             configure_opts = '--prefix={0:s} {1}'.format(self.prefix,
                                                          configure_opts)
 
-        cmd = '{0} {1} ./configure {2}'.format(change_directory,
-                                               configure_env, configure_opts)
+        cmd = '{0} {1} {3}/configure {2}'.format(change_directory,
+                                       configure_env, configure_opts,
+                                       src_directory)
 
         return cmd.strip() # trim whitespace
 

--- a/hpccm/templates/tar.py
+++ b/hpccm/templates/tar.py
@@ -50,6 +50,8 @@ class tar(hpccm.base_object):
             opts.append('-z')
         elif re.search(r'\.tgz$', tarball):
             opts.append('-z')
+        elif re.search(r'\.tar\.xz$', tarball):
+            opts.append('-J')
         elif re.search(r'\.tar$', tarball):
             pass
         else:

--- a/test/test_ConfigureMake.py
+++ b/test/test_ConfigureMake.py
@@ -73,6 +73,16 @@ class Test_ConfigureMake(unittest.TestCase):
         self.assertEqual(configure,
                          'cd /tmp/foo &&   ./configure --prefix=/usr/local')
 
+    def test_build_directory(self):
+        """Build directory specified"""
+        cm = ConfigureMake()
+
+        configure = cm.configure_step(build_directory='/tmp/build',
+                                      directory='/tmp/src')
+        # Note extra whitespace
+        self.assertEqual(configure,
+                         'mkdir -p /tmp/build && cd /tmp/build &&   /tmp/src/configure --prefix=/usr/local')
+
     def test_parallel(self):
         """Parallel count specified"""
         cm = ConfigureMake(parallel=7)

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -128,7 +128,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://f
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/gcc-9.1.0.tar.xz /var/tmp/gcc-9.1.0 /var/tmp/objdir
-ENV LD_LIBARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
+ENV LD_LIBRARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
     PATH=/usr/local/gnu/bin:$PATH''')
 
     @centos
@@ -198,7 +198,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://f
     make -j$(nproc) install && \
     rm -rf /var/tmp/gcc-9.1.0.tar.xz /var/tmp/gcc-9.1.0 /var/tmp/objdir && \
     rm -rf /var/tmp/accel_objdir /var/tmp/nvptx-newlib
-ENV LD_LIBARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
+ENV LD_LIBRARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
     PATH=/usr/local/gnu/bin:$PATH''')
 
     @ubuntu

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -96,6 +96,113 @@ ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH''')
 
     @ubuntu
     @docker
+    def test_source_no_version(self):
+        """GNU compiler from source with no version"""
+        with self.assertRaises(RuntimeError):
+            g = gnu(source=True)
+
+    @ubuntu
+    @docker
+    def test_source_ubuntu(self):
+        """GNU compiler from source"""
+        g = gnu(source=True, version='9.1.0')
+        self.assertEqual(str(g),
+r'''# GNU compiler
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        g++ \
+        gcc \
+        git \
+        make \
+        perl \
+        tar \
+        wget \
+        xz-utils && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://ftpmirror.gnu.org/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/gcc-9.1.0.tar.xz -C /var/tmp -J && \
+    cd /var/tmp/gcc-9.1.0 && ./contrib/download_prerequisites && \
+    mkdir -p /var/tmp/objdir && cd /var/tmp/objdir &&   /var/tmp/gcc-9.1.0/configure --prefix=/usr/local/gnu --disable-multilib --enable-languages=c,c++,fortran && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/gcc-9.1.0.tar.xz /var/tmp/gcc-9.1.0 /var/tmp/objdir
+ENV LD_LIBARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
+    PATH=/usr/local/gnu/bin:$PATH''')
+
+    @centos
+    @docker
+    def test_source_ldconfig_centos(self):
+        """GNU compiler from source"""
+        g = gnu(ldconfig=True, source=True, version='9.1.0')
+        self.assertEqual(str(g),
+r'''# GNU compiler
+RUN yum install -y \
+        bzip2 \
+        file \
+        gcc \
+        gcc-c++ \
+        git \
+        make \
+        perl \
+        tar \
+        wget \
+        xz && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://ftpmirror.gnu.org/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/gcc-9.1.0.tar.xz -C /var/tmp -J && \
+    cd /var/tmp/gcc-9.1.0 && ./contrib/download_prerequisites && \
+    mkdir -p /var/tmp/objdir && cd /var/tmp/objdir &&   /var/tmp/gcc-9.1.0/configure --prefix=/usr/local/gnu --disable-multilib --enable-languages=c,c++,fortran && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/gnu/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/gcc-9.1.0.tar.xz /var/tmp/gcc-9.1.0 /var/tmp/objdir
+ENV PATH=/usr/local/gnu/bin:$PATH''')
+
+    @centos
+    @docker
+    def test_source_openacc_centos(self):
+        """GNU compiler from source"""
+        g = gnu(openacc=True, source=True, version='9.1.0')
+        self.assertEqual(str(g),
+r'''# GNU compiler
+RUN yum install -y \
+        bzip2 \
+        file \
+        gcc \
+        gcc-c++ \
+        git \
+        make \
+        perl \
+        tar \
+        wget \
+        xz && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://ftpmirror.gnu.org/gcc/gcc-9.1.0/gcc-9.1.0.tar.xz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/gcc-9.1.0.tar.xz -C /var/tmp -J && \
+    cd /var/tmp/gcc-9.1.0 && ./contrib/download_prerequisites && \
+    mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://github.com/MentorEmbedded/nvptx-tools.git nvptx-tools && cd - && \
+    cd /var/tmp/nvptx-tools &&   ./configure --prefix=/usr/local/gnu && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/nvptx-tools && \
+    cd /var/tmp && \
+    mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://github.com/MentorEmbedded/nvptx-newlib nvptx-newlib && cd - && \
+    ln -s /var/tmp/nvptx-newlib/newlib /var/tmp/gcc-9.1.0/newlib && \
+    mkdir -p /var/tmp/accel_objdir && cd /var/tmp/accel_objdir &&   /var/tmp/gcc-9.1.0/configure --prefix=/usr/local/gnu --enable-languages=c,c++,fortran,lto --target=nvptx-none --enable-as-accelerator-for=x86_64-pc-linux-gnu --disable-sjlj-exceptions --enable-newlib-io-long-long --disable-multilib && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    mkdir -p /var/tmp/objdir && cd /var/tmp/objdir &&   /var/tmp/gcc-9.1.0/configure --prefix=/usr/local/gnu --disable-multilib --with-cuda-driver=/usr/local/cuda --enable-offload-targets=nvptx-none=/usr/local/gnu/nvptx-none --enable-languages=c,c++,fortran,lto && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/gcc-9.1.0.tar.xz /var/tmp/gcc-9.1.0 /var/tmp/objdir && \
+    rm -rf /var/tmp/accel_objdir /var/tmp/nvptx-newlib
+ENV LD_LIBARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH \
+    PATH=/usr/local/gnu/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         g = gnu()
@@ -107,6 +214,28 @@ RUN apt-get update -y && \
         libgfortran3 \
         libgomp1 && \
     rm -rf /var/lib/apt/lists/*''')
+
+    @centos
+    @docker
+    def test_runtime_source(self):
+        """Runtime"""
+        g = gnu(source=True, version='9.1.0')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# GNU compiler runtime
+COPY --from=0 /usr/local/gnu/lib64 /usr/local/gnu/lib64
+ENV LD_LIBRARY_PATH=/usr/local/gnu/lib64:$LD_LIBRARY_PATH''')
+
+    @centos
+    @docker
+    def test_runtime_source_ldconfig(self):
+        """Runtime"""
+        g = gnu(ldconfig=True, source=True, version='9.1.0')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# GNU compiler runtime
+COPY --from=0 /usr/local/gnu/lib64 /usr/local/gnu/lib64
+RUN echo "/usr/local/gnu/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_tar.py
+++ b/test/test_tar.py
@@ -43,6 +43,9 @@ class Test_tar(unittest.TestCase):
         self.assertEqual(t.untar_step(tarball='foo.tar.gz'),
                          'tar -x -f foo.tar.gz -z')
 
+        self.assertEqual(t.untar_step(tarball='foo.tar.xz'),
+                         'tar -x -f foo.tar.xz -J')
+
         self.assertEqual(t.untar_step(tarball='foo.tgz'),
                          'tar -x -f foo.tgz -z')
 


### PR DESCRIPTION
@tschwinge does this look okay to you?

A simple recipe with OpenACC enabled:

```
Stage0 += baseimage(image='nvidia/cuda:10.0-devel-centos7')
Stage0 += gnu(openacc=True, source=True, version='9.1.0')
```