### PR TITLE
Update default component versions to latest upstream stable versions

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -83,7 +83,7 @@ repository.  For versions of Boost older than 1.63.0, the
 SourceForge repository should be used.  The default is False.
 
 - __version__: The version of Boost source to download.  The default
-value is `1.68.0`.
+value is `1.70.0`.
 
 __Examples__
 
@@ -174,7 +174,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of Catalyst source to download.  The default
-value is `5.6.0`.
+value is `5.6.1`.
 
 __Examples__
 
@@ -232,7 +232,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of CGNS source to download.  The default
-value is `3.3.1`.
+value is `3.4.0`.
 
 __Examples__
 
@@ -283,7 +283,8 @@ directory. The default value is False.
 The default values are `--build-shared`, and `--with-production`.
 
 - __ospackages__: List of OS packages to install prior to configuring
-and building.  The default values are `git`, `make`, and `wget`.
+and building.  The default values are `autoconf`, `automake`,
+`git`, `libtool`, `make`, and `wget`.
 
 - __prefix__: The top level install prefix.  The default value is
 `/usr/local`.
@@ -295,7 +296,7 @@ is `charm++`.
 The default value is `multicore-linux-x86_64`.
 
 - __version__: The version of Charm++ to download.  The default value is
-`6.8.2`.
+`6.9.0`.
 
 __Examples__
 
@@ -345,7 +346,7 @@ The default value is `wget`.
 `/usr/local`.
 
 - __version__: The version of CMake to download.  The default value is
-`3.12.3`.
+`3.14.5`.
 
 __Examples__
 
@@ -654,7 +655,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of HDF5 source to download.  This value is
-ignored if `directory` is set.  The default value is `1.10.4`.
+ignored if `directory` is set.  The default value is `1.10.5`.
 
 __Examples__
 
@@ -737,7 +738,7 @@ Intel MPI.  For Ubuntu, the default values are
 the default values are `man-db` and `openssh-clients`.
 
 - __version__: The version of Intel MPI to install.  The default value
-is `2019.1-053`.
+is `2019.4-070`.
 
 __Examples__
 
@@ -971,7 +972,7 @@ and `which`.
 install.  Due to issues in the Intel apt / yum repositories, only
 the major version is used; within a major version, the most recent
 minor version will be installed.  The default value is
-`2019.3-199`.
+`2019.4-243`.
 
 - __tbb__: Boolean flag to specify whether the Intel Threading Building
 Blocks runtime should be installed.  The default is True.
@@ -1088,7 +1089,7 @@ default values are `bc`, `gzip`, `hwloc-devel`, `make`, `tar`,
 is `/usr/local/kokkos`.
 
 - __version__: The version of Kokkos source to download.  The default
-value is `2.8.00`.
+value is `2.9.00`.
 
 __Examples__
 
@@ -1139,7 +1140,10 @@ directories should be added dynamic linker cache.  If False, then
 directories. The default value is False.
 
 - __mpi__: Boolean flag to specify whether Libsim should be built with
-MPI support.  If True, then the build script options `--parallel`
+MPI support.  VisIt uses MPI-1 routines that have been removed
+from the MPI standard; the MPI library may need to be built with
+special compatibility options, e.g., `--enable-mpi1-compatibility`
+for OpenMPI.  If True, then the build script options `--parallel`
 and `--no-icet` are added and the environment variable
 `PAR_COMPILER` is set to `mpicc`. If True, a MPI library building
 block should be installed prior this building block.  The default
@@ -1307,7 +1311,7 @@ MKL.  For Ubuntu, the default values are `apt-transport-https`,
 distributions, the default is an empty list.
 
 - __version__: The version of MKL to install.  The default value is
-`2019.0-045`.
+`2019.4-070`.
 
 __Examples__
 
@@ -1373,7 +1377,7 @@ container entry point.  The default value is empty, i.e., install
 via the package manager to the standard system locations.
 
 - __version__: The version of Mellanox OFED to download.  The default
-value is `4.5-1.0.1.0`.
+value is `4.6-1.0.1.1`.
 
 __Examples__
 
@@ -1441,7 +1445,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of MPICH source to download.  The default
-value is `3.3`.
+value is `3.3.1`.
 
 __Examples__
 
@@ -1593,7 +1597,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of MVAPICH2 source to download.  This value
-is ignored if `directory` is set.  The default value is `2.3`.
+is ignored if `directory` is set.  The default value is `2.3.1`.
 
 __Examples__
 
@@ -1790,13 +1794,13 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of NetCDF to download.  The default value is
-`4.6.1`.
+`4.7.0`.
 
 - __version_cxx__: The version of NetCDF C++ to download.  The default
 value is `4.3.0`.
 
 - __version_fortran__: The version of NetCDF Fortran to download.  The
-default value is `4.4.4`.
+default value is `4.4.5`.
 
 __Examples__
 
@@ -1917,7 +1921,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of OpenBLAS source to download.  The default
-value is `0.3.3`.
+value is `0.3.6`.
 
 __Examples__
 
@@ -2016,7 +2020,7 @@ list of `configure` options.  The default is False.
 
 - __version__: The version of OpenMPI source to download.  This
 value is ignored if `directory` is set.  The default value is
-`3.1.2`.
+`4.0.1`.
 
 __Examples__
 
@@ -2309,7 +2313,7 @@ used.  The default is to use the standard MPI compiler wrappers,
 e.g., `CC=mpicc`, `CXX=mpicxx`, etc.
 
 - __version__: The version of PnetCDF source to download.  The default
-value is `1.10.0`.
+value is `1.11.2`.
 
 __Examples__
 
@@ -2614,7 +2618,7 @@ non-default compilers or other toolchain options are needed.  The
 default value is empty.
 
 - __version__: The version of UCX source to download.  The default value
