### PR TITLE
Add envvars template

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -43,6 +43,10 @@ __Parameters__
 - __bootstrap_opts__: List of options to pass to `bootstrap.sh`.  The
 default is an empty list.
 
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`) should be modified to include Boost. The
+default is True.
+
 - __ldconfig__: Boolean flag to specify whether the Boost library
 directory should be added dynamic linker cache.  If False, then
 `LD_LIBRARY_PATH` is modified to include the Boost library
@@ -111,9 +115,6 @@ this building block.
 A MPI building block should be installed prior to this building
 block.
 
-As a side effect, this building block modifies `PATH` to include
-the Catalyst build.
-
 If GPU rendering will be used then a
 [cudagl](https://hub.docker.com/r/nvidia/cudagl) base image is
 recommended.
@@ -134,6 +135,10 @@ Python edition is selected, then the [Python](#python) building
 block should be installed with development libraries prior to this
 building block. The default value is
 `Base-Enable-Python-Essentials-Extras-Rendering-Base`.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+ParaView Catalyst. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the Catalyst library
 directory should be added dynamic linker cache.  If False, then
@@ -249,15 +254,15 @@ charm(self, **kwargs)
 The `charm` building block downloads and install the
 [Charm++](http://charm.cs.illinois.edu/research/charm) component.
 
-As a side effect, this building block modifies `PATH` to include
-the Charm++ build.  It also sets the `CHARMBASE` environment
-variable to the top level install directory.
-
 __Parameters__
 
 
 - __check__: Boolean flag to specify whether the test cases should be
 run.  The default is False.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and other variables) should be
+modified to include Charm++. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the Charm++ library
 directory should be added dynamic linker cache.  If False, then
@@ -368,6 +373,10 @@ local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
 
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`) should be modified to include FFTW. The
+default is True.
+
 - __ldconfig__: Boolean flag to specify whether the FFTW library
 directory should be added dynamic linker cache.  If False, then
 `LD_LIBRARY_PATH` is modified to include the FFTW library
@@ -435,11 +444,12 @@ The `gdrcopy` building block builds and installs the user space
 library from the [gdrcopy](https://github.com/NVIDIA/gdrcopy)
 component.
 
-As a side effect, this building block modifies `CPATH` and
-`LIBRARY_PATH`.
-
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`CPATH`, `LIBRARY_PATH`, and `LD_LIBRARY_PATH`) should be
+modified to include the gdrcopy. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the gdrcopy library
 directory should be added dynamic linker cache.  If False, then
@@ -461,6 +471,7 @@ __Examples__
 ```python
 gdrcopy(prefix='/opt/gdrcopy/1.3', version='1.3')
 ```
+
 
 ## runtime
 ```python
@@ -501,6 +512,10 @@ recognized if a source build is enabled.
 
 - __cxx__: Boolean flag to specify whether to install `g++`.  The
 default is True.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+the GNU compiler. The default is True.
 
 - __extra_repository__: Boolean flag to specify whether to enable an
 extra package repository containing addition GNU compiler
@@ -603,9 +618,6 @@ on the parameters, the source will be downloaded from the web
 (default) or copied from a source directory in the local build
 context.
 
-As a side effect, this building block modifies `PATH`
-to include the HDF5 build, and sets `HDF5_DIR`.
-
 __Parameters__
 
 
@@ -619,6 +631,10 @@ default values are `--enable-cxx` and `--enable-fortran`.
 local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+include HDF5. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the HDF5 library
 directory should be added dynamic linker cache.  If False, then
@@ -688,13 +704,12 @@ MPI Library](https://software.intel.com/en-us/intel-mpi-library).
 You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
 to use this building block.
 
-As a side effect, this building block modifies `PATH`,
-`LD_LIBRARY_PATH`, and other environment variables to include
-Intel MPI.  Please see the `mpivars` parameter for more
-information.
-
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+include Intel MPI. `mpivars` has precedence. The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
 The default value is `False`.
@@ -757,9 +772,6 @@ XE](https://software.intel.com/en-us/parallel-studio-xe).
 You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
 to use this building block.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH`.
-
 __Parameters__
 
 
@@ -776,6 +788,11 @@ Acceleration Library environment should be configured when
 - __the corresponding runtime in the `runtime` method.  Note__: this
 flag does not control whether the developer environment is
 installed; see `components`.  The default is True.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+include Intel Parallel Studio XE. `psxevars` has precedence. The
