### PR TITLE
Fix netcdf package name change

### DIFF
--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import LooseVersion
 import logging # pylint: disable=unused-import
 import posixpath
 from copy import copy as _copy
@@ -206,7 +207,12 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         if not toolchain.LDFLAGS:
             toolchain.LDFLAGS = '-L{}/lib'.format(self.__hdf5_dir)
 
-        tarball = 'netcdf-{}.tar.gz'.format(self.__version)
+        # Version 4.7.0 changed the package name
+        if LooseVersion(self.__version) >= LooseVersion('4.7.0'):
+            pkgname = 'netcdf-c'
+        else:
+            pkgname = 'netcdf'
+        tarball = '{0}-{1}.tar.gz'.format(pkgname, self.__version)
         url = '{0}/{1}'.format(self.__baseurl, tarball)
 
         # Download source from web
@@ -217,7 +223,7 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
         self.__commands.append(self.configure_step(
             directory=posixpath.join(self.__wd,
-                                     'netcdf-{}'.format(self.__version)),
+                                     '{0}-{1}'.format(pkgname, self.__version)),
             toolchain=toolchain))
 
         self.__commands.append(self.build_step())
@@ -238,7 +244,7 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, tarball),
                    posixpath.join(self.__wd,
-                                  'netcdf-{}'.format(self.__version))]))
+                                  '{0}-{1}'.format(pkgname, self.__version))]))
 
         # Set the environment
         self.environment_variables['PATH'] = '{}:$PATH'.format(

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-c-4.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-c-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-4.7.0.tar.gz /var/tmp/netcdf-4.7.0 && \
+    rm -rf /var/tmp/netcdf-c-4.7.0.tar.gz /var/tmp/netcdf-c-4.7.0 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-cxx4-4.3.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
@@ -87,12 +87,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-4.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-4.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-c-4.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-c-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/netcdf-4.7.0.tar.gz /var/tmp/netcdf-4.7.0 && \
+    rm -rf /var/tmp/netcdf-c-4.7.0.tar.gz /var/tmp/netcdf-c-4.7.0 && \
     mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.3.0.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/netcdf-cxx4-4.3.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS=-I/usr/local/netcdf/include LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \


### PR DESCRIPTION
The netcdf package name changed from `netcdf` to `netcdf-c` starting in version 4.7.0.