-is `1.4.0`.
+is `1.5.2`.
 
 - __xpmem__: Flag to control whether XPMEM is used by the build.  If
 True, adds `--with-xpmem` to the list of `configure` options.  If

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -74,7 +74,7 @@ class boost(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
     SourceForge repository should be used.  The default is False.
 
     version: The version of Boost source to download.  The default
-    value is `1.68.0`.
+    value is `1.70.0`.
 
     # Examples
 
@@ -101,7 +101,7 @@ class boost(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self.__prefix = kwargs.get('prefix', '/usr/local/boost')
         self.__python = kwargs.get('python', False)
         self.__sourceforge = kwargs.get('sourceforge', False)
-        self.__version = kwargs.get('version', '1.68.0')
+        self.__version = kwargs.get('version', '1.70.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {} # Filled in by __setup()

--- a/hpccm/building_blocks/catalyst.py
+++ b/hpccm/building_blocks/catalyst.py
@@ -99,7 +99,7 @@ class catalyst(bb_base, hpccm.templates.CMakeBuild, hpccm.templates.ldconfig,
     default is empty.
 
     version: The version of Catalyst source to download.  The default
-    value is `5.6.0`.
+    value is `5.6.1`.
 
     # Examples
 
@@ -121,7 +121,7 @@ class catalyst(bb_base, hpccm.templates.CMakeBuild, hpccm.templates.ldconfig,
         self.__runtime_ospackages = [] # Filled in by __distro()
         # Input toolchain, i.e., what to use when building
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '5.6.0')
+        self.__version = kwargs.get('version', '5.6.1')
         self.__url = r'https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version={0}\&type=catalyst\&os=Sources\&downloadFile={1}'
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/cgns.py
+++ b/hpccm/building_blocks/cgns.py
@@ -70,7 +70,7 @@ class cgns(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.rm,
     default is empty.
 
     version: The version of CGNS source to download.  The default
-    value is `3.3.1`.
+    value is `3.4.0`.
 
     # Examples
 
@@ -93,7 +93,7 @@ class cgns(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.rm,
         self.__check = kwargs.get('check', False)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '3.3.1')
+        self.__version = kwargs.get('version', '3.4.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/charm.py
+++ b/hpccm/building_blocks/charm.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import LooseVersion
 import logging # pylint: disable=unused-import
 import posixpath
 
@@ -60,7 +61,8 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
     The default values are `--build-shared`, and `--with-production`.
 
     ospackages: List of OS packages to install prior to configuring
-    and building.  The default values are `git`, `make`, and `wget`.
+    and building.  The default values are `autoconf`, `automake`,
+    `git`, `libtool`, `make`, and `wget`.
 
     prefix: The top level install prefix.  The default value is
     `/usr/local`.
@@ -72,7 +74,7 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
     The default value is `multicore-linux-x86_64`.
 
     version: The version of Charm++ to download.  The default value is
-    `6.8.2`.
+    `6.9.0`.
 
     # Examples
 
@@ -96,16 +98,24 @@ class charm(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
         self.__check = kwargs.get('check', False)
         self.__options = kwargs.get('options', ['--build-shared',
                                                 '--with-production'])
-        self.__ospackages = kwargs.get('ospackages', ['git', 'make', 'wget'])
+        self.__ospackages = kwargs.get('ospackages',
+                                       ['autoconf', 'automake', 'git',
+                                        'libtool', 'make', 'wget'])
         self.__parallel = kwargs.get('parallel', 4)
         self.__prefix = kwargs.get('prefix', '/usr/local')
         self.__target = kwargs.get('target', 'charm++')
         self.__target_architecture = kwargs.get('target_architecture',
                                                 'multicore-linux-x86_64')
-        self.__version = kwargs.get('version', '6.8.2')
+        self.__version = kwargs.get('version', '6.9.0')
 
-        self.__installdir = posixpath.join(self.__prefix,
-                                           'charm-v{}'.format(self.__version))
+        # Version 6.9.0 dropped the 'v' from directory name
+        if LooseVersion(self.__version) >= LooseVersion('6.9.0'):
+            self.__installdir = posixpath.join(
+                self.__prefix, 'charm-{}'.format(self.__version))
+        else:
+            self.__installdir = posixpath.join(
+                self.__prefix, 'charm-v{}'.format(self.__version))
+
         self.__wd = '/var/tmp' # working directory
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -49,7 +49,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.wget):
     `/usr/local`.
 
     version: The version of CMake to download.  The default value is
-    `3.12.3`.
+    `3.14.5`.
 
     # Examples
 
@@ -76,7 +76,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.wget):
 
         self.__ospackages = kwargs.get('ospackages', ['wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local')
-        self.__version = kwargs.get('version', '3.12.3')
+        self.__version = kwargs.get('version', '3.14.5')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -84,7 +84,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     default is empty.
 
     version: The version of HDF5 source to download.  This value is
-    ignored if `directory` is set.  The default value is `1.10.4`.
+    ignored if `directory` is set.  The default value is `1.10.5`.
 
     # Examples
 
@@ -122,7 +122,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '1.10.4')
+        self.__version = kwargs.get('version', '1.10.5')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -78,7 +78,7 @@ class intel_mpi(bb_base, hpccm.templates.wget):
     the default values are `man-db` and `openssh-clients`.
 
     version: The version of Intel MPI to install.  The default value
-    is `2019.1-053`.
+    is `2019.4-070`.
 
     # Examples
 
@@ -99,7 +99,7 @@ class intel_mpi(bb_base, hpccm.templates.wget):
 
         self.__mpivars = kwargs.get('mpivars', True)
         self.__ospackages = kwargs.get('ospackages', [])
-        self.version = kwargs.get('version', '2019.1-053')
+        self.version = kwargs.get('version', '2019.4-070')
 
         self.__bashrc = ''      # Filled in by __distro()
 

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -190,7 +190,7 @@ class intel_psxe(bb_base, hpccm.templates.rm, hpccm.templates.sed,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/opt/intel')
         self.__psxevars = kwargs.get('psxevars', True)
-        self.__runtime_version = kwargs.get('runtime_version', '2019.1-144')
+        self.__runtime_version = kwargs.get('runtime_version', '2019.4-243')
         self.__tarball = kwargs.get('tarball', None)
         self.__tbb = kwargs.get('tbb', True)
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -103,7 +103,7 @@ class intel_psxe_runtime(bb_base):
     install.  Due to issues in the Intel apt / yum repositories, only
     the major version is used; within a major version, the most recent
     minor version will be installed.  The default value is
-    `2019.3-199`.
+    `2019.4-243`.
 
     tbb: Boolean flag to specify whether the Intel Threading Building
     Blocks runtime should be installed.  The default is True.
@@ -139,7 +139,7 @@ class intel_psxe_runtime(bb_base):
         self.__psxevars = kwargs.get('psxevars', True)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__tbb = kwargs.get('tbb', True)
-        self.__version = kwargs.get('version', '2019.3-199')
+        self.__version = kwargs.get('version', '2019.4-243')
         self.__year = self.__version.split('.')[0]
 
         self.__bashrc = ''            # Filled in by __distro()

--- a/hpccm/building_blocks/kokkos.py
+++ b/hpccm/building_blocks/kokkos.py
@@ -75,7 +75,7 @@ class kokkos(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     is `/usr/local/kokkos`.
 
     version: The version of Kokkos source to download.  The default
-    value is `2.8.00`.
+    value is `2.9.00`.
 
     # Examples
 
@@ -100,7 +100,7 @@ class kokkos(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__parallel = kwargs.get('parallel', '$(nproc)')
         self.__prefix = kwargs.get('prefix', '/usr/local/kokkos')
-        self.__version = kwargs.get('version', '2.8.00')
+        self.__version = kwargs.get('version', '2.9.00')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/libsim.py
+++ b/hpccm/building_blocks/libsim.py
@@ -59,7 +59,10 @@ class libsim(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
     directories. The default value is False.
 
     mpi: Boolean flag to specify whether Libsim should be built with
-    MPI support.  If True, then the build script options `--parallel`
+    MPI support.  VisIt uses MPI-1 routines that have been removed
+    from the MPI standard; the MPI library may need to be built with
+    special compatibility options, e.g., `--enable-mpi1-compatibility`
+    for OpenMPI.  If True, then the build script options `--parallel`
     and `--no-icet` are added and the environment variable
     `PAR_COMPILER` is set to `mpicc`. If True, a MPI library building
     block should be installed prior this building block.  The default

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -73,7 +73,7 @@ class mkl(bb_base, hpccm.templates.wget):
     distributions, the default is an empty list.
 
     version: The version of MKL to install.  The default value is
-    `2019.0-045`.
+    `2019.4-070`.
 
     # Examples
 
@@ -94,7 +94,7 @@ class mkl(bb_base, hpccm.templates.wget):
 
         self.__mklvars = kwargs.get('mklvars', True)
         self.__ospackages = kwargs.get('ospackages', [])
-        self.version = kwargs.get('version', '2019.0-045')
+        self.version = kwargs.get('version', '2019.4-070')
 
         self.__bashrc = ''      # Filled in by __distro()
 

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -74,7 +74,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     via the package manager to the standard system locations.
 
     version: The version of Mellanox OFED to download.  The default
-    value is `4.5-1.0.1.0`.
+    value is `4.6-1.0.1.1`.
 
     # Examples
 
@@ -97,7 +97,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', None)
         self.__symlink = kwargs.get('symlink', False)
-        self.__version = kwargs.get('version', '4.5-1.0.1.0')
+        self.__version = kwargs.get('version', '4.6-1.0.1.1')
 
         self.__commands = []
         self.__wd = '/var/tmp'

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -81,7 +81,7 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     default is empty.
 
     version: The version of MPICH source to download.  The default
-    value is `3.3`.
+    value is `3.3.1`.
 
     # Examples
 
@@ -112,7 +112,7 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # MPICH does not accept F90
         self.toolchain_control = {'CC': True, 'CXX': True, 'F77': True,
                                   'F90': False, 'FC': True}
-        self.version = kwargs.get('version', '3.3')
+        self.version = kwargs.get('version', '3.3.1')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -107,7 +107,7 @@ class mvapich2(bb_base, hpccm.templates.ConfigureMake,
     default is empty.
 
     version: The version of MVAPICH2 source to download.  This value
-    is ignored if `directory` is set.  The default value is `2.3`.
+    is ignored if `directory` is set.  The default value is `2.3.1`.
 
     # Examples
 
@@ -148,7 +148,7 @@ class mvapich2(bb_base, hpccm.templates.ConfigureMake,
         # MVAPICH2 does not accept F90
         self.toolchain_control = {'CC': True, 'CXX': True, 'F77': True,
                                   'F90': False, 'FC': True}
-        self.version = kwargs.get('version', '2.3')
+        self.version = kwargs.get('version', '2.3.1')
 
         self.__commands = []              # Filled in by __setup()
         self.__environment_variables = {} # Filled in by __setup()
@@ -235,6 +235,9 @@ class mvapich2(bb_base, hpccm.templates.ConfigureMake,
             if toolchain.CC and re.match('.*pgcc', toolchain.CC):
                 self.configure_opts.append(
                     '--enable-cuda=basic --with-cuda={}'.format(cuda_home))
+
+                # Work around issue when using PGI 19.4
+                self.configure_opts.append('--enable-fast=O1')
 
                 if not toolchain.CFLAGS:
                     toolchain.CFLAGS = '-ta=tesla:nordc'

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -90,13 +90,13 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     default is empty.
 
     version: The version of NetCDF to download.  The default value is
-    `4.6.1`.
+    `4.7.0`.
 
     version_cxx: The version of NetCDF C++ to download.  The default
     value is `4.3.0`.
 
     version_fortran: The version of NetCDF Fortran to download.  The
-    default value is `4.4.4`.
+    default value is `4.4.5`.
 
     # Examples
 
@@ -127,9 +127,9 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.prefix = kwargs.get('prefix', '/usr/local/netcdf')
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '4.6.1')
+        self.__version = kwargs.get('version', '4.7.0')
         self.__version_cxx = kwargs.get('version_cxx', '4.3.0')
-        self.__version_fortran = kwargs.get('version_fortran', '4.4.4')
+        self.__version_fortran = kwargs.get('version_fortran', '4.4.5')
         self.__wd = '/var/tmp'
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -63,7 +63,7 @@ class openblas(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
     default is empty.
 
     version: The version of OpenBLAS source to download.  The default
-    value is `0.3.3`.
+    value is `0.3.6`.
 
     # Examples
 
@@ -88,7 +88,7 @@ class openblas(bb_base, hpccm.templates.ldconfig, hpccm.templates.rm,
                                                       'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/openblas')
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '0.3.3')
+        self.__version = kwargs.get('version', '0.3.6')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {} # Filled in by __setup()

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -108,7 +108,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
 
     version: The version of OpenMPI source to download.  This
     value is ignored if `directory` is set.  The default value is
-    `3.1.2`.
+    `4.0.1`.
 
     # Examples
 
@@ -152,7 +152,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
 
         # Input toolchain, i.e., what to use when building
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.version = kwargs.get('version', '3.1.2')
+        self.version = kwargs.get('version', '4.0.1')
         self.__ucx = kwargs.get('ucx', False)
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/pnetcdf.py
+++ b/hpccm/building_blocks/pnetcdf.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import LooseVersion
 import logging # pylint: disable=unused-import
 import posixpath
 
@@ -75,7 +76,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     e.g., `CC=mpicc`, `CXX=mpicxx`, etc.
 
     version: The version of PnetCDF source to download.  The default
-    value is `1.10.0`.
+    value is `1.11.2`.
 
     # Examples
 
@@ -97,7 +98,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.configure_opts = kwargs.get('configure_opts', ['--enable-shared'])
         self.prefix = kwargs.get('prefix', '/usr/local/pnetcdf')
 
-        self.__baseurl = kwargs.get('baseurl', 'http://cucis.ece.northwestern.edu/projects/PnetCDF/Release')
+        self.__baseurl = kwargs.get('baseurl', 'https://parallel-netcdf.github.io/Release')
         self.__check = kwargs.get('check', False)
         self.__ospackages = kwargs.get('ospackages', ['m4', 'make', 'tar',
                                                       'wget'])
@@ -106,7 +107,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
                                       toolchain(CC='mpicc', CXX='mpicxx',
                                                 F77='mpif77', F90='mpif90',
                                                 FC='mpifort'))
-        self.__version = kwargs.get('version', '1.10.0')
+        self.__version = kwargs.get('version', '1.11.2')
 
         self.__commands = [] # Filled in by __setup()
         self.__environment_variables = {
@@ -146,7 +147,12 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         """Construct the series of shell commands, i.e., fill in
            self.__commands"""
 
-        tarball = 'parallel-netcdf-{}.tar.gz'.format(self.__version)
+        # Version 1.11.0 changed the package name
+        if LooseVersion(self.__version) >= LooseVersion('1.11.0'):
+            pkgname = 'pnetcdf'
+        else:
+            pkgname = 'parallel-netcdf'
+        tarball = '{0}-{1}.tar.gz'.format(pkgname, self.__version)
         url = '{0}/{1}'.format(self.__baseurl, tarball)
 
         # Download source from web
@@ -155,8 +161,8 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__commands.append(self.untar_step(
             tarball=posixpath.join(self.__wd, tarball), directory=self.__wd))
         self.__commands.append(self.configure_step(
-            directory=posixpath.join(self.__wd, 'parallel-netcdf-{}'.format(
-                self.__version)),
+            directory=posixpath.join(self.__wd, '{0}-{1}'.format(
+                pkgname, self.__version)),
             toolchain=self.__toolchain))
 
         # For some compilers, --enable-shared leads to the following error:
@@ -165,7 +171,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         # .libs/libpnetcdf.lax/libf77.a/strerrnof.o: error adding symbols: Bad value
         # Apply the workaround
         if '--enable-shared' in self.configure_opts:
-          self.__commands.append('sed -i -e \'s#pic_flag=""#pic_flag=" -fpic -DPIC"#\' -e \'s#wl=""#wl="-Wl,"#\' {}'.format(posixpath.join(self.__wd, 'parallel-netcdf-{}'.format(self.__version), 'libtool')))
+          self.__commands.append('sed -i -e \'s#pic_flag=""#pic_flag=" -fpic -DPIC"#\' -e \'s#wl=""#wl="-Wl,"#\' {}'.format(posixpath.join(self.__wd, '{0}-{1}'.format(pkgname, self.__version), 'libtool')))
 
         self.__commands.append(self.build_step())
 
@@ -186,7 +192,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, tarball),
                    posixpath.join(self.__wd,
-                                  'parallel-netcdf-{}'.format(self.__version))]))
+                                  '{0}-{1}'.format(pkgname, self.__version))]))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -117,7 +117,7 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
     default value is empty.
 
     version: The version of UCX source to download.  The default value
-    is `1.4.0`.
+    is `1.5.2`.
 
     xpmem: Flag to control whether XPMEM is used by the build.  If
     True, adds `--with-xpmem` to the list of `configure` options.  If
@@ -161,7 +161,7 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.ldconfig,
         self.__ofed = kwargs.get('ofed', '')
         self.__ospackages = kwargs.get('ospackages', [])
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '1.4.0')
+        self.__version = kwargs.get('version', '1.5.2')
         self.__xpmem = kwargs.get('xpmem', '')
 
         self.__commands = [] # Filled in by __setup()

--- a/recipes/hpcbase-gnu-mvapich2.py
+++ b/recipes/hpcbase-gnu-mvapich2.py
@@ -2,23 +2,23 @@
 HPC Base image
 
 Contents:
-  CUDA version 9.0
+  CUDA version 10.0
   FFTW version 3.3.8
   GNU compilers (upstream)
-  HDF5 version 1.10.4
-  Mellanox OFED version 3.4-1.0.0.0
-  MVAPICH version 2.3
+  HDF5 version 1.10.5
+  Mellanox OFED version 4.6-1.0.1.1
+  MVAPICH version 2.3.1
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
 
 # Choose between either Ubuntu 16.04 (default) or CentOS 7
 # Add '--userarg centos=true' to the command line to select CentOS
-devel_image = 'nvidia/cuda:9.0-devel-ubuntu16.04'
-runtime_image = 'nvidia/cuda:9.0-runtime-ubuntu16.04'
+devel_image = 'nvidia/cuda:10.0-devel-ubuntu16.04'
+runtime_image = 'nvidia/cuda:10.0-runtime-ubuntu16.04'
 if USERARG.get('centos', False):
-    devel_image = 'nvidia/cuda:9.0-devel-centos7'
-    runtime_image = 'nvidia/cuda:9.0-runtime-centos7'
+    devel_image = 'nvidia/cuda:10.0-devel-centos7'
+    runtime_image = 'nvidia/cuda:10.0-runtime-centos7'
 
 ######
 # Devel stage
@@ -36,16 +36,16 @@ compiler = gnu()
 Stage0 += compiler
 
 # Mellanox OFED
-Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
+Stage0 += mlnx_ofed(version='4.6-1.0.1.1')
 
 # MVAPICH2
-Stage0 += mvapich2(version='2.3', toolchain=compiler.toolchain)
+Stage0 += mvapich2(version='2.3.1', toolchain=compiler.toolchain)
 
 # FFTW
 Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
+Stage0 += hdf5(version='1.10.5', toolchain=compiler.toolchain)
 
 ######
 # Runtime image

--- a/recipes/hpcbase-gnu-openmpi.py
+++ b/recipes/hpcbase-gnu-openmpi.py
@@ -2,23 +2,23 @@
 HPC Base image
 
 Contents:
-  CUDA version 9.0
+  CUDA version 10.0
   FFTW version 3.3.8
   GNU compilers (upstream)
-  HDF5 version 1.10.4
-  Mellanox OFED version 3.4-1.0.0.0
-  OpenMPI version 3.1.2
+  HDF5 version 1.10.5
+  Mellanox OFED version 4.6-1.0.1.1
+  OpenMPI version 4.0.1
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
 
 # Choose between either Ubuntu 16.04 (default) or CentOS 7
 # Add '--userarg centos=true' to the command line to select CentOS
-devel_image = 'nvidia/cuda:9.0-devel-ubuntu16.04'
-runtime_image = 'nvidia/cuda:9.0-runtime-ubuntu16.04'
+devel_image = 'nvidia/cuda:10.0-devel-ubuntu16.04'
+runtime_image = 'nvidia/cuda:10.0-runtime-ubuntu16.04'
 if USERARG.get('centos', False):
-    devel_image = 'nvidia/cuda:9.0-devel-centos7'
-    runtime_image = 'nvidia/cuda:9.0-runtime-centos7'
+    devel_image = 'nvidia/cuda:10.0-devel-centos7'
+    runtime_image = 'nvidia/cuda:10.0-runtime-centos7'
 
 ######
 # Devel stage
@@ -36,16 +36,16 @@ compiler = gnu()
 Stage0 += compiler
 
 # Mellanox OFED
-Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
+Stage0 += mlnx_ofed(version='4.6-1.0.1.1')
 
 # OpenMPI
-Stage0 += openmpi(version='3.1.2', toolchain=compiler.toolchain)
+Stage0 += openmpi(version='4.0.1', toolchain=compiler.toolchain)
 
 # FFTW
 Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
+Stage0 += hdf5(version='1.10.5', toolchain=compiler.toolchain)
 
 ######
 # Runtime image

--- a/recipes/hpcbase-pgi-mvapich2.py
+++ b/recipes/hpcbase-pgi-mvapich2.py
@@ -2,12 +2,12 @@
 HPC Base image
 
 Contents:
-  CUDA version 9.0
+  CUDA version 10.0
   FFTW version 3.3.8
-  HDF5 version 1.10.4
-  Mellanox OFED version 3.4-1.0.0.0
-  MVAPICH2 version 2.3
-  PGI compilers version 18.10
+  HDF5 version 1.10.5
+  Mellanox OFED version 4.6-1.0.1.1
+  MVAPICH2 version 2.3.1
+  PGI compilers version 19.4
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -22,11 +22,11 @@ else:
 
 # Choose between either Ubuntu 16.04 (default) or CentOS 7
 # Add '--userarg centos=true' to the command line to select CentOS
-devel_image = 'nvidia/cuda:9.0-devel-ubuntu16.04'
-runtime_image = 'nvidia/cuda:9.0-runtime-ubuntu16.04'
+devel_image = 'nvidia/cuda:10.0-devel-ubuntu16.04'
+runtime_image = 'nvidia/cuda:10.0-runtime-ubuntu16.04'
 if USERARG.get('centos', False):
-    devel_image = 'nvidia/cuda:9.0-devel-centos7'
-    runtime_image = 'nvidia/cuda:9.0-runtime-centos7'
+    devel_image = 'nvidia/cuda:10.0-devel-centos7'
+    runtime_image = 'nvidia/cuda:10.0-runtime-centos7'
 
 ######
 # Devel stage
@@ -40,20 +40,20 @@ Stage0 += baseimage(image=devel_image, _as='devel')
 Stage0 += python()
 
 # PGI compilers
-compiler = pgi(eula=pgi_eula, version='18.10')
+compiler = pgi(eula=pgi_eula, version='19.4')
 Stage0 += compiler
 
 # Mellanox OFED
-Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
+Stage0 += mlnx_ofed(version='4.6-1.0.1.1')
 
 # MVAPICH2
-Stage0 += mvapich2(version='2.3', toolchain=compiler.toolchain)
+Stage0 += mvapich2(version='2.3.1', toolchain=compiler.toolchain)
 
 # FFTW
 Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
+Stage0 += hdf5(version='1.10.5', toolchain=compiler.toolchain)
 
 ######
 # Runtime image

--- a/recipes/hpcbase-pgi-openmpi.py
+++ b/recipes/hpcbase-pgi-openmpi.py
@@ -2,12 +2,12 @@
 HPC Base image
 
 Contents:
-  CUDA version 9.0
+  CUDA version 10.0
   FFTW version 3.3.8
-  HDF5 version 1.10.4
-  Mellanox OFED version 3.4-1.0.0.0
-  OpenMPI version 3.1.2
-  PGI compilers version 18.10
+  HDF5 version 1.10.5
+  Mellanox OFED version 4.6-1.0.1.1
+  OpenMPI version 4.0.1
+  PGI compilers version 19.4
   Python 2 and 3 (upstream)
 """
 # pylint: disable=invalid-name, undefined-variable, used-before-assignment
@@ -22,11 +22,11 @@ else:
 
 # Choose between either Ubuntu 16.04 (default) or CentOS 7
 # Add '--userarg centos=true' to the command line to select CentOS
-devel_image = 'nvidia/cuda:9.0-devel-ubuntu16.04'
-runtime_image = 'nvidia/cuda:9.0-runtime-ubuntu16.04'
+devel_image = 'nvidia/cuda:10.0-devel-ubuntu16.04'
+runtime_image = 'nvidia/cuda:10.0-runtime-ubuntu16.04'
 if USERARG.get('centos', False):
-    devel_image = 'nvidia/cuda:9.0-devel-centos7'
-    runtime_image = 'nvidia/cuda:9.0-runtime-centos7'
+    devel_image = 'nvidia/cuda:10.0-devel-centos7'
+    runtime_image = 'nvidia/cuda:10.0-runtime-centos7'
 
 ######
 # Devel stage
@@ -40,20 +40,20 @@ Stage0 += baseimage(image=devel_image, _as='devel')
 Stage0 += python()
 
 # PGI compilers
-compiler = pgi(eula=pgi_eula, version='18.10')
+compiler = pgi(eula=pgi_eula, version='19.4')
 Stage0 += compiler
 
 # Mellanox OFED
-Stage0 += mlnx_ofed(version='3.4-1.0.0.0')
+Stage0 += mlnx_ofed(version='4.6-1.0.1.1')
 
 # OpenMPI
-Stage0 += openmpi(version='3.1.2', toolchain=compiler.toolchain)
+Stage0 += openmpi(version='4.0.1', toolchain=compiler.toolchain)
 
 # FFTW
 Stage0 += fftw(version='3.3.8', mpi=True, toolchain=compiler.toolchain)
 
 # HDF5
-Stage0 += hdf5(version='1.10.4', toolchain=compiler.toolchain)
+Stage0 += hdf5(version='1.10.5', toolchain=compiler.toolchain)
 
 ######
 # Runtime image

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -37,7 +37,7 @@ class Test_boost(unittest.TestCase):
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.68.0
+r'''# Boost version 1.70.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,11 +46,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
+    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -59,7 +59,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.68.0
+r'''# Boost version 1.70.0
 RUN yum install -y \
         bzip2 \
         bzip2-devel \
@@ -68,11 +68,11 @@ RUN yum install -y \
         which \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
+    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
@@ -81,7 +81,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """python option"""
         b = boost(python=True)
         self.assertEqual(str(b),
-r'''# Boost version 1.68.0
+r'''# Boost version 1.70.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -90,11 +90,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_68_0.tar.bz2 /var/tmp/boost_1_68_0
+    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_catalyst.py
+++ b/test/test_catalyst.py
@@ -38,7 +38,7 @@ class Test_catalyst(unittest.TestCase):
         """Default catalyst building block"""
         c = catalyst()
         self.assertEqual(str(c),
-r'''# ParaView Catalyst version 5.6.0
+r'''# ParaView Catalyst version 5.6.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git \
@@ -54,12 +54,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && cd /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target all -- -j$(nproc) && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && cd /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base
 ENV LD_LIBRARY_PATH=/usr/local/catalyst/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/catalyst/bin:$PATH''')
 
@@ -69,7 +69,7 @@ ENV LD_LIBRARY_PATH=/usr/local/catalyst/lib:$LD_LIBRARY_PATH \
         """Default catalyst building block"""
         c = catalyst()
         self.assertEqual(str(c),
-r'''# ParaView Catalyst version 5.6.0
+r'''# ParaView Catalyst version 5.6.1
 RUN yum install -y \
         git \
         gzip \
@@ -86,12 +86,12 @@ RUN yum install -y \
         wget \
         which && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && cd /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target all -- -j$(nproc) && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz /var/tmp/Catalyst-v5.6.0-Base-Enable-Python-Essentials-Extras-Rendering-Base
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && cd /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build && /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base.tar.gz /var/tmp/Catalyst-v5.6.1-Base-Enable-Python-Essentials-Extras-Rendering-Base
 ENV LD_LIBRARY_PATH=/usr/local/catalyst/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/catalyst/bin:$PATH''')
 
@@ -101,7 +101,7 @@ ENV LD_LIBRARY_PATH=/usr/local/catalyst/lib:$LD_LIBRARY_PATH \
         """edition option"""
         c = catalyst(edition='Base-Essentials')
         self.assertEqual(str(c),
-r'''# ParaView Catalyst version 5.6.0
+r'''# ParaView Catalyst version 5.6.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         git \
@@ -110,12 +110,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.0-Base-Essentials.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.0-Base-Essentials.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.0-Base-Essentials.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/Catalyst-v5.6.0-Base-Essentials/build && cd /var/tmp/Catalyst-v5.6.0-Base-Essentials/build && /var/tmp/Catalyst-v5.6.0-Base-Essentials/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.0-Base-Essentials && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Essentials/build --target all -- -j$(nproc) && \
-    cmake --build /var/tmp/Catalyst-v5.6.0-Base-Essentials/build --target install -- -j$(nproc) && \
-    rm -rf /var/tmp/Catalyst-v5.6.0-Base-Essentials.tar.gz /var/tmp/Catalyst-v5.6.0-Base-Essentials
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/Catalyst-v5.6.1-Base-Essentials.tar.gz -P /var/tmp https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version=v5.6\&type=catalyst\&os=Sources\&downloadFile=Catalyst-v5.6.1-Base-Essentials.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Catalyst-v5.6.1-Base-Essentials.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/Catalyst-v5.6.1-Base-Essentials/build && cd /var/tmp/Catalyst-v5.6.1-Base-Essentials/build && /var/tmp/Catalyst-v5.6.1-Base-Essentials/cmake.sh -DCMAKE_INSTALL_PREFIX=/usr/local/catalyst /var/tmp/Catalyst-v5.6.1-Base-Essentials && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Essentials/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/Catalyst-v5.6.1-Base-Essentials/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/Catalyst-v5.6.1-Base-Essentials.tar.gz /var/tmp/Catalyst-v5.6.1-Base-Essentials
 ENV LD_LIBRARY_PATH=/usr/local/catalyst/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/catalyst/bin:$PATH''')
 

--- a/test/test_cgns.py
+++ b/test/test_cgns.py
@@ -37,7 +37,7 @@ class Test_cgns(unittest.TestCase):
         """Default cgns building block"""
         c = cgns()
         self.assertEqual(str(c),
-r'''# CGNS version 3.3.1
+r'''# CGNS version 3.4.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
@@ -45,12 +45,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/CGNS/CGNS/archive/v3.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v3.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/CGNS-3.3.1/src &&  FLIBS='-Wl,--no-as-needed -ldl' LIBS='-Wl,--no-as-needed -ldl' ./configure --prefix=/usr/local/cgns --with-hdf5=/usr/local/hdf5 --with-zlib && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/CGNS/CGNS/archive/v3.4.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v3.4.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/CGNS-3.4.0/src &&  FLIBS='-Wl,--no-as-needed -ldl' LIBS='-Wl,--no-as-needed -ldl' ./configure --prefix=/usr/local/cgns --with-hdf5=/usr/local/hdf5 --with-zlib && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v3.3.1.tar.gz /var/tmp/v3.3.1''')
+    rm -rf /var/tmp/v3.4.0.tar.gz /var/tmp/v3.4.0''')
 
     @centos
     @docker
@@ -58,7 +58,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default cgns building block"""
         c = cgns()
         self.assertEqual(str(c),
-r'''# CGNS version 3.3.1
+r'''# CGNS version 3.4.0
 RUN yum install -y \
         bzip2 \
         file \
@@ -66,12 +66,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/CGNS/CGNS/archive/v3.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v3.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/CGNS-3.3.1/src &&  FLIBS='-Wl,--no-as-needed -ldl' LIBS='-Wl,--no-as-needed -ldl' ./configure --prefix=/usr/local/cgns --with-hdf5=/usr/local/hdf5 --with-zlib && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/CGNS/CGNS/archive/v3.4.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v3.4.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/CGNS-3.4.0/src &&  FLIBS='-Wl,--no-as-needed -ldl' LIBS='-Wl,--no-as-needed -ldl' ./configure --prefix=/usr/local/cgns --with-hdf5=/usr/local/hdf5 --with-zlib && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v3.3.1.tar.gz /var/tmp/v3.3.1''')
+    rm -rf /var/tmp/v3.4.0.tar.gz /var/tmp/v3.4.0''')
 
     @ubuntu
     @docker

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -37,20 +37,23 @@ class Test_charm(unittest.TestCase):
         """Default charm building block"""
         c = charm()
         self.assertEqual(str(c),
-r'''# Charm++ version 6.8.2
+r'''# Charm++ version 6.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
         git \
+        libtool \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://charm.cs.illinois.edu/distrib/charm-6.8.2.tar.gz && \
-    mkdir -p /usr/local && tar -x -f /var/tmp/charm-6.8.2.tar.gz -C /usr/local -z && \
-    cd /usr/local/charm-v6.8.2 && ./build charm++ multicore-linux-x86_64 --build-shared --with-production -j4 && \
-    rm -rf /var/tmp/charm-6.8.2.tar.gz
-ENV CHARMBASE=/usr/local/charm-v6.8.2 \
-    LD_LIBRARY_PATH=/usr/local/charm-v6.8.2/lib_so:$LD_LIBRARY_PATH \
-    PATH=/usr/local/charm-v6.8.2/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz && \
+    mkdir -p /usr/local && tar -x -f /var/tmp/charm-6.9.0.tar.gz -C /usr/local -z && \
+    cd /usr/local/charm-6.9.0 && ./build charm++ multicore-linux-x86_64 --build-shared --with-production -j4 && \
+    rm -rf /var/tmp/charm-6.9.0.tar.gz
+ENV CHARMBASE=/usr/local/charm-6.9.0 \
+    LD_LIBRARY_PATH=/usr/local/charm-6.9.0/lib_so:$LD_LIBRARY_PATH \
+    PATH=/usr/local/charm-6.9.0/bin:$PATH''')
 
     @ubuntu
     @docker
@@ -61,7 +64,10 @@ ENV CHARMBASE=/usr/local/charm-v6.8.2 \
 r'''# Charm++ version 6.8.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
         git \
+        libtool \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
@@ -81,7 +87,7 @@ ENV CHARMBASE=/usr/local/charm-v6.8.2 \
         r = c.runtime()
         self.assertEqual(r,
 r'''# Charm++
-COPY --from=0 /usr/local/charm-v6.8.2 /usr/local/charm-v6.8.2
-ENV CHARMBASE=/usr/local/charm-v6.8.2 \
-    LD_LIBRARY_PATH=/usr/local/charm-v6.8.2/lib_so:$LD_LIBRARY_PATH \
-    PATH=/usr/local/charm-v6.8.2/bin:$PATH''')
+COPY --from=0 /usr/local/charm-6.9.0 /usr/local/charm-6.9.0
+ENV CHARMBASE=/usr/local/charm-6.9.0 \
+    LD_LIBRARY_PATH=/usr/local/charm-6.9.0/lib_so:$LD_LIBRARY_PATH \
+    PATH=/usr/local/charm-6.9.0/bin:$PATH''')

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -37,14 +37,14 @@ class Test_cmake(unittest.TestCase):
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.12.3
+r'''# CMake version 3.14.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
 
     @centos
     @docker
@@ -52,13 +52,13 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.12.3
+r'''# CMake version 3.14.5
 RUN yum install -y \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
 
     @ubuntu
     @docker
@@ -66,14 +66,14 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Accept EULA"""
         c = cmake(eula=True)
         self.assertEqual(str(c),
-r'''# CMake version 3.12.3
+r'''# CMake version 3.14.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.12/cmake-3.12.3-Linux-x86_64.sh && \
-    /bin/sh /var/tmp/cmake-3.12.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.12.3-Linux-x86_64.sh''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
 
     @ubuntu
     @docker

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -37,7 +37,7 @@ class Test_hdf5(unittest.TestCase):
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.4
+r'''# HDF5 version 1.10.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.4.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.4 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.5.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.10.4.tar.bz2 /var/tmp/hdf5-1.10.4
+    rm -rf /var/tmp/hdf5-1.10.5.tar.bz2 /var/tmp/hdf5-1.10.5
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')
@@ -62,7 +62,7 @@ ENV HDF5_DIR=/usr/local/hdf5 \
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.4
+r'''# HDF5 version 1.10.5
 RUN yum install -y \
         bzip2 \
         file \
@@ -70,12 +70,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.4/src/hdf5-1.10.4.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.4.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.4 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.5.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.10.4.tar.bz2 /var/tmp/hdf5-1.10.4
+    rm -rf /var/tmp/hdf5-1.10.5.tar.bz2 /var/tmp/hdf5-1.10.5
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -44,7 +44,7 @@ class Test_intel_mpi(unittest.TestCase):
         """Default intel_mpi building block"""
         impi = intel_mpi(eula=True)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.1-053
+r'''# Intel MPI version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -58,7 +58,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.1-053 && \
+        intel-mpi-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
 
@@ -68,7 +68,7 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         """Default intel_mpi building block"""
         impi = intel_mpi(eula=True)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.1-053
+r'''# Intel MPI version 2019.4-070
 RUN yum install -y \
         man-db \
         openssh-clients && \
@@ -76,7 +76,7 @@ RUN yum install -y \
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mpi/setup/intel-mpi.repo && \
     yum install -y \
-        intel-mpi-2019.1-053 && \
+        intel-mpi-2019.4-070 && \
     rm -rf /var/cache/yum/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bashrc''')
 
@@ -110,7 +110,7 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         """mpivars is False"""
         impi = intel_mpi(eula=True, mpivars=False)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.1-053
+r'''# Intel MPI version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -124,7 +124,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.1-053 && \
+        intel-mpi-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 ENV FI_PROVIDER_PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov \
     I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
@@ -138,7 +138,7 @@ ENV FI_PROVIDER_PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfab
         impi = intel_mpi(eula=True)
         r = impi.runtime()
         self.assertEqual(r,
-r'''# Intel MPI version 2019.1-053
+r'''# Intel MPI version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -152,6 +152,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.1-053 && \
+        intel-mpi-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_kokkos.py
+++ b/test/test_kokkos.py
@@ -37,7 +37,7 @@ class Test_kokkos(unittest.TestCase):
         """Default kokkos building block"""
         k = kokkos()
         self.assertEqual(str(k),
-r'''# Kokkos version 2.8.00
+r'''# Kokkos version 2.9.00
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bc \
@@ -47,13 +47,13 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.8.00.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.8.00.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/kokkos-2.8.00/build && cd /var/tmp/kokkos-2.8.00/build && \
-    /var/tmp/kokkos-2.8.00/generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.9.00.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/2.9.00.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/kokkos-2.9.00/build && cd /var/tmp/kokkos-2.9.00/build && \
+    /var/tmp/kokkos-2.9.00/generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
     make kokkoslib -j$(nproc) && \
     make install -j$(nproc) && \
-    rm -rf /var/tmp/2.8.00.tar.gz /var/tmp/kokkos-2.8.00
+    rm -rf /var/tmp/2.9.00.tar.gz /var/tmp/kokkos-2.9.00
 ENV PATH=/usr/local/kokkos/bin:$PATH''')
 
     @centos
@@ -62,7 +62,7 @@ ENV PATH=/usr/local/kokkos/bin:$PATH''')
         """Default kokkos building block"""
         k = kokkos()
         self.assertEqual(str(k),
-r'''# Kokkos version 2.8.00
+r'''# Kokkos version 2.9.00
 RUN yum install -y \
         bc \
         gzip \
@@ -72,13 +72,13 @@ RUN yum install -y \
         wget \
         which && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.8.00.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.8.00.tar.gz -C /var/tmp -z && \
-    mkdir -p /var/tmp/kokkos-2.8.00/build && cd /var/tmp/kokkos-2.8.00/build && \
-    /var/tmp/kokkos-2.8.00/generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.9.00.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/2.9.00.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/kokkos-2.9.00/build && cd /var/tmp/kokkos-2.9.00/build && \
+    /var/tmp/kokkos-2.9.00/generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
     make kokkoslib -j$(nproc) && \
     make install -j$(nproc) && \
-    rm -rf /var/tmp/2.8.00.tar.gz /var/tmp/kokkos-2.8.00
+    rm -rf /var/tmp/2.9.00.tar.gz /var/tmp/kokkos-2.9.00
 ENV PATH=/usr/local/kokkos/bin:$PATH''')
 
     @ubuntu

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -44,7 +44,7 @@ class Test_mkl(unittest.TestCase):
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2019.0-045
+r'''# MKL version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -56,7 +56,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2019.0-045 && \
+        intel-mkl-64bit-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
 
@@ -66,11 +66,11 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2019.0-045
+r'''# MKL version 2019.4-070
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo && \
     yum install -y \
-        intel-mkl-64bit-2019.0-045 && \
+        intel-mkl-64bit-2019.4-070 && \
     rm -rf /var/cache/yum/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bashrc''')
 
@@ -102,7 +102,7 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         """mklvars is False"""
         m = mkl(eula=True, mklvars=False)
         self.assertEqual(str(m),
-r'''# MKL version 2019.0-045
+r'''# MKL version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -114,7 +114,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2019.0-045 && \
+        intel-mkl-64bit-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 ENV CPATH=/opt/intel/mkl/include:$CPATH \
     LD_LIBRARY_PATH=/opt/intel/mkl/lib/intel64:/opt/intel/lib/intel64:$LD_LIBRARY_PATH \
@@ -128,7 +128,7 @@ ENV CPATH=/opt/intel/mkl/include:$CPATH \
         m = mkl(eula=True)
         r = m.runtime()
         self.assertEqual(r,
-r'''# MKL version 2019.0-045
+r'''# MKL version 2019.4-070
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -140,6 +140,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2019.0-045 && \
+        intel-mkl-64bit-2019.4-070 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -37,7 +37,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
@@ -45,10 +45,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
     @ubuntu18
     @docker
@@ -56,7 +56,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
@@ -64,10 +64,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
-    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu18.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64''')
 
     @centos
     @docker
@@ -75,17 +75,17 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
         libnl \
         libnl3 \
         numactl-libs \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
-    rpm --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz -C /var/tmp -z && \
+    rpm --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
 
     @ubuntu
     @docker
@@ -93,7 +93,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Prefix option"""
         mofed = mlnx_ofed(prefix='/opt/ofed')
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
@@ -101,24 +101,24 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
     mkdir -p /etc/libibverbs.d && \
     mkdir -p /opt/ofed && cd /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /opt/ofed && \
-    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /opt/ofed && \
+    dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
     @centos
     @docker
@@ -126,31 +126,31 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Prefix option"""
         mofed = mlnx_ofed(prefix='/opt/ofed')
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
         libnl \
         libnl3 \
         numactl-libs \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz -C /var/tmp -z && \
     mkdir -p /etc/libibverbs.d && \
     mkdir -p /opt/ofed && cd /opt/ofed && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm | cpio -idm && \
-    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm | cpio -idm && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-rhel7.2-x86_64''')
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm | cpio -idm && \
+    rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm | cpio -idm && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
 
     @ubuntu
     @docker
@@ -159,7 +159,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         mofed = mlnx_ofed()
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \
@@ -167,10 +167,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
     @ubuntu
     @docker
@@ -179,7 +179,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         mofed = mlnx_ofed(prefix='/opt/ofed')
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.5-1.0.1.0
+r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \

--- a/test/test_mpich.py
+++ b/test/test_mpich.py
@@ -38,7 +38,7 @@ class Test_mpich(unittest.TestCase):
         """Default mpich building block"""
         m = mpich()
         self.assertEqual(str(m),
-r'''# MPICH version 3.3
+r'''# MPICH version 3.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mpich-3.3 &&   ./configure --prefix=/usr/local/mpich && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mpich-3.3.tar.gz /var/tmp/mpich-3.3
+    rm -rf /var/tmp/mpich-3.3.1.tar.gz /var/tmp/mpich-3.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mpich/bin:$PATH''')
 
