### PR TITLE
Add multi_ofed building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2590,6 +2590,16 @@ directory should be added dynamic linker cache.  If False, then
 `LD_LIBRARY_PATH` is modified to include the UCX library
 directory. The default value is False.
 
+- __ofed__: Flag to control whether OFED is used by the build.  If True,
+adds `--with-verbs` and `--with-rdmacm` to the list of `configure`
+options.  If a string, uses the value of the string as the OFED
+path, e.g., `--with-verbs=/path/to/ofed`.  If False, adds
+`--without-verbs` and `--without-rdmacm` to the list of
+`configure` options.  The default is an empty string, i.e.,
+include neither `--with-verbs` not `--without-verbs` and let
+`configure` try to automatically detect whether OFED is present or
+not.
+
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are `binutils-dev`,
 `file`, `libnuma-dev`, `make`, and `wget`. For RHEL-based Linux

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -12,6 +12,20 @@ used instead of `apt_get`.
 __Parameters__
 
 
+- __download__: Boolean flag to specify whether to download the deb
+packages instead of installing them.  The default is False.
+
+- __download_directory__: The deb package download location. This
+parameter is ignored if `download` is False. The default value is
+`/var/tmp/apt_get_download`.
+
+- __extract__: Location where the downloaded packages should be
+extracted. Note, this extracts and does not install the packages,
+i.e., the package manager is bypassed. After the downloaded
+packages are extracted they are deleted. This parameter is ignored
+if `download` is False. If empty, then the downloaded packages are
+not extracted. The default value is an empty string.
+
 - __keys__: A list of GPG keys to add.  The default is an empty list.
 
 - __ospackages__: A list of packages to install.  The default is an
@@ -29,6 +43,7 @@ __Examples__
 ```python
 apt_get(ospackages=['make', 'wget'])
 ```
+
 
 # boost
 ```python
@@ -1455,6 +1470,63 @@ Stage0 += m
 Stage1 += m.runtime()
 ```
 