+default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
 The default value is `False`.
@@ -894,11 +911,6 @@ Parallel Studio XE runtime](https://software.intel.com/en-us/articles/intel-para
 You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
 to use this building block.
 
-As a side effect, this building block modifies `PATH`,
-`LD_LIBRARY_PATH`, and other environment variables to include the
-Intel Parallel Studio XE runtime.  Please see the `psxevars`
-parameter for more information.
-
 Note: this building block does *not* install development versions
 of the Intel software tools.  Please see the
 [intel_psxe](#intel_psxe), [intel_mpi](#intel_mpi), or [mkl](#mkl)
@@ -910,6 +922,11 @@ __Parameters__
 - __daal__: Boolean flag to specify whether the Intel Data Analytics
 Acceleration Library runtime should be installed.  The default is
 True.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+include Intel Parallel Studio XE runtime. `psxevars` has
+precedence. The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
 The default value is `False`.
@@ -996,11 +1013,11 @@ knem(self, **kwargs)
 The `knem` building block install the headers from the
 [KNEM](http://knem.gforge.inria.fr) component.
 
-As a side effect, this building block modifies `CPATH`,
-`LD_LIBRARY_PATH`, and `LIBRARY_PATH`.
-
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`CPATH`) should be modified to include knem. The default is True.
 
 - __ospackages__: List of OS packages to install prior to installing.
 The default values are `ca-certificates` and `git`.
@@ -1017,6 +1034,7 @@ __Examples__
 ```python
 knem(prefix='/opt/knem/1.1.3', version='1.1.3')
 ```
+
 
 ## runtime
 ```python
@@ -1053,6 +1071,10 @@ build is not selected, then a non-default value should be used.
 True, adds `--with-cuda` to the list of `generate_makefile.bash`
 options.  If a string, uses the value of the string as the CUDA
 path.  If False, does nothing.  The default value is True.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+Kokkos. The default is True.
 
 - __hwloc__: Flag to control whether a hwloc aware build is performed.
 If True, adds `--with-hwloc` to the list of
@@ -1108,15 +1130,16 @@ The `libsim` building block configures, builds, and installs the
 Libsim](http://www.visitusers.org/index.php?title=Libsim_Batch)
 component.
 
-As a side effect, this building block modifies `PATH` to include
-the Libsim build.
-
 If GPU rendering will be used then a
 [cudagl](https://hub.docker.com/r/nvidia/cudagl) base image is
 recommended.
 
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+Libsim. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the Libsim library
 directories should be added dynamic linker cache.  If False, then
@@ -1203,6 +1226,10 @@ want to build using the LLVM compilers.
 __Parameters__
 
 
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include the
+LLVM compilers. The default is True.
+
 - __extra_repository__: Boolean flag to specify whether to enable an
 extra package repository containing addition LLVM compiler
 packages.  For Ubuntu, setting this flag to True enables the
@@ -1236,6 +1263,7 @@ l = llvm()
 openmpi(..., toolchain=l.toolchain, ...)
 ```
 
+
 ## runtime
 ```python
 llvm.runtime(self, _from=u'0')
@@ -1262,12 +1290,12 @@ Kernel Library](http://software.intel.com/mkl).
 You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
 to use this building block.
 
-As a side effect, this building block modifies `LIBRARY_PATH`,
-`LD_LIBRARY_PATH`, and other environment variables to include MKL.
-Please see the `mklvars` parameter for more information.
-
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and other variables) should be
+modified to include MKL. The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
 The default value is `False`.
@@ -1300,6 +1328,7 @@ __Examples__
 ```python
 mkl(eula=True, version='2018.3-051')
 ```
+
 
 ## runtime
 ```python
@@ -1391,9 +1420,6 @@ mpich(self, **kwargs)
 The `mpich` building block configures, builds, and installs the
 [MPICH](https://www.mpich.org) component.
 
-As a side effect, this building block modifies `PATH` to include
-the MPICH build.
-
 As a side effect, a toolchain is created containing the MPI
 compiler wrappers.  The tool can be passed to other operations
 that want to build using the MPI compiler wrappers.
@@ -1406,6 +1432,10 @@ testing` steps should be performed.  The default is False.
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default is an empty list.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+MPICH. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the MPICH library
 directory should be added dynamic linker cache.  If False, then
@@ -1469,9 +1499,6 @@ An InfiniBand building block ([OFED](#ofed) or [Mellanox
 OFED](#mlnx_ofed)) should be installed prior to this building
 block.
 
-As a side effect, this building block modifies `PATH`
-to include the MVAPICH2 build.
-
 As a side effect, a toolchain is created containing the MPI
 compiler wrappers.  The tool can be passed to other operations
 that want to build using the MPI compiler wrappers.
@@ -1496,6 +1523,10 @@ True.
 the local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+MVAPICH2. The default is True.
 
 - __gpu_arch__: The GPU architecture to use.  Older versions of MVAPICH2
 (2.3b and previous) were hard-coded to use "sm_20".  This option
@@ -1582,9 +1613,6 @@ prior to this building block.
 The [gdrcopy](#gdrcopy) building block should be installed prior
 to this building block.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the MVAPICH2-GDR build.
-
 As a side effect, a toolchain is created containing the MPI
 compiler wrappers.  The toolchain can be passed to other
 operations that want to build using the MPI compiler wrappers.
@@ -1600,6 +1628,10 @@ __Parameters__
 built against.  The version string format is X.Y.  The version
 should match the version of CUDA provided by the base image.  This
 value is ignored if `package` is set.  The default value is `9.2`.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+MVAPICH2-GDR. The default is True.
 
 - __gnu__: Boolean flag to specify whether a GNU build should be used.
 The default value is True.
@@ -1677,9 +1709,6 @@ installs the
 The [HDF5](#hdf5) building block should be installed prior to this
 building block.
 
-As a side effect, this building block modifies `PATH` to include
-the NetCDF build.
-
 __Parameters__
 
 
@@ -1691,6 +1720,10 @@ default value is an empty list.
 
 - __cxx__: Boolean flag to specify whether the NetCDF C++ library should
 be installed.  The default is True.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+NetCDF. The default is True.
 
 - __fortran__: Boolean flag to specify whether the NetCDF Fortran
 library should be installed.  The default is True.
@@ -1820,6 +1853,10 @@ The `openblas` building block builds and installs the
 __Parameters__
 
 
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+OpenBLAS. The default is True.
+
 - __ldconfig__: Boolean flag to specify whether the OpenBLAS library
 directory should be added dynamic linker cache.  If False, then
 `LD_LIBRARY_PATH` is modified to include the OpenBLAS library
@@ -1853,6 +1890,7 @@ p = pgi(eula=True)
 openblas(toolchain=p.toolchain)
 ```
 
+
 ## runtime
 ```python
 openblas.runtime(self, _from=u'0')
@@ -1878,9 +1916,6 @@ The `openmpi` building block configures, builds, and installs the
 parameters, the source will be downloaded from the web (default)
 or copied from a source directory in the local build context.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the OpenMPI build.
-
 As a side effect, a toolchain is created containing the MPI
 compiler wrappers.  The tool can be passed to other operations
 that want to build using the MPI compiler wrappers.
@@ -1905,6 +1940,10 @@ is True.
 local build context.  The default value is empty.  If this is
 defined, the source in the local build context will be used rather
 than downloading the source from the web.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+OpenMPI. The default is True.
 
 - __infiniband__: Boolean flag to control whether InfiniBand
 capabilities are included.  If True, adds `--with-verbs` to the
@@ -2054,15 +2093,17 @@ edition.
 You must agree to the [PGI End-User License Agreement](https://www.pgroup.com/doc/LICENSE.txt) to use this
 building block.
 
-As a side effect, this building block modifies `PATH` and
-`LD_LIBRARY_PATH` to include the PGI compiler.
-
 As a side effect, a toolchain is created containing the PGI
 compilers.  The tool can be passed to other operations that want
 to build using the PGI compilers.
 
 __Parameters__
 
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH`, `PATH`, and potentially other variables)
+should be modified to include the PGI compiler. The default is
+True.
 
 - __eula__: By setting this value to `True`, you agree to the [PGI End-User License Agreement](https://www.pgroup.com/doc/LICENSE.txt).
 The default value is `False`.
@@ -2123,6 +2164,7 @@ pgi(eula=True, tarball='pgilinux-2017-1710-x86_64.tar.gz')
 p = pgi(eula=True)
 openmpi(..., toolchain=p.toolchain, ...)
 ```
+
 
 ## runtime
 ```python
@@ -2187,9 +2229,6 @@ installs the
 [PnetCDF](http://cucis.ece.northwestern.edu/projects/PnetCDF/index.html)
 component.
 
-As a side effect, this building block modifies `PATH` to include
-the PnetCDF build.
-
 __Parameters__
 
 
@@ -2198,6 +2237,10 @@ should be performed.  The default is False.
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default values are `--enable-shared`.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+PnetCDF. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the PnetCDF library
 directory should be added dynamic linker cache.  If False, then
@@ -2229,6 +2272,7 @@ pnetcdf(prefix='/opt/pnetcdf/1.10.0', version='1.10.0')
 ompi = openmpi(...)
 pnetcdf(toolchain=ompi.toolchain, ...)
 ```
+
 
 ## runtime
 ```python
@@ -2456,9 +2500,6 @@ block.  One or all of the [gdrcopy](#gdrcopy), [KNEM](#knem), and
 [XPMEM](#xpmem) building blocks should also be installed prior to
 this building block.
 
-As a side effect, this building block modifies `PATH`
-to include the UCX build.
-
 __Parameters__
 
 
@@ -2473,6 +2514,10 @@ True, adds `--with-cuda=/usr/local/cuda` to the list of
 the CUDA path.  If the toolchain specifies `CUDA_HOME`, then that
 path is used.  If False, adds `--without-cuda` to the list of
 `configure` options.  The default value is an empty string.
+
+- __environment__: Boolean flag to specify whether the environment
+(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+UCX. The default is True.
 
 - __gdrcopy__: Flag to control whether gdrcopy is used by the build.  If
 True, adds `--with-gdrcopy` to the list of `configure` options.
@@ -2534,6 +2579,7 @@ ucx(cuda='/usr/local/cuda', gdrcopy='/usr/local/gdrcopy',
     knem='/usr/local/knem', xpmem='/usr/local/xpmem')
 ```
 
+
 ## runtime
 ```python
 ucx.runtime(self, _from=u'0')
@@ -2558,9 +2604,6 @@ The `xpmem` building block builds and installs the user space
 library from the [XPMEM](https://gitlab.com/hjelmn/xpmem)
 component.
 
-As a side effect, this building block modifies `CPATH` and
-`LIBRARY_PATH`.
-
 __Parameters__
 
 
@@ -2569,6 +2612,10 @@ __Parameters__
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default values are `--disable-kernel-module`.
+
+- __environment__: Boolean flag to specify whether the environment
+(`CPATH`, `LD_LIBRARY_PATH` and `LIBRARY_PATH`) should be modified
+to include XPMEM. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the XPMEM library
 directory should be added dynamic linker cache.  If False, then
@@ -2592,6 +2639,7 @@ __Examples__
 ```python
 xpmem(prefix='/opt/xpmem', branch='master')
 ```
+
 
 ## runtime
 ```python

--- a/hpccm/building_blocks/base.py
+++ b/hpccm/building_blocks/base.py
@@ -54,4 +54,4 @@ class bb_base(hpccm.base_object):
 
     def __str__(self):
         """String representation of the building block"""
-        return '\n'.join(str(x) for x in self.__instructions)
+        return '\n'.join(str(x) for x in self.__instructions if str(x))

--- a/hpccm/building_blocks/charm.py
+++ b/hpccm/building_blocks/charm.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import posixpath
 
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.sed
@@ -37,19 +38,20 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
-            hpccm.templates.sed, hpccm.templates.tar, hpccm.templates.wget):
+class charm(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
+            hpccm.templates.rm, hpccm.templates.sed, hpccm.templates.tar,
+            hpccm.templates.wget):
     """The `charm` building block downloads and install the
     [Charm++](http://charm.cs.illinois.edu/research/charm) component.
-
-    As a side effect, this building block modifies `PATH` to include
-    the Charm++ build.  It also sets the `CHARMBASE` environment
-    variable to the top level install directory.
 
     # Parameters
 
     check: Boolean flag to specify whether the test cases should be
     run.  The default is False.
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH`, `PATH`, and other variables) should be
+    modified to include Charm++. The default is True.
 
     ldconfig: Boolean flag to specify whether the Charm++ library
     directory should be added dynamic linker cache.  If False, then
@@ -109,10 +111,6 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self.__wd = '/var/tmp' # working directory
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'CHARMBASE': self.__installdir,
-            'PATH': '{}:$PATH'.format(posixpath.join(self.__installdir,
-                                                     'bin'))}
 
         # Construct series of steps to execute
         self.__setup()
@@ -126,8 +124,7 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self += comment('Charm++ version {}'.format(self.__version))
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -168,7 +165,7 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(directory=libpath))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
 
         # Check the build
         if self.__check:
@@ -178,6 +175,11 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         # Cleanup tarball and directory
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, tarball)]))
+
+        # Set the environment
+        self.environment_variables['CHARMBASE'] = self.__installdir
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.__installdir, 'bin'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -199,7 +201,5 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
             instructions.append(shell(
                 commands=[self.ldcache_step(
                     directory=posixpath.join(self.__prefix, 'lib_so'))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -27,6 +27,7 @@ import re
 
 import hpccm.config
 import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
@@ -41,16 +42,14 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
-           hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
+class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
+           hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
+           hpccm.templates.wget):
     """The `hdf5` building block downloads, configures, builds, and
     installs the [HDF5](http://www.hdfgroup.org) component.  Depending
     on the parameters, the source will be downloaded from the web
     (default) or copied from a source directory in the local build
     context.
-
-    As a side effect, this building block modifies `PATH`
-    to include the HDF5 build, and sets `HDF5_DIR`.
 
     # Parameters
 
@@ -64,6 +63,10 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     local build context.  The default value is empty.  If this is
     defined, the source in the local build context will be used rather
     than downloading the source from the web.
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+    include HDF5. The default is True.
 
     ldconfig: Boolean flag to specify whether the HDF5 library
     directory should be added dynamic linker cache.  If False, then
@@ -125,10 +128,6 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__version = kwargs.get('version', '1.10.4')
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'HDF5_DIR': self.prefix,
-            'PATH':
-            '{}:$PATH'.format(posixpath.join(self.prefix, 'bin'))}
         self.__wd = '/var/tmp' # working directory
 
         # Set the Linux distribution specific parameters
@@ -156,8 +155,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
                          dest=posixpath.join(self.__wd, self.__directory))
 
         self += shell(commands=self.__commands)
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -221,7 +219,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(directory=libpath))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
 
         if self.__directory:
             # Using source from local build context, cleanup directory
@@ -233,6 +231,11 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
                 items=[posixpath.join(self.__wd, tarball),
                        posixpath.join(self.__wd,
                                       'hdf5-{}'.format(self.__version))]))
+
+        # Set the environment
+        self.environment_variables['HDF5_DIR'] = self.prefix
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -255,7 +258,5 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             instructions.append(shell(
                 commands=[self.ldcache_step(
                     directory=posixpath.join(self.prefix, 'lib'))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -27,6 +27,7 @@ import os
 import re
 
 import hpccm.config
+import hpccm.templates.envvars
 import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
@@ -38,19 +39,18 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class intel_mpi(bb_base, hpccm.templates.wget):
+class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     """The `intel_mpi` building block downloads and installs the [Intel
     MPI Library](https://software.intel.com/en-us/intel-mpi-library).
 
     You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
     to use this building block.
 
-    As a side effect, this building block modifies `PATH`,
-    `LD_LIBRARY_PATH`, and other environment variables to include
-    Intel MPI.  Please see the `mpivars` parameter for more
-    information.
-
     # Parameters
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
+    include Intel MPI. `mpivars` has precedence. The default is True.
 
     eula: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
     The default value is `False`.
@@ -139,16 +139,18 @@ class intel_mpi(bb_base, hpccm.templates.wget):
             # but this may miss some things relative to the mpivars
             # environment script.
             if LooseVersion(self.version) >= LooseVersion('2019.0'):
-              self += environment(variables={
+              self.environment_variables={
                   'FI_PROVIDER_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov',
                   'I_MPI_ROOT': '/opt/intel/compilers_and_libraries/linux/mpi',
                   'LD_LIBRARY_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib:/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/lib:$LD_LIBRARY_PATH',
-                  'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/bin:$PATH'})
+                  'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/bin:$PATH'}
             else:
-              self += environment(variables={
+              self.environment_variables={
                   'I_MPI_ROOT': '/opt/intel/compilers_and_libraries/linux/mpi',
                   'LD_LIBRARY_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/lib:$LD_LIBRARY_PATH',
-                  'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:$PATH'})
+                  'PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/bin:$PATH'}
+
+            self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/libsim.py
+++ b/hpccm/building_blocks/libsim.py
@@ -25,6 +25,7 @@ import logging # pylint: disable=unused-import
 import posixpath
 
 import hpccm.config
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.wget
@@ -37,21 +38,22 @@ from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
-class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
-             hpccm.templates.wget):
+class libsim(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
+             hpccm.templates.rm, hpccm.templates.wget):
     """The `libsim` building block configures, builds, and installs the
     [VisIt
     Libsim](http://www.visitusers.org/index.php?title=Libsim_Batch)
     component.
-
-    As a side effect, this building block modifies `PATH` to include
-    the Libsim build.
 
     If GPU rendering will be used then a
     [cudagl](https://hub.docker.com/r/nvidia/cudagl) base image is
     recommended.
 
     # Parameters
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+    Libsim. The default is True.
 
     ldconfig: Boolean flag to specify whether the Libsim library
     directories should be added dynamic linker cache.  If False, then
@@ -128,8 +130,6 @@ class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self.__url = r'http://portal.nersc.gov/project/visit/releases/{0}/{1}'
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'PATH': '{}:$PATH'.format(posixpath.join(self.__prefix, 'bin'))}
         self.__wd = '/var/tmp/visit' # working directory
 
         # Set the Linux distribution specific parameters
@@ -147,8 +147,7 @@ class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self += comment('VisIt libsim version {}'.format(self.__version))
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -220,11 +219,15 @@ class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
             self.__commands.append(self.ldcache_step(
                 directory=posixpath.join(libpath, suffix2)))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{0}:{1}:$LD_LIBRARY_PATH'.format(posixpath.join(libpath, suffix1), posixpath.join(libpath, suffix2))
+            self.environment_variables['LD_LIBRARY_PATH'] = '{0}:{1}:$LD_LIBRARY_PATH'.format(posixpath.join(libpath, suffix1), posixpath.join(libpath, suffix2))
 
         # Cleanup
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd)]))
+
+        # Set the environment
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.__prefix, 'bin'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -253,7 +256,5 @@ class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
                                                                      suffix1)),
                           self.ldcache_step(
                               directory=posixpath.join(libpath, suffix2))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -26,6 +26,7 @@ import os
 import re
 
 import hpccm.config
+import hpccm.templates.envvars
 import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
@@ -37,18 +38,18 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class mkl(bb_base, hpccm.templates.wget):
+class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     """The `mkl` building block downloads and installs the [Intel Math
     Kernel Library](http://software.intel.com/mkl).
 
     You must agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement)
     to use this building block.
 
-    As a side effect, this building block modifies `LIBRARY_PATH`,
-    `LD_LIBRARY_PATH`, and other environment variables to include MKL.
-    Please see the `mklvars` parameter for more information.
-
     # Parameters
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH`, `PATH`, and other variables) should be
+    modified to include MKL. The default is True.
 
     eula: By setting this value to `True`, you agree to the [Intel End User License Agreement](https://software.intel.com/en-us/articles/end-user-license-agreement).
     The default value is `False`.
@@ -80,6 +81,7 @@ class mkl(bb_base, hpccm.templates.wget):
     ```python
     mkl(eula=True, version='2018.3-051')
     ```
+
     """
 
     def __init__(self, **kwargs):
@@ -133,11 +135,12 @@ class mkl(bb_base, hpccm.templates.wget):
             # subsequent build steps and when starting the container,
             # but this may miss some things relative to the mklvars
             # environment script.
-            self += environment(variables={
+            self.environment_variables={
                 'CPATH': '/opt/intel/mkl/include:$CPATH',
                 'LD_LIBRARY_PATH': '/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64:$LD_LIBRARY_PATH',
                 'LIBRARY_PATH': '/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64:$LIBRARY_PATH',
-                'MKLROOT': '/opt/intel/mkl'})
+                'MKLROOT': '/opt/intel/mkl'}
+            self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -28,6 +28,7 @@ from six import string_types
 
 import hpccm.config
 import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
@@ -42,13 +43,11 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
-            hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
+class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
+            hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
+            hpccm.templates.wget):
     """The `mpich` building block configures, builds, and installs the
     [MPICH](https://www.mpich.org) component.
-
-    As a side effect, this building block modifies `PATH` to include
-    the MPICH build.
 
     As a side effect, a toolchain is created containing the MPI
     compiler wrappers.  The tool can be passed to other operations
@@ -61,6 +60,10 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
 
     configure_opts: List of options to pass to `configure`.  The
     default is an empty list.
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+    MPICH. The default is True.
 
     ldconfig: Boolean flag to specify whether the MPICH library
     directory should be added dynamic linker cache.  If False, then
@@ -115,8 +118,6 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.version = kwargs.get('version', '3.3')
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'PATH': '{}:$PATH'.format(posixpath.join(self.prefix, 'bin'))}
         self.__wd = '/var/tmp' # working directory
 
         # Output toolchain
@@ -138,8 +139,7 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self += comment('MPICH version {}'.format(self.version))
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -204,13 +204,17 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(directory=libpath))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
 
         # Cleanup
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, tarball),
                    posixpath.join(self.__wd,
                                   'mpich-{}'.format(self.version))]))
+
+        # Set the environment
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -232,7 +236,5 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             instructions.append(shell(
                 commands=[self.ldcache_step(
                     directory=posixpath.join(self.prefix, 'lib'))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -27,6 +27,7 @@ from copy import copy as _copy
 
 import hpccm.config
 import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
@@ -41,17 +42,15 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
-             hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
+class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
+             hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
+             hpccm.templates.wget):
     """The `netcdf` building block downloads, configures, builds, and
     installs the
     [NetCDF](https://www.unidata.ucar.edu/software/netcdf/) component.
 
     The [HDF5](#hdf5) building block should be installed prior to this
     building block.
-
-    As a side effect, this building block modifies `PATH` to include
-    the NetCDF build.
 
     # Parameters
 
@@ -63,6 +62,10 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
 
     cxx: Boolean flag to specify whether the NetCDF C++ library should
     be installed.  The default is True.
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+    NetCDF. The default is True.
 
     fortran: Boolean flag to specify whether the NetCDF Fortran
     library should be installed.  The default is True.
@@ -133,8 +136,6 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__wd = '/var/tmp'
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'PATH': '{}:$PATH'.format(posixpath.join(self.prefix, 'bin'))}
 
         # Set the Linux distribution specific parameters
         self.__distro()
@@ -170,8 +171,7 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
 
         self += shell(commands=self.__commands)
 
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -233,12 +233,16 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(directory=libpath))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
 
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, tarball),
                    posixpath.join(self.__wd,
                                   'netcdf-{}'.format(self.__version))]))
+
+        # Set the environment
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))
 
     def __setup_optional(self, pkg='', version=''):
         # Create a copy of the toolchain so that it can be modified
@@ -306,7 +310,5 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             instructions.append(shell(
                 commands=[self.ldcache_step(
                     directory=posixpath.join(self.prefix, 'lib'))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -28,6 +28,7 @@ from six import string_types
 
 import hpccm.config
 import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
@@ -42,15 +43,13 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
-class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
-              hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
+class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
+              hpccm.templates.ldconfig, hpccm.templates.rm,
+              hpccm.templates.tar, hpccm.templates.wget):
     """The `openmpi` building block configures, builds, and installs the
     [OpenMPI](https://www.open-mpi.org) component.  Depending on the
     parameters, the source will be downloaded from the web (default)
     or copied from a source directory in the local build context.
-
-    As a side effect, this building block modifies `PATH` and
-    `LD_LIBRARY_PATH` to include the OpenMPI build.
 
     As a side effect, a toolchain is created containing the MPI
     compiler wrappers.  The tool can be passed to other operations
@@ -75,6 +74,10 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     local build context.  The default value is empty.  If this is
     defined, the source in the local build context will be used rather
     than downloading the source from the web.
+
+    environment: Boolean flag to specify whether the environment
+    (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
+    OpenMPI. The default is True.
 
     infiniband: Boolean flag to control whether InfiniBand
     capabilities are included.  If True, adds `--with-verbs` to the
@@ -156,8 +159,6 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__ucx = kwargs.get('ucx', False)
 
         self.__commands = [] # Filled in by __setup()
-        self.__environment_variables = {
-            'PATH': '{}:$PATH'.format(posixpath.join(self.prefix, 'bin'))}
         self.__wd = '/var/tmp' # working directory
 
         # Output toolchain
@@ -186,8 +187,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             self += copy(src=self.directory,
                          dest=posixpath.join(self.__wd, self.directory))
         self += shell(commands=self.__commands)
-        if self.__environment_variables:
-            self += environment(variables=self.__environment_variables)
+        self += environment(variables=self.environment_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -293,7 +293,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(directory=libpath))
         else:
-            self.__environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
 
         if self.directory:
             # Using source from local build context, cleanup directory
@@ -305,6 +305,10 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
                 items=[posixpath.join(self.__wd, tarball),
                        posixpath.join(self.__wd,
                                       'openmpi-{}'.format(self.version))]))
+
+        # Set the environment
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -326,7 +330,5 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
             instructions.append(shell(
                 commands=[self.ldcache_step(
                     directory=posixpath.join(self.prefix, 'lib'))]))
-        if self.__environment_variables:
-            instructions.append(environment(
-                variables=self.__environment_variables))
+        instructions.append(environment(variables=self.environment_step()))
         return '\n'.join(str(x) for x in instructions)

--- a/hpccm/templates/__init__.py
+++ b/hpccm/templates/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 from hpccm.templates.CMakeBuild import CMakeBuild
 from hpccm.templates.ConfigureMake import ConfigureMake
+from hpccm.templates.envvars import envvars
 from hpccm.templates.git import git
 from hpccm.templates.ldconfig import ldconfig
 from hpccm.templates.rm import rm

--- a/hpccm/templates/envvars.py
+++ b/hpccm/templates/envvars.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""environment variables template"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+import hpccm.base_object
+
+class envvars(hpccm.base_object):
+    """Template for setting environment variables"""
+
+    def __init__(self, **kwargs):
+        """Initialize template"""
+
+        super(envvars, self).__init__(**kwargs)
+
+        self.environment = kwargs.get('environment', True)
+        self.environment_variables = {}
+        # Use only if the runtime environment is incompatible with the
+        # non-runtime environment, e.g., PATH contains different
+        # values.  Otherwise, try to use the filtering options.
+        self.runtime_environment_variables = {}
+
+    def environment_step(self, include_only=None, exclude=None, runtime=False):
+        """Return dictionary of environment variables"""
+
+        if runtime:
+            e = self.runtime_environment_variables
+        else:
+            e = self.environment_variables
+
+        if self.environment:
+            if include_only:
+                return {x: e[x] for x in e if x in include_only}
+            elif exclude:
+                return {x: e[x] for x in e if x not in exclude}
+            else:
+                return e
+        else:
+            return {}

--- a/test/test_envvars.py
+++ b/test/test_envvars.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the envvars module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.templates.envvars import envvars
+
+class Test_envvars(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_no_variables(self):
+        """No variables specified"""
+        e = envvars()
+
+        self.assertDictEqual(e.environment_step(), {})
+
+    def test_basic(self):
+        """Basic envvars"""
+        d = {'A': 'a', 'B': 'b', 'one': 1}
+        e = envvars()
+        e.environment_variables = d
+
+        self.assertDictEqual(e.environment_step(), d)
+
+        e.environment = False
+        self.assertDictEqual(e.environment_step(), {})
+
+    def test_include_exclude(self):
+        """Include / exclude keys"""
+        d = {'A': 'a', 'B': 'b', 'one': 1}
+        e = envvars()
+        e.environment_variables = d
+
+        self.assertDictEqual(e.environment_step(exclude=['B']),
+                             {'A': 'a', 'one': 1})
+
+        self.assertDictEqual(e.environment_step(include_only=['A', 'one']),
+                             {'A': 'a', 'one': 1})
+
+    def test_runtime(self):
+        """Runtime environment variables"""
+        d = {'A': 'a', 'B': 'b', 'one': 1}
+        r = {'A': 'alpha', 'B': 'b'}
+        e = envvars()
+        e.environment_variables = d
+        e.runtime_environment_variables = r
+
+        self.assertDictEqual(e.environment_step(runtime=True),
+                             {'A': 'alpha', 'B': 'b'})

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -176,6 +176,28 @@ ENV PATH=/usr/local/ucx/bin:$PATH''')
 
     @ubuntu
     @docker
+    def test_environment(self):
+        """environment option"""
+        u = ucx(environment=False, version='1.4.0')
+        self.assertEqual(str(u),
+r'''# UCX version 1.4.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        binutils-dev \
+        file \
+        libnuma-dev \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         u = ucx()


### PR DESCRIPTION
Adds an `environment` option to most building blocks that can be used to disable the generation of the `ENV` block to set the environment.  The default is True, i.e., include the `ENV` block, which is the prior behavior.