@@ -64,7 +64,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
         """Default mpich building block"""
         m = mpich()
         self.assertEqual(str(m),
-r'''# MPICH version 3.3
+r'''# MPICH version 3.3.1
 RUN yum install -y \
         file \
         gzip \
@@ -74,12 +74,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mpich-3.3 &&   ./configure --prefix=/usr/local/mpich && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mpich-3.3.tar.gz /var/tmp/mpich-3.3
+    rm -rf /var/tmp/mpich-3.3.1.tar.gz /var/tmp/mpich-3.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mpich/bin:$PATH''')
 

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -38,7 +38,7 @@ class Test_mvapich2(unittest.TestCase):
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3
+r'''# MVAPICH2 version 2.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.1 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
+    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -70,7 +70,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         tc.FC = 'pgfortran'
         mv2 = mvapich2(toolchain=tc, cuda=True)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3
+r'''# MVAPICH2 version 2.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -81,12 +81,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.1 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda --enable-fast=O1 && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
+    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -125,7 +125,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Disable CUDA"""
         mv2 = mvapich2(cuda=False)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3
+r'''# MVAPICH2 version 2.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -134,12 +134,12 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --disable-cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.1 &&   ./configure --prefix=/usr/local/mvapich2 --disable-mcast --disable-cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
+    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
@@ -149,7 +149,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3
+r'''# MVAPICH2 version 2.3.1
 RUN yum install -y \
         byacc \
         file \
@@ -159,12 +159,12 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.1 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.tar.gz /var/tmp/mvapich2-2.3
+    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -37,8 +37,8 @@ class Test_netcdf(unittest.TestCase):
         """Default netcdf building block"""
         n = netcdf()
         self.assertEqual(str(n),
-r'''# NetCDF version 4.6.1, NetCDF C++ version 4.3.0, NetCDF Fortran
-# version 4.4.4
+r'''# NetCDF version 4.7.0, NetCDF C++ version 4.3.0, NetCDF Fortran
+# version 4.4.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -49,24 +49,24 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.6.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.6.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-4.6.1 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-4.6.1.tar.gz /var/tmp/netcdf-4.6.1 && \
+    rm -rf /var/tmp/netcdf-4.7.0.tar.gz /var/tmp/netcdf-4.7.0 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-cxx4-4.3.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/netcdf-cxx4-4.3.0.tar.gz /var/tmp/netcdf-cxx4-4.3.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.4.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-fortran-4.4.4.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-fortran-4.4.4 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.5.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-fortran-4.4.5.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-fortran-4.4.5 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-fortran-4.4.4.tar.gz /var/tmp/netcdf-fortran-4.4.4
+    rm -rf /var/tmp/netcdf-fortran-4.4.5.tar.gz /var/tmp/netcdf-fortran-4.4.5
 ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/netcdf/bin:$PATH''')
 