+# multi_ofed
+```python
+multi_ofed(self, **kwargs)
+```
+The `multi_ofed` building block downloads and installs multiple
+versions of the OpenFabrics Enterprise Distribution (OFED). Please
+refer to the [`mlnx_ofed`](#mlnx_ofed) and [`ofed`](#ofed)
+building blocks for more information.
+
+__Parameters__
+
+
+- __inbox__: Boolean flag to specify whether to install the 'inbox' OFED
+distributed by the Linux distribution.  The default is True.
+
+- __mlnx_oslabel__: The Linux distribution label assigned by Mellanox to
+the tarball. Please see the corresponding
+[`mlnx_ofed`](#mlnx_ofed) parameter for more information.
+
+- __mlnx_packages__: List of packages to install from Mellanox
+OFED. Please see the corresponding [`mlnx_ofed`](#mlnx_ofed)
+parameter for more information.
+
+- __mlnx_versions__: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
+versions to install.  The default values are `3.3-1.0.4.0`,
+`3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
+`4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`
+
+- __ospackages__: List of OS packages to install prior to installing
+OFED.  For Ubuntu, the default values are `libnl-3-200`,
+`libnl-route-3-200`, and `libnuma1`.  For RHEL-based Linux
+distributions, the default values are `libnl`, `libnl3`, and
+`numactl-libs`.
+
+- __prefix__: The top level install location.  The OFED packages will be
+extracted to this location as subdirectories named for the
+respective Mellanox OFED version, or `inbox` for the 'inbox'
+OFED. The environment must be manually configured to recognize the
+desired OFED location, e.g., in the container entry point. The
+default value is `/usr/local/ofed`.
+
+__Examples__
+
+
+```python
+multi_ofed(inbox=True, mlnx_versions=['4.5-1.0.1.0', '4.6-1.0.1.1'],
+           prefix='/usr/local/ofed')
+```
+
+
+## runtime
+```python
+multi_ofed.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
 # mvapich2
 ```python
 mvapich2(self, **kwargs)
@@ -1764,27 +1836,33 @@ Distribution packages that are part of the Linux distribution.
 
 For Ubuntu 16.04, the following packages are installed:
 `dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
-`libdapl-dev`, `libibcm-dev`, `libibmad5`, `libibmad-dev`,
-`libibverbs1`, `libibverbs-dev`, `libmlx4-1`, `libmlx4-dev`,
-`libmlx5-1`, `libmlx5-dev`, `librdmacm1`, `librdmacm-dev`,
-`opensm`, and `rdmacm-utils`.
+`libdapl2`, `libdapl-dev`, `libibcm1`, `libibcm-dev`, `libibmad5`,
+`libibmad-dev`, `libibverbs1`, `libibverbs-dev`, `libmlx4-1`,
+`libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`, `librdmacm1`,
+`librdmacm-dev`, and `rdmacm-utils`.
 
 For Ubuntu 18.04, the following packages are installed:
-`dapl2-utils`, `ibutils`, `ibverbs-utils`, `infiniband-diags`,
-`libdapl-dev`, `libibmad5`, `libibmad-dev`, `libibverbs1`,
-`libibverbs-dev`, `librdmacm1`, `librdmacm-dev`, `opensm`, and
-`rdmacm-utils`.
+`dapl2-utils`, `ibutils`, `ibverbs-providers`, `ibverbs-utils`,
+`infiniband-diags`, `libdapl2`, `libdapl-dev`, `libibmad5`,
+`libibmad-dev`, `libibverbs1`, `libibverbs-dev`, `librdmacm1`,
+`librdmacm-dev`, and `rdmacm-utils`.
 
 For RHEL-based Linux distributions, the following packages are
 installed: `dapl`, `dapl-devel`, `ibutils`, `libibcm`, `libibmad`,
 `libibmad-devel`, `libmlx5`, `libibumad`, `libibverbs`,
-`libibverbs-utils`, `librdmacm`, `opensm`, `rdma-core`, and
+`libibverbs-utils`, `librdmacm`, `rdma-core`, and
 `rdma-core-devel`.
 
 __Parameters__
 
 
-None
+- __prefix__: The top level install location. Install of installing the
+packages via the package manager, they will be extracted to this
+location. This option is useful if multiple versions of OFED need
+to be installed. The environment must be manually configured to
+recognize the OFED location, e.g., in the container entry
+point. The default value is empty, i.e., install via the package
+manager to the standard system locations.
 
 __Examples__
 
@@ -2004,10 +2082,24 @@ is an empty list.
 - __apt_repositories__: A list of apt repositories to add.  The default
 is an empty list.
 
+- __download__: Boolean flag to specify whether to download the deb /
+rpm packages instead of installing them.  The default is False.
+
+- __download_directory__: The deb package download location. This
+parameter is ignored if `download` is False. The default value is
+`/var/tmp/packages_download`.
+
 - __epel__: Boolean flag to specify whether to enable the Extra Packages
 for Enterprise Linux (EPEL) repository.  The default is False.
 This parameter is ignored if the Linux distribution is not
 RHEL-based.
+
+- __extract__: Location where the downloaded packages should be
+extracted. Note, this extracts and does not install the packages,
+i.e., the package manager is bypassed. After the downloaded
+packages are extracted they are deleted. This parameter is ignored
+if `download` is False. If empty, then the downloaded packages are
+not extracted. The default value is an empty string.
 
 - __ospackages__: A list of packages to install.  The list is used for
 both Ubuntu and RHEL-based Linux distributions, therefore only
@@ -2042,6 +2134,7 @@ packages(apt=['zlib1g-dev'], yum=['zlib-devel'])
 ```python
 packages(apt=['python3'], yum=['python34'], epel=True)
 ```
+
 
 # pgi
 ```python
@@ -2623,9 +2716,23 @@ be used instead of `yum`.
 __Parameters__
 
 
+- __download__: Boolean flag to specify whether to download the rpm
+packages instead of installing them.  The default is False.
+
+- __download_directory__: The deb package download location. This
+parameter is ignored if `download` is False. The default value is
+`/var/tmp/yum_download`.
+
 - __epel__: - Boolean flag to specify whether to enable the Extra
 Packages for Enterprise Linux (EPEL) repository.  The default is
 False.
+
+- __extract__: Location where the downloaded packages should be
+extracted. Note, this extracts and does not install the packages,
+i.e., the package manager is bypassed. After the downloaded
+packages are extracted they are deleted. This parameter is ignored
+if `download` is False. If empty, then the downloaded packages are
+not extracted. The default value is an empty string.
 
 - __keys__: A list of GPG keys to import.  The default is an empty list.
 
@@ -2644,4 +2751,5 @@ __Examples__
 ```python
 yum(ospackages=['make', 'wget'])
 ```
+
 

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -34,6 +34,7 @@ from hpccm.building_blocks.llvm import llvm
 from hpccm.building_blocks.mkl import mkl
 from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
 from hpccm.building_blocks.mpich import mpich
+from hpccm.building_blocks.multi_ofed import multi_ofed
 from hpccm.building_blocks.mvapich2_gdr import mvapich2_gdr
 from hpccm.building_blocks.mvapich2 import mvapich2
 from hpccm.building_blocks.netcdf import netcdf

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -208,7 +208,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                 # Prune the symlink directory itself and any debug
                 # libraries
                 self.__commands.append('find .. -path ../lib -prune -o -name "*valgrind*" -prune -o -name "lib*.so*" -exec ln -s {} \;')
-                self.__commands.append('cd {0} && ln -s usr/bin bin'.format(
+                self.__commands.append('cd {0} && ln -s usr/bin bin && ln -s usr/include include'.format(
                     self.__prefix))
         else:
             # Install in the normal system locations

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -33,6 +33,7 @@ from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
 from hpccm.primitives.shell import shell
 
 class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
@@ -218,4 +219,19 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         Stage1 += m.runtime()
         ```
         """
-        return str(self)
+        if self.__prefix:
+            instructions = []
+            instructions.append(comment('Mellanox OFED version {}'.format(
+                self.__version)))
+
+            if self.__ospackages:
+                instructions.append(packages(ospackages=self.__ospackages))
+
+            # Suppress warnings from libibverbs
+            instructions.append(shell(commands=['mkdir -p /etc/libibverbs.d']))
+
+            instructions.append(copy(_from=_from, dest=self.__prefix,
+                                     src=self.__prefix))
+            return '\n'.join(str(x) for x in instructions)
+        else:
+            return str(self)

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -96,6 +96,7 @@ class multi_ofed(bb_base):
                                            '4.6-1.0.1.1'])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/ofed')
+        self.__symlink = kwargs.get('symlink', False)
 
         self.__commands = []
 
@@ -124,11 +125,13 @@ class multi_ofed(bb_base):
             self += mlnx_ofed(oslabel=self.__mlnx_oslabel,
                               packages=self.__mlnx_packages,
                               prefix=posixpath.join(self.__prefix, version),
+                              symlink=self.__symlink,
                               version=version)
 
         # Inbox OFED
         if self.__inbox:
-            self += ofed(prefix=posixpath.join(self.__prefix, 'inbox'))
+            self += ofed(prefix=posixpath.join(self.__prefix, 'inbox'),
+                         symlink=self.__symlink)
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -132,6 +132,9 @@ class multi_ofed(bb_base):
         if self.__inbox:
             self += ofed(prefix=posixpath.join(self.__prefix, 'inbox'),
                          symlink=self.__symlink)
+            self += shell(commands=['ln -s {0} {1}'.format(
+                posixpath.join(self.__prefix, 'inbox'),
+                posixpath.join(self.__prefix, '5.0-0'))])
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""'multi' OFED building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import posixpath
+
+import hpccm.config
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
+from hpccm.building_blocks.ofed import ofed
+from hpccm.building_blocks.packages import packages
+from hpccm.common import linux_distro
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.shell import shell
+
+class multi_ofed(bb_base):
+    """The `multi_ofed` building block downloads and installs multiple
+    versions of the OpenFabrics Enterprise Distribution (OFED). Please
+    refer to the [`mlnx_ofed`](#mlnx_ofed) and [`ofed`](#ofed)
+    building blocks for more information.
+
+    # Parameters
+
+    inbox: Boolean flag to specify whether to install the 'inbox' OFED
+    distributed by the Linux distribution.  The default is True.
+
+    mlnx_oslabel: The Linux distribution label assigned by Mellanox to
+    the tarball. Please see the corresponding
+    [`mlnx_ofed`](#mlnx_ofed) parameter for more information.
+
+    mlnx_packages: List of packages to install from Mellanox
+    OFED. Please see the corresponding [`mlnx_ofed`](#mlnx_ofed)
+    parameter for more information.
+
+    mlnx_versions: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
+    versions to install.  The default values are `3.3-1.0.4.0`,
+    `3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
+    `4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`
+
+    ospackages: List of OS packages to install prior to installing
+    OFED.  For Ubuntu, the default values are `libnl-3-200`,
+    `libnl-route-3-200`, and `libnuma1`.  For RHEL-based Linux
+    distributions, the default values are `libnl`, `libnl3`, and
+    `numactl-libs`.
+
+    prefix: The top level install location.  The OFED packages will be
+    extracted to this location as subdirectories named for the
+    respective Mellanox OFED version, or `inbox` for the 'inbox'
+    OFED. The environment must be manually configured to recognize the
+    desired OFED location, e.g., in the container entry point. The
+    default value is `/usr/local/ofed`.
+
+    # Examples
+
+    ```python
+    multi_ofed(inbox=True, mlnx_versions=['4.5-1.0.1.0', '4.6-1.0.1.1'],
+               prefix='/usr/local/ofed')
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(multi_ofed, self).__init__()
+
+        self.__inbox = kwargs.get('inbox', True)
+        self.__mlnx_oslabel = kwargs.get('mlnx_oslabel', '')
+        self.__mlnx_packages = kwargs.get('mlnx_packages', [])
+        self.__mlnx_versions = kwargs.get('mlnx_versions',
+                                          ['3.3-1.0.4.0', '3.4-2.0.0.0',
+                                           '4.0-2.0.0.1', '4.1-1.0.2.0',
+                                           '4.2-1.2.0.0', '4.3-1.0.1.0',
+                                           '4.4-2.0.7.0', '4.5-1.0.1.0',
+                                           '4.6-1.0.1.1'])
+        self.__ospackages = kwargs.get('ospackages', [])
+        self.__prefix = kwargs.get('prefix', '/usr/local/ofed')
+
+        self.__commands = []
+
+        # Set the Linux distribution specific parameters
+        self.__distro()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __distro(self):
+        if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+            if not self.__ospackages:
+                self.__ospackages = ['libnl-3-200', 'libnl-route-3-200',
+                                     'libnuma1']
+        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+            if not self.__ospackages:
+                self.__ospackages = ['libnl', 'libnl3', 'numactl-libs']
+        else: # pragma: no cover
+            raise RuntimeError('Unknown Linux distribution')
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        # Mellanox OFED
+        for version in self.__mlnx_versions:
+            self += mlnx_ofed(oslabel=self.__mlnx_oslabel,
+                              packages=self.__mlnx_packages,
+                              prefix=posixpath.join(self.__prefix, version),
+                              version=version)
+
+        # Inbox OFED
+        if self.__inbox:
+            self += ofed(prefix=posixpath.join(self.__prefix, 'inbox'))
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+        """
+
+        instructions = []
+        instructions.append(comment('OFED'))
+
+        if self.__ospackages:
+            instructions.append(packages(ospackages=self.__ospackages))
+
+        # Suppress warnings from libibverbs
+        instructions.append(shell(commands=['mkdir -p /etc/libibverbs.d']))
+
+        instructions.append(copy(_from=_from, dest=self.__prefix,
+                                 src=self.__prefix))
+        return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -147,7 +147,7 @@ class ofed(bb_base):
                 # Prune the symlink directory itself and any debug
                 # libraries
                 commands.append('find .. -path ../lib -prune -o -name "*valgrind*" -prune -o -name "lib*.so*" -exec ln -s {} \;')
-                commands.append('cd {0} && ln -s usr/bin bin'.format(
+                commands.append('cd {0} && ln -s usr/bin bin && ln -s usr/include include'.format(
                     self.__prefix))
 
             # Suppress warnings from libibverbs

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -52,10 +52,24 @@ class packages(bb_base):
     apt_repositories: A list of apt repositories to add.  The default
     is an empty list.
 
+    download: Boolean flag to specify whether to download the deb /
+    rpm packages instead of installing them.  The default is False.
+
+    download_directory: The deb package download location. This
+    parameter is ignored if `download` is False. The default value is
+    `/var/tmp/packages_download`.
+
     epel: Boolean flag to specify whether to enable the Extra Packages
     for Enterprise Linux (EPEL) repository.  The default is False.
     This parameter is ignored if the Linux distribution is not
     RHEL-based.
+
+    extract: Location where the downloaded packages should be
+    extracted. Note, this extracts and does not install the packages,
+    i.e., the package manager is bypassed. After the downloaded
+    packages are extracted they are deleted. This parameter is ignored
+    if `download` is False. If empty, then the downloaded packages are
+    not extracted. The default value is an empty string.
 
     ospackages: A list of packages to install.  The list is used for
     both Ubuntu and RHEL-based Linux distributions, therefore only
@@ -89,6 +103,7 @@ class packages(bb_base):
     ```python
     packages(apt=['python3'], yum=['python34'], epel=True)
     ```
+
     """
 
     def __init__(self, **kwargs):
@@ -100,6 +115,10 @@ class packages(bb_base):
         self.__apt_keys = kwargs.get('apt_keys', [])
         self.__apt_ppas = kwargs.get('apt_ppas', [])
         self.__apt_repositories = kwargs.get('apt_repositories', [])
+        self.__download = kwargs.get('download', False)
+        self.__download_directory = kwargs.get('download_directory',
+                                               '/var/tmp/packages_download')
+        self.__extract = kwargs.get('extract', None)
         self.__epel = kwargs.get('epel', False)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__scl = kwargs.get('scl', False)
@@ -114,21 +133,33 @@ class packages(bb_base):
         """String representation of the building block"""
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if self.__apt:
-                self += apt_get(keys=self.__apt_keys, ospackages=self.__apt,
+                self += apt_get(download=self.__download,
+                                download_directory=self.__download_directory,
+                                extract=self.__extract,
+                                keys=self.__apt_keys, ospackages=self.__apt,
                                 ppas=self.__apt_ppas,
                                 repositories=self.__apt_repositories)
             else:
-                self += apt_get(keys=self.__apt_keys,
+                self += apt_get(download=self.__download,
+                                download_directory=self.__download_directory,
+                                extract=self.__extract,
+                                keys=self.__apt_keys,
                                 ospackages=self.__ospackages,
                                 ppas=self.__apt_ppas,
                                 repositories=self.__apt_repositories)
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if self.__yum:
-                self += yum(epel=self.__epel, keys=self.__yum_keys,
+                self += yum(download=self.__download,
+                            download_directory=self.__download_directory,
+                            extract=self.__extract, epel=self.__epel,
+                            keys=self.__yum_keys,
                             ospackages=self.__yum, scl=self.__scl,
                             repositories=self.__yum_repositories)
             else:
-                self += yum(epel=self.__epel, keys=self.__yum_keys,
+                self += yum(download=self.__download,
+                            download_directory=self.__download_directory,
+                            extract=self.__extract,
+                            epel=self.__epel, keys=self.__yum_keys,
                             ospackages=self.__ospackages, scl=self.__scl,
                             repositories=self.__yum_repositories)
         else:

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -93,6 +93,16 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     `LD_LIBRARY_PATH` is modified to include the UCX library
     directory. The default value is False.
 
+    ofed: Flag to control whether OFED is used by the build.  If True,
+    adds `--with-verbs` and `--with-rdmacm` to the list of `configure`
+    options.  If a string, uses the value of the string as the OFED
+    path, e.g., `--with-verbs=/path/to/ofed`.  If False, adds
+    `--without-verbs` and `--without-rdmacm` to the list of
+    `configure` options.  The default is an empty string, i.e.,
+    include neither `--with-verbs` not `--without-verbs` and let
+    `configure` try to automatically detect whether OFED is present or
+    not.
+
     ospackages: List of OS packages to install prior to configuring
     and building.  For Ubuntu, the default values are `binutils-dev`,
     `file`, `libnuma-dev`, `make`, and `wget`. For RHEL-based Linux
@@ -148,6 +158,7 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__cuda = kwargs.get('cuda', True)
         self.__gdrcopy = kwargs.get('gdrcopy', '')
         self.__knem = kwargs.get('knem', '')
+        self.__ofed = kwargs.get('ofed', '')
         self.__ospackages = kwargs.get('ospackages', [])
         self.__toolchain = kwargs.get('toolchain', toolchain())
         self.__version = kwargs.get('version', '1.4.0')
@@ -236,6 +247,19 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
                 self.configure_opts.append('--with-knem')
         elif self.__knem == False:
             self.configure_opts.append('--without-knem')
+
+        # OFED
+        if self.__ofed:
+            if isinstance(self.__ofed, string_types):
+                # Use specified path
+                self.configure_opts.extend(
+                    ['--with-verbs={}'.format(self.__ofed),
+                     '--with-rdmacm={}'.format(self.__ofed)])
+            else:
+                # Boolean, let UCX try to figure out where to find it
+                self.configure_opts.extend(['--with-verbs', '--with-rdmacm'])
+        elif self.__ofed == False:
+            self.configure_opts.extend(['--without-verbs', '--without-rdmacm'])
 
         # XPMEM
         if self.__xpmem:

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -24,6 +24,7 @@ generate:
   - hpccm.building_blocks.mkl+
   - hpccm.building_blocks.mlnx_ofed+
   - hpccm.building_blocks.mpich+
+  - hpccm.building_blocks.multi_ofed+
   - hpccm.building_blocks.mvapich2+
   - hpccm.building_blocks.mvapich2_gdr+
   - hpccm.building_blocks.netcdf+

--- a/test/test_apt_get.py
+++ b/test/test_apt_get.py
@@ -58,3 +58,32 @@ r'''RUN wget -qO - https://www.example.com/key.pub | apt-key add - && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         example && \
     rm -rf /var/lib/apt/lists/*''')
+
+    @ubuntu
+    @docker
+    def test_download(self):
+        """Download parameter"""
+        a = apt_get(download=True, download_directory='/tmp/download',
+                    ospackages=['libibverbs1'])
+        self.assertEqual(str(a),
+r'''RUN apt-get update -y && \
+    mkdir -m 777 -p /tmp/download && cd /tmp/download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+        libibverbs1 && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    @ubuntu
+    @docker
+    def test_extract(self):
+        """Extract parameter"""
+        a = apt_get(download=True, extract='/usr/local/ofed',
+                    ospackages=['libibverbs1'])
+        self.assertEqual(str(a),
+r'''RUN apt-get update -y && \
+    mkdir -m 777 -p /var/tmp/apt_get_download && cd /var/tmp/apt_get_download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+        libibverbs1 && \
+    mkdir -p /usr/local/ofed && \
+    find /var/tmp/apt_get_download -regextype posix-extended -type f -regex "/var/tmp/apt_get_download/(libibverbs1).*deb" -exec dpkg --extract {} /usr/local/ofed \; && \
+    rm -rf /var/tmp/apt_get_download && \
+    rm -rf /var/lib/apt/lists/*''')

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -187,21 +187,5 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    mkdir -p /etc/libibverbs.d && \
-    mkdir -p /opt/ofed && cd /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+RUN mkdir -p /etc/libibverbs.d
+COPY --from=0 /opt/ofed /opt/ofed''')

--- a/test/test_multi_ofed.py
+++ b/test/test_multi_ofed.py
@@ -1,0 +1,159 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the multi_ofed module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu, ubuntu18
+
+from hpccm.building_blocks.multi_ofed import multi_ofed
+
+class Test_multi_ofed(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @ubuntu
+    @docker
+    def test_versions_ubuntu(self):
+        """mlnx_version parameter"""
+        # Reduced set of versions to limit gold output
+        ofed = multi_ofed(mlnx_versions=['4.5-1.0.1.0', '4.6-1.0.1.1'])
+        self.assertEqual(str(ofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    mkdir -p /etc/libibverbs.d && \
+    mkdir -p /usr/local/ofed/4.5-1.0.1.0 && cd /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /usr/local/ofed/4.5-1.0.1.0 && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64
+# Mellanox OFED version 4.6-1.0.1.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    mkdir -p /etc/libibverbs.d && \
+    mkdir -p /usr/local/ofed/4.6-1.0.1.1 && cd /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /usr/local/ofed/4.6-1.0.1.1 && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64
+# OFED
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 && \
+    rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && \
+    mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+        dapl2-utils \
+        ibutils \
+        ibverbs-utils \
+        infiniband-diags \
+        libdapl-dev \
+        libdapl2 \
+        libibcm-dev \
+        libibcm1 \
+        libibmad-dev \
+        libibmad5 \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 \
+        rdmacm-utils && \
+    mkdir -p /usr/local/ofed/inbox && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(dapl2-utils|ibutils|ibverbs-utils|infiniband-diags|libdapl-dev|libdapl2|libibcm-dev|libibcm1|libibmad-dev|libibmad5|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1|rdmacm-utils).*deb" -exec dpkg --extract {} /usr/local/ofed/inbox \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d''')
+
+    @centos
+    @docker
+    def test_runtime_centos(self):
+        """Runtime"""
+        ofed = multi_ofed()
+        r = ofed.runtime()
+        self.assertEqual(r,
+r'''# OFED
+RUN yum install -y \
+        libnl \
+        libnl3 \
+        numactl-libs && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /etc/libibverbs.d
+COPY --from=0 /usr/local/ofed /usr/local/ofed''')
+
+    @ubuntu
+    @docker
+    def test_runtime_ubuntu(self):
+        """Runtime"""
+        ofed = multi_ofed()
+        r = ofed.runtime()
+        self.assertEqual(r,
+r'''# OFED
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d
+COPY --from=0 /usr/local/ofed /usr/local/ofed''')

--- a/test/test_multi_ofed.py
+++ b/test/test_multi_ofed.py
@@ -123,7 +123,8 @@ RUN apt-get update -y && \
     find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(dapl2-utils|ibutils|ibverbs-utils|infiniband-diags|libdapl-dev|libdapl2|libibcm-dev|libibcm1|libibmad-dev|libibmad5|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1|rdmacm-utils).*deb" -exec dpkg --extract {} /usr/local/ofed/inbox \; && \
     rm -rf /var/tmp/packages_download && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /etc/libibverbs.d''')
+RUN mkdir -p /etc/libibverbs.d
+RUN ln -s /usr/local/ofed/inbox /usr/local/ofed/5.0-0''')
 
     @centos
     @docker

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -82,7 +82,8 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     @docker
     def test_with_paths_ubuntu(self):
         """ucx building block with paths"""
-        u = ucx(cuda='/cuda', gdrcopy='/gdrcopy', knem='/knem', xpmem='/xpmem')
+        u = ucx(cuda='/cuda', gdrcopy='/gdrcopy', knem='/knem', ofed='/ofed',
+                xpmem='/xpmem')
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
@@ -95,7 +96,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-xpmem=/xpmem && \
+    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-verbs=/ofed --with-rdmacm=/ofed --with-xpmem=/xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
@@ -106,7 +107,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     @docker
     def test_with_true_ubuntu(self):
         """ucx building block with True values"""
-        u = ucx(cuda=True, gdrcopy=True, knem=True, xpmem=True)
+        u = ucx(cuda=True, gdrcopy=True, knem=True, ofed=True, xpmem=True)
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
@@ -119,7 +120,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-xpmem && \
+    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-verbs --with-rdmacm --with-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
@@ -130,7 +131,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     @docker
     def test_with_false_ubuntu(self):
         """ucx building block with False values"""
-        u = ucx(cuda=False, gdrcopy=False, knem=False, xpmem=False)
+        u = ucx(cuda=False, gdrcopy=False, knem=False, ofed=False, xpmem=False)
         self.assertEqual(str(u),
 r'''# UCX version 1.4.0
 RUN apt-get update -y && \
@@ -143,7 +144,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --without-cuda --without-gdrcopy --without-knem --without-xpmem && \
+    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --without-cuda --without-gdrcopy --without-knem --without-verbs --without-rdmacm --without-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0

--- a/test/test_yum.py
+++ b/test/test_yum.py
@@ -56,3 +56,32 @@ r'''RUN rpm --import https://www.example.com/key.pub && \
     yum install -y \
         example && \
     rm -rf /var/cache/yum/*''')
+
+    @centos
+    @docker
+    def test_download(self):
+        """Download parameter"""
+        y = yum(download=True, download_directory='/tmp/download',
+                ospackages=['rdma-core'])
+        self.assertEqual(str(y),
+r'''RUN yum install -y yum-utils && \
+    mkdir -p /tmp/download && \
+    yumdownloader --destdir=/tmp/download -x \*i?86 --archlist=x86_64 \
+        rdma-core && \
+    rm -rf /var/cache/yum/*''')
+
+    @centos
+    @docker
+    def test_extract(self):
+        """Extract parameter"""
+        y = yum(download=True, extract='/usr/local/ofed',
+                ospackages=['rdma-core'])
+        self.assertEqual(str(y),
+r'''RUN yum install -y yum-utils && \
+    mkdir -p /var/tmp/yum_download && \
+    yumdownloader --destdir=/var/tmp/yum_download -x \*i?86 --archlist=x86_64 \
+        rdma-core && \
+    mkdir -p /usr/local/ofed && cd /usr/local/ofed && \
+    find /var/tmp/yum_download -regextype posix-extended -type f -regex "/var/tmp/yum_download/(rdma-core).*rpm" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
+    rm -rf /var/tmp/yum_download && \
+    rm -rf /var/cache/yum/*''')


### PR DESCRIPTION
Add a new building block to install multiple versions of OFED. 

An example use case is a container entrypoint that detects the host IB kernel module version at runtime and sets up the container environment to use the corresponding OFED user space library.

To support this, enhances the package management building blocks (`apt_get`, `packages`, and `yum`) to support downloading and optionally extracting a package instead of installing it.

The `ofed` building block has also been enhanced to "install" at a specified prefix.

A `ofed` option has been added to `ucx` building block to control whether OFED is used in the build and where to find it.