@@ -76,8 +76,8 @@ ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
         """Default netcdf building block"""
         n = netcdf()
         self.assertEqual(str(n),
-r'''# NetCDF version 4.6.1, NetCDF C++ version 4.3.0, NetCDF Fortran
-# version 4.4.4
+r'''# NetCDF version 4.7.0, NetCDF C++ version 4.3.0, NetCDF Fortran
+# version 4.4.5
 RUN yum install -y \
         ca-certificates \
         file \
@@ -87,24 +87,24 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.6.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.6.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-4.6.1 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-4.6.1.tar.gz /var/tmp/netcdf-4.6.1 && \
+    rm -rf /var/tmp/netcdf-4.7.0.tar.gz /var/tmp/netcdf-4.7.0 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-cxx4-4.3.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/netcdf-cxx4-4.3.0.tar.gz /var/tmp/netcdf-cxx4-4.3.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.4.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-fortran-4.4.4.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-fortran-4.4.4 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-fortran-4.4.5.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-fortran-4.4.5.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-fortran-4.4.5 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-fortran-4.4.4.tar.gz /var/tmp/netcdf-fortran-4.4.4
+    rm -rf /var/tmp/netcdf-fortran-4.4.5.tar.gz /var/tmp/netcdf-fortran-4.4.5
 ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/netcdf/bin:$PATH''')
 

--- a/test/test_openblas.py
+++ b/test/test_openblas.py
@@ -39,7 +39,7 @@ class Test_openblas(unittest.TestCase):
         tc = toolchain(CC='gcc', FC='gfortran')
         o = openblas(toolchain=tc)
         self.assertEqual(str(o),
-r'''# OpenBLAS version 0.3.3
+r'''# OpenBLAS version 0.3.6
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
@@ -47,11 +47,11 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/OpenBLAS-0.3.3 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.6.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/OpenBLAS-0.3.6 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
     make install PREFIX=/usr/local/openblas && \
-    rm -rf /var/tmp/v0.3.3.tar.gz /var/tmp/OpenBLAS-0.3.3
+    rm -rf /var/tmp/v0.3.6.tar.gz /var/tmp/OpenBLAS-0.3.6
 ENV LD_LIBRARY_PATH=/usr/local/openblas/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -37,7 +37,7 @@ class Test_openmpi(unittest.TestCase):
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 3.1.2
+r'''# OpenMPI version 4.0.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -50,12 +50,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-3.1.2.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.1.2.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-3.1.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-3.1.2.tar.bz2 /var/tmp/openmpi-3.1.2
+    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
@@ -65,7 +65,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 3.1.2
+r'''# OpenMPI version 4.0.1
 RUN yum install -y \
         bzip2 \
         file \
@@ -77,12 +77,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v3.1/downloads/openmpi-3.1.2.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-3.1.2.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-3.1.2 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-3.1.2.tar.bz2 /var/tmp/openmpi-3.1.2
+    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 

--- a/test/test_pnetcdf.py
+++ b/test/test_pnetcdf.py
@@ -37,7 +37,7 @@ class Test_pnetcdf(unittest.TestCase):
         """Default pnetcdf building block"""
         p = pnetcdf()
         self.assertEqual(str(p),
-r'''# PnetCDF version 1.10.0
+r'''# PnetCDF version 1.11.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         m4 \
@@ -45,13 +45,13 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/parallel-netcdf-1.10.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/parallel-netcdf-1.10.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/parallel-netcdf-1.10.0 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
-    sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/parallel-netcdf-1.10.0/libtool && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://parallel-netcdf.github.io/Release/pnetcdf-1.11.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/pnetcdf-1.11.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/pnetcdf-1.11.2 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
+    sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/pnetcdf-1.11.2/libtool && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/parallel-netcdf-1.10.0.tar.gz /var/tmp/parallel-netcdf-1.10.0
+    rm -rf /var/tmp/pnetcdf-1.11.2.tar.gz /var/tmp/pnetcdf-1.11.2
 ENV LD_LIBRARY_PATH=/usr/local/pnetcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/pnetcdf/bin:$PATH''')
 
@@ -69,7 +69,7 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://cucis.ece.northwestern.edu/projects/PnetCDF/Release/parallel-netcdf-1.10.0.tar.gz && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://parallel-netcdf.github.io/Release/parallel-netcdf-1.10.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/parallel-netcdf-1.10.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/parallel-netcdf-1.10.0 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
     sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/parallel-netcdf-1.10.0/libtool && \

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -37,7 +37,7 @@ class Test_ucx(unittest.TestCase):
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.4.0
+r'''# UCX version 1.5.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -61,7 +61,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.4.0
+r'''# UCX version 1.5.2
 RUN yum install -y \
         binutils-devel \
         file \
@@ -69,12 +69,12 @@ RUN yum install -y \
         numactl-devel \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -85,7 +85,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         u = ucx(cuda='/cuda', gdrcopy='/gdrcopy', knem='/knem', ofed='/ofed',
                 xpmem='/xpmem')
         self.assertEqual(str(u),
-r'''# UCX version 1.4.0
+r'''# UCX version 1.5.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -94,12 +94,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-verbs=/ofed --with-rdmacm=/ofed --with-xpmem=/xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-verbs=/ofed --with-rdmacm=/ofed --with-xpmem=/xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -109,7 +109,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with True values"""
         u = ucx(cuda=True, gdrcopy=True, knem=True, ofed=True, xpmem=True)
         self.assertEqual(str(u),
-r'''# UCX version 1.4.0
+r'''# UCX version 1.5.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -118,12 +118,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-verbs --with-rdmacm --with-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-verbs --with-rdmacm --with-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -133,7 +133,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with False values"""
         u = ucx(cuda=False, gdrcopy=False, knem=False, ofed=False, xpmem=False)
         self.assertEqual(str(u),
-r'''# UCX version 1.4.0
+r'''# UCX version 1.5.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -142,12 +142,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.4.0/ucx-1.4.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.4.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.4.0 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --without-cuda --without-gdrcopy --without-knem --without-verbs --without-rdmacm --without-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --enable-optimizations --disable-logging --disable-debug --disable-assertions --disable-params-check --disable-doxygen-doc --without-cuda --without-gdrcopy --without-knem --without-verbs --without-rdmacm --without-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.4.0.tar.gz /var/tmp/ucx-1.4.0
+    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 


### PR DESCRIPTION
| component | previous | updated |
| --------- | -------- | ------- |
| boost | 1.68.0 | 1.70.0 |
| catalyst | 5.6.0 | 5.6.1 |
| cgns | 3.3.1 | 3.4.0 |
| charm | 6.8.2 | 6.9.0 |
| cmake | 3.12.3 | 3.14.5 |
| hdf5 | 1.10.4 | 1.10.5 |
| intel_mpi | 2019.1-053 | 2019.4-070 |
| intel_psxe | 2019.3-199 | 2019.4.243 |
| intel_psxe_runtime | 2019.3-199 | 2019.4.243 |
| kokkos | 2.8.00 | 2.9.00 |
| mkl | 2019.0-045 | 2019.4-070 |
| mlnx_ofed | 4.5-1.0.1.0 | 4.6-1.0.1.1 |
| mpich | 3.3 | 3.3.1 |
| mvapich2 | 2.3 | 2.3.1 |
| netcdf | 4.6.1 | 4.7.0 |
| openblas | 0.3.3 | 0.3.6 |
| openmpi | 3.1.2 | 4.0.1 |
| pnetcdf | 1.10.0 | 1.11.2 |
| ucx | 1.4.0 | 1.5.2 |