### PR TITLE
Add support for aarch64 processors

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1714,6 +1714,10 @@ incompatibilities.
 __Parameters__
 
 
+- __arch__: The processor architecture of the MVAPICH2-GDR package.  The
+default value is set automatically based on the processor
+architecture of the base image.
+
 - __cuda_version__: The version of CUDA the MVAPICH2-GDR package was
 built against.  The version string format is X.Y.  The version
 should match the version of CUDA provided by the base image.  This

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -298,7 +298,9 @@ and building.  The default values are `autoconf`, `automake`,
 is `charm++`.
 
 - __target_architecture__: The target machine architecture to build.
-The default value is `multicore-linux-x86_64`.
+For x86_64 processors, the default value is
+`multicore-linux-x86_64`.  For aarch64 processors, the default
+value is `multicore-arm8`.
 
 - __version__: The version of Charm++ to download.  The default value is
 `6.9.0`.
@@ -380,9 +382,11 @@ __Parameters__
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
 
-- __configure_opts__: List of options to pass to `configure`.  The
-default values are `--enable-shared`, `--enable-openmp`,
-`--enable-threads`, and `--enable-sse2`.
+- __configure_opts__: List of options to pass to `configure`.  For
+x86_64 processors, the default values are `--enable-shared`,
+`--enable-openmp`, `--enable-threads`, and `--enable-sse2`.  For
+aarch64 processors, the default values are `--enable-shared`,
+`--enable-openmp`, and `--enable-threads`.
 
 - __directory__: Path to the unpackaged source directory relative to the
 local build context.  The default value is empty.  If this is
@@ -1378,7 +1382,8 @@ __Parameters__
 
 - __oslabel__: The Linux distribution label assigned by Mellanox to the
 tarball.  For Ubuntu, the default value is `ubuntu16.04`.  For
-RHEL-based Linux distributions, the default value is `rhel7.2`.
+RHEL-based Linux distributions, the default value is `rhel7.2` for
+x86_64 processors and `rhel7.6alternate` for aarch64 processors.
 
 - __ospackages__: List of OS packages to install prior to installing
 OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -1876,7 +1881,10 @@ For Ubuntu 16.04, the following packages are installed:
 `libdapl2`, `libdapl-dev`, `libibcm1`, `libibcm-dev`, `libibmad5`,
 `libibmad-dev`, `libibverbs1`, `libibverbs-dev`, `libmlx4-1`,
 `libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`, `librdmacm1`,
-`librdmacm-dev`, and `rdmacm-utils`.
+`librdmacm-dev`, and `rdmacm-utils`.  For Ubuntu 16.04 and aarch64
+processors, the `dapl2-utils`, `libdapl2`, `libdapl-dev`,
+`libibcm1` and `libibcm-dev` packages not installed because they
+are not available.
 
 For Ubuntu 18.04, the following packages are installed:
 `dapl2-utils`, `ibutils`, `ibverbs-providers`, `ibverbs-utils`,
@@ -1944,8 +1952,10 @@ directory should be added dynamic linker cache.  If False, then
 `LD_LIBRARY_PATH` is modified to include the OpenBLAS library
 directory. The default value is False.
 
-- __make_opts__: List of options to pass to `make`.  The default value
-is `USE_OPENMP=1`.
+- __make_opts__: List of options to pass to `make`.  For aarch64
+processors, the default values are `TARGET=ARMV8` and
+`USE_OPENMP=1`.  For x86_64 processors, the default value is
+`USE_OPENMP=1`.
 
 - __ospackages__: List of OS packages to install prior to building.  The
 default values are `make`, `perl`, `tar`, and `wget`.

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -343,6 +343,9 @@ The `cmake` building block downloads and installs the
 __Parameters__
 
 
+- __bootstrap_opts__: List of options to pass to `bootstrap` when
+building from source.  The default is an empty list.
+
 - __eula__: By setting this value to `True`, you agree to the [CMake End-User License Agreement](https://gitlab.kitware.com/cmake/cmake/raw/master/Copyright.txt).
 The default value is `False`.
 
@@ -351,6 +354,11 @@ The default value is `wget`.
 
 - __prefix__: The top level install location.  The default value is
 `/usr/local`.
+
+- __source__: Boolean flag to specify whether to build CMake from
+source.  For x86_64 processors, the default is False, i.e., use
+the available pre-compiled package.  For all other processors, the
+default is True.
 
 - __version__: The version of CMake to download.  The default value is
 `3.14.5`.
@@ -365,6 +373,7 @@ cmake(eula=True)
 ```python
 cmake(eula=True, version='3.10.3')
 ```
+
 
 # fftw
 ```python

--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -1,5 +1,13 @@
 # hpccm.config
 
+## get_cpu_architecture
+```python
+get_cpu_architecture()
+```
+Return the architecture string for the currently configured CPU
+architecture, e.g., `aarch64`, `ppc64le`, or `x86_64`.
+
+
 ## set_container_format
 ```python
 set_container_format(ctype)

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import posixpath
 
+import hpccm.config
 import hpccm.templates.ConfigureMake
 import hpccm.templates.envvars
 import hpccm.templates.ldconfig
@@ -33,6 +34,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
+from hpccm.common import cpu_arch
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
@@ -53,9 +55,11 @@ class fftw(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 
-    configure_opts: List of options to pass to `configure`.  The
-    default values are `--enable-shared`, `--enable-openmp`,
-    `--enable-threads`, and `--enable-sse2`.
+    configure_opts: List of options to pass to `configure`.  For
+    x86_64 processors, the default values are `--enable-shared`,
+    `--enable-openmp`, `--enable-threads`, and `--enable-sse2`.  For
+    aarch64 processors, the default values are `--enable-shared`,
+    `--enable-openmp`, and `--enable-threads`.
 
     directory: Path to the unpackaged source directory relative to the
     local build context.  The default value is empty.  If this is
@@ -114,9 +118,7 @@ class fftw(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
         super(fftw, self).__init__(**kwargs)
 
-        self.configure_opts = kwargs.get('configure_opts',
-                                         ['--enable-shared', '--enable-openmp',
-                                          '--enable-threads', '--enable-sse2'])
+        self.configure_opts = kwargs.get('configure_opts', [])
         self.prefix = kwargs.get('prefix', '/usr/local/fftw')
 
         self.__baseurl = kwargs.get('baseurl', 'ftp://ftp.fftw.org/pub/fftw')
@@ -129,6 +131,9 @@ class fftw(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory
+
+        # Set the CPU architecture specific parameters
+        self.__cpu_arch()
 
         # Construct series of steps to execute
         self.__setup()
@@ -151,6 +156,21 @@ class fftw(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
                                              self.__directory))
         self += shell(commands=self.__commands)
         self += environment(variables=self.environment_step())
+
+    def __cpu_arch(self):
+        """Based on the CPU architecture, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if hpccm.config.g_cpu_arch == cpu_arch.AARCH64:
+            if not self.configure_opts:
+                self.configure_opts = ['--enable-shared', '--enable-openmp',
+                                       '--enable-threads']
+        elif hpccm.config.g_cpu_arch == cpu_arch.X86_64:
+            if not self.configure_opts:
+                self.configure_opts = ['--enable-shared', '--enable-openmp',
+                                       '--enable-threads', '--enable-sse2']
+        else: # pragma: no cover
+            raise RuntimeError('Unknown CPU architecture')
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -32,7 +32,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
@@ -102,6 +102,9 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
         self.version = kwargs.get('version', '2019.4-070')
 
         self.__bashrc = ''      # Filled in by __distro()
+
+        if hpccm.config.g_cpu_arch != cpu_arch.X86_64: # pragma: no cover
+            logging.warning('Using intel_mpi on a non-x86_64 processor')
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -34,7 +34,7 @@ import hpccm.templates.tar
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.intel_psxe_runtime import intel_psxe_runtime
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
@@ -203,6 +203,9 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
         self.__bashrc = ''   # Filled in by __distro()
         self.__commands = [] # Filled in by __setup()
+
+        if hpccm.config.g_cpu_arch != cpu_arch.X86_64: # pragma: no cover
+            logging.warning('Using intel_psxe on a non-x86_64 processor')
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -30,7 +30,7 @@ import hpccm.templates.envvars
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
@@ -145,6 +145,9 @@ class intel_psxe_runtime(bb_base, hpccm.templates.envvars):
 
         self.__bashrc = ''            # Filled in by __distro()
         self.__runtime_packages = []  # Filled in by __setup()
+
+        if hpccm.config.g_cpu_arch != cpu_arch.X86_64: # pragma: no cover
+            logging.warning('Using intel_psxe_runtime on a non-x86_64 processor')
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -31,7 +31,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
@@ -99,6 +99,9 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
         self.version = kwargs.get('version', '2019.4-070')
 
         self.__bashrc = ''      # Filled in by __distro()
+
+        if hpccm.config.g_cpu_arch != cpu_arch.X86_64: # pragma: no cover
+            logging.warning('Using mkl on a non-x86_64 processor')
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -31,7 +31,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.shell import shell
@@ -46,7 +46,8 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
 
     oslabel: The Linux distribution label assigned by Mellanox to the
     tarball.  For Ubuntu, the default value is `ubuntu16.04`.  For
-    RHEL-based Linux distributions, the default value is `rhel7.2`.
+    RHEL-based Linux distributions, the default value is `rhel7.2` for
+    x86_64 processors and `rhel7.6alternate` for aarch64 processors.
 
     ospackages: List of OS packages to install prior to installing
     OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -89,6 +90,8 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
 
         super(mlnx_ofed, self).__init__(**kwargs)
 
+        self.__arch_download = None # Filled in __cpu_arch()
+        self.__arch_pkg = None # Filled in by __cpu_arch()
         self.__baseurl = kwargs.get('baseurl',
                                     'http://content.mellanox.com/ofed')
         self.__label = None  # Filled in by __setup()
@@ -101,6 +104,9 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
 
         self.__commands = []
         self.__wd = '/var/tmp'
+
+        # Set the CPU architecture specific parameters
+        self.__cpu_arch()
 
         # Set the Linux distribution specific parameters
         self.__distro()
@@ -117,6 +123,25 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self += comment('Mellanox OFED version {}'.format(self.__version))
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
+
+    def __cpu_arch(self):
+        """Based on the CPU architecture, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if hpccm.config.g_cpu_arch == cpu_arch.AARCH64:
+            self.__arch_download = 'aarch64'
+            if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+                self.__arch_pkg = 'arm64'
+            else:
+                self.__arch_pkg = 'aarch64'
+        elif hpccm.config.g_cpu_arch == cpu_arch.X86_64:
+            self.__arch_download = 'x86_64'
+            if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+                self.__arch_pkg = 'amd64'
+            else:
+                self.__arch_pkg = 'x86_64'
+        else: # pragma: no cover
+            raise RuntimeError('Unknown CPU architecture')
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
@@ -140,18 +165,22 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                                    'libmlx5-1', 'libmlx5-dev',
                                    'librdmacm-dev', 'librdmacm1']
 
-            self.__label = 'MLNX_OFED_LINUX-{0}-{1}-x86_64'.format(
-                self.__version, self.__oslabel)
+            self.__label = 'MLNX_OFED_LINUX-{0}-{1}-{2}'.format(
+                self.__version, self.__oslabel, self.__arch_download)
 
             self.__installer = 'dpkg --install'
             self.__extractor_template = 'dpkg --extract {0} {1}'
 
-            self.__pkglist = ' '.join('{}_*_amd64.deb'.format(
-                posixpath.join(self.__wd, self.__label, 'DEBS', x))
+            self.__pkglist = ' '.join('{}_*_{}.deb'.format(
+                posixpath.join(self.__wd, self.__label, 'DEBS', x),
+                self.__arch_pkg)
                                       for x in self.__packages)
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__oslabel:
-                self.__oslabel = 'rhel7.2'
+                if hpccm.config.g_cpu_arch == cpu_arch.AARCH64:
+                    self.__oslabel = 'rhel7.6alternate'
+                else:
+                    self.__oslabel = 'rhel7.2'
             if not self.__ospackages:
                 self.__ospackages = ['libnl', 'libnl3', 'numactl-libs', 'wget']
             if not self.__packages:
@@ -163,14 +192,15 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                                    'libmlx5', 'libmlx5-devel',
                                    'librdmacm-devel', 'librdmacm']
 
-            self.__label = 'MLNX_OFED_LINUX-{0}-{1}-x86_64'.format(
-                self.__version, self.__oslabel)
+            self.__label = 'MLNX_OFED_LINUX-{0}-{1}-{2}'.format(
+                self.__version, self.__oslabel, self.__arch_download)
 
             self.__installer = 'rpm --install'
             self.__extractor_template = 'rpm2cpio {0} | cpio -idm'
 
-            self.__pkglist = ' '.join('{}-*.x86_64.rpm'.format(
-                posixpath.join(self.__wd, self.__label, 'RPMS', x))
+            self.__pkglist = ' '.join('{}-*.{}.rpm'.format(
+                posixpath.join(self.__wd, self.__label, 'RPMS', x),
+                self.__arch_pkg)
                                       for x in self.__packages)
         else: # pragma: no cover
             raise RuntimeError('Unknown Linux distribution')

--- a/hpccm/building_blocks/mvapich2_gdr.py
+++ b/hpccm/building_blocks/mvapich2_gdr.py
@@ -71,6 +71,10 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
     # Parameters
 
+    arch: The processor architecture of the MVAPICH2-GDR package.  The
+    default value is set automatically based on the processor
+    architecture of the base image.
+
     cuda_version: The version of CUDA the MVAPICH2-GDR package was
     built against.  The version string format is X.Y.  The version
     should match the version of CUDA provided by the base image.  This
@@ -134,6 +138,7 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         super(mvapich2_gdr, self).__init__(**kwargs)
 
+        self.__arch = kwargs.get('arch', hpccm.config.get_cpu_architecture())
         self.__baseurl = kwargs.get('baseurl',
                                     'http://mvapich.cse.ohio-state.edu/download/mvapich/gdr')
         self.__cuda_version = kwargs.get('cuda_version', '9.2')
@@ -143,7 +148,7 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__mofed_version = kwargs.get('mlnx_ofed_version', '4.5')
         self.__ospackages = kwargs.get('ospackages', [])
         self.__package = kwargs.get('package', '')
-        self.__package_template = 'mvapich2-gdr-mcast.{0}.{1}.{2}-{3}-1.el7.x86_64.rpm'
+        self.__package_template = 'mvapich2-gdr-mcast.{0}.{1}.{2}-{3}-1.el7.{4}.rpm'
         self.__pgi = kwargs.get('pgi', False)
         self.__pgi_version = kwargs.get('pgi_version', '18.10')
         self.version = kwargs.get('version', '2.3.1')
@@ -245,7 +250,8 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
             # Package filename
             package = self.__package_template.format(
-                cuda_string, mofed_string, compiler_string, self.version)
+                cuda_string, mofed_string, compiler_string, self.version,
+                self.__arch)
 
         self.__install_path = self.__install_path_template.format(
             self.version, cuda_string, mofed_string, compiler_string)

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -28,7 +28,7 @@ import hpccm.config
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import linux_distro
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.shell import shell
@@ -42,7 +42,10 @@ class ofed(bb_base):
     `libdapl2`, `libdapl-dev`, `libibcm1`, `libibcm-dev`, `libibmad5`,
     `libibmad-dev`, `libibverbs1`, `libibverbs-dev`, `libmlx4-1`,
     `libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`, `librdmacm1`,
-    `librdmacm-dev`, and `rdmacm-utils`.
+    `librdmacm-dev`, and `rdmacm-utils`.  For Ubuntu 16.04 and aarch64
+    processors, the `dapl2-utils`, `libdapl2`, `libdapl-dev`,
+    `libibcm1` and `libibcm-dev` packages not installed because they
+    are not available.
 
     For Ubuntu 18.04, the following packages are installed:
     `dapl2-utils`, `ibutils`, `ibverbs-providers`, `ibverbs-utils`,
@@ -118,6 +121,12 @@ class ofed(bb_base):
                                      'libmlx5-1', 'libmlx5-dev',
                                      'librdmacm1', 'librdmacm-dev',
                                      'rdmacm-utils']
+                if hpccm.config.g_cpu_arch == cpu_arch.AARCH64:
+                    # Ubuntu 16.04 for ARM is missing these packages
+                    for missing in ['dapl2-utils', 'libdapl2', 'libdapl-dev',
+                                    'libibcm1', 'libibcm-dev']:
+                        if missing in self.__ospackages:
+                            self.__ospackages.remove(missing)
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             self.__deppackages = ['libnl', 'libnl3', 'numactl-libs']
             self.__ospackages = ['dapl', 'dapl-devel', 'ibutils', 'libibcm',

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import posixpath
 
+import hpccm.config
 import hpccm.templates.envvars
 import hpccm.templates.ldconfig
 import hpccm.templates.rm
@@ -32,6 +33,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
+from hpccm.common import cpu_arch
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
@@ -54,8 +56,10 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     `LD_LIBRARY_PATH` is modified to include the OpenBLAS library
     directory. The default value is False.
 
-    make_opts: List of options to pass to `make`.  The default value
-    is `USE_OPENMP=1`.
+    make_opts: List of options to pass to `make`.  For aarch64
+    processors, the default values are `TARGET=ARMV8` and
+    `USE_OPENMP=1`.  For x86_64 processors, the default value is
+    `USE_OPENMP=1`.
 
     ospackages: List of OS packages to install prior to building.  The
     default values are `make`, `perl`, `tar`, and `wget`.
@@ -89,7 +93,8 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         super(openblas, self).__init__(**kwargs)
 
         self.__baseurl = kwargs.get('baseurl', 'https://github.com/xianyi/OpenBLAS/archive')
-        self.__make_opts = kwargs.get('make_opts', ['USE_OPENMP=1'])
+        self.__make_opts = kwargs.get('make_opts',
+                                      []) # Filled in by __cpu_arch()
         self.__ospackages = kwargs.get('ospackages', ['make', 'perl', 'tar',
                                                       'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/openblas')
@@ -98,6 +103,9 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory
+
+        # Set the CPU architecture specific parameters
+        self.__cpu_arch()
 
         # Construct the series of steps to execute
         self.__setup()
@@ -112,6 +120,19 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
         self += environment(variables=self.environment_step())
+
+    def __cpu_arch(self):
+        """Based on the CPU architecture, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if hpccm.config.g_cpu_arch == cpu_arch.AARCH64:
+            if not self.__make_opts:
+                self.__make_opts = ['TARGET=ARMV8', 'USE_OPENMP=1']
+        elif hpccm.config.g_cpu_arch == cpu_arch.X86_64:
+            if not self.__make_opts:
+                self.__make_opts = ['USE_OPENMP=1']
+        else: # pragma: no cover
+            raise RuntimeError('Unknown CPU architecture')
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -37,7 +37,24 @@ g_linux_distro = linux_distro.UBUNTU # Linux distribution
 g_linux_version = StrictVersion('16.04') # Linux distribution version
 g_singularity_version = StrictVersion('2.6') # Singularity version
 
+def get_cpu_architecture():
+  """Return the architecture string for the currently configured CPU
+  architecture, e.g., `aarch64`, `ppc64le`, or `x86_64`.
+
+  """
+
+  this = sys.modules[__name__]
+  if this.g_cpu_arch == cpu_arch.AARCH64:
+    return 'aarch64'
+  elif this.g_cpu_arch == cpu_arch.PPC64LE:
+    return 'ppc64le'
+  elif this.g_cpu_arch == cpu_arch.X86_64:
+    return 'x86_64'
+  else: # pragma: no cover
+    raise RuntimeError('Unrecognized processor architecture')
+
 def set_container_format(ctype):
+
   """Set the container format
 
   # Arguments

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -24,7 +24,15 @@ import logging # pylint: disable=unused-import
 
 import hpccm.config
 
-from hpccm.common import container_type, linux_distro
+from hpccm.common import container_type, cpu_arch, linux_distro
+
+def aarch64(function):
+    """Decorator to set the CPU architecture to aarch64"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_arch = cpu_arch.AARCH64
+        return function(*args, **kwargs)
+
+    return wrapper
 
 def bash(function):
     """Decorator to set the global container type to bash"""
@@ -51,6 +59,14 @@ def docker(function):
 
     return wrapper
 
+def invalid_cpu_arch(function):
+    """Decorator to set the global CPU architecture to an invalid value"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_arch = None
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def invalid_ctype(function):
     """Decorator to set the global container type to an invalid value"""
     def wrapper(*args, **kwargs):
@@ -63,6 +79,14 @@ def invalid_distro(function):
     """Decorator to set the global Linux distribution to an invalid value"""
     def wrapper(*args, **kwargs):
         hpccm.config.g_linux_distro = None
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def ppc64le(function):
+    """Decorator to set the CPU architecture to ppc64le"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_arch = cpu_arch.PPC64LE
         return function(*args, **kwargs)
 
     return wrapper
@@ -103,6 +127,14 @@ def ubuntu18(function):
     def wrapper(*args, **kwargs):
         hpccm.config.g_linux_distro = linux_distro.UBUNTU
         hpccm.config.g_linux_version = StrictVersion('18.04')
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def x86_64(function):
+    """Decorator to set the CPU architecture to x86_64"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_arch = cpu_arch.X86_64
         return function(*args, **kwargs)
 
     return wrapper

--- a/test/test_charm.py
+++ b/test/test_charm.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import aarch64, centos, docker, ubuntu, x86_64
 
 from hpccm.building_blocks.charm import charm
 
@@ -31,6 +31,7 @@ class Test_charm(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @x86_64
     @ubuntu
     @docker
     def test_defaults(self):
@@ -55,6 +56,32 @@ ENV CHARMBASE=/usr/local/charm-6.9.0 \
     LD_LIBRARY_PATH=/usr/local/charm-6.9.0/lib_so:$LD_LIBRARY_PATH \
     PATH=/usr/local/charm-6.9.0/bin:$PATH''')
 
+    @aarch64
+    @ubuntu
+    @docker
+    def test_aarch64(self):
+        """Default charm building block"""
+        c = charm(version='6.9.0')
+        self.assertEqual(str(c),
+r'''# Charm++ version 6.9.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        git \
+        libtool \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://charm.cs.illinois.edu/distrib/charm-6.9.0.tar.gz && \
+    mkdir -p /usr/local && tar -x -f /var/tmp/charm-6.9.0.tar.gz -C /usr/local -z && \
+    cd /usr/local/charm-6.9.0 && ./build charm++ multicore-arm8 --build-shared --with-production -j4 && \
+    rm -rf /var/tmp/charm-6.9.0.tar.gz
+ENV CHARMBASE=/usr/local/charm-6.9.0 \
+    LD_LIBRARY_PATH=/usr/local/charm-6.9.0/lib_so:$LD_LIBRARY_PATH \
+    PATH=/usr/local/charm-6.9.0/bin:$PATH''')
+
+    @x86_64
     @ubuntu
     @docker
     def test_ldconfig(self):
@@ -79,6 +106,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 ENV CHARMBASE=/usr/local/charm-v6.8.2 \
     PATH=/usr/local/charm-v6.8.2/bin:$PATH''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_runtime(self):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -101,6 +101,7 @@ class Test_config(unittest.TestCase):
         """Set CPU architecture to ARM"""
         hpccm.config.set_cpu_architecture('aarch64')
         self.assertEqual(hpccm.config.g_cpu_arch, hpccm.cpu_arch.AARCH64)
+        self.assertEqual(hpccm.config.get_cpu_architecture(), 'aarch64')
 
     @docker
     def test_set_cpu_architecture_arm(self):
@@ -119,6 +120,7 @@ class Test_config(unittest.TestCase):
         """Set CPU architecture to POWER"""
         hpccm.config.set_cpu_architecture('ppc64le')
         self.assertEqual(hpccm.config.g_cpu_arch, hpccm.cpu_arch.PPC64LE)
+        self.assertEqual(hpccm.config.get_cpu_architecture(), 'ppc64le')
 
     @docker
     def test_set_cpu_architecture_power(self):
@@ -131,6 +133,7 @@ class Test_config(unittest.TestCase):
         """Set CPU architecture to x86_64"""
         hpccm.config.set_cpu_architecture('x86_64')
         self.assertEqual(hpccm.config.g_cpu_arch, hpccm.cpu_arch.X86_64)
+        self.assertEqual(hpccm.config.get_cpu_architecture(), 'x86_64')
 
     @docker
     def test_set_cpu_architecture_amd64(self):

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import aarch64, centos, docker, ubuntu, x86_64
 
 from hpccm.building_blocks.fftw import fftw
 
@@ -31,6 +31,7 @@ class Test_fftw(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @x86_64
     @ubuntu
     @docker
     def test_defaults_ubuntu(self):
@@ -52,6 +53,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     @centos
     @docker
     def test_defaults_centos(self):
@@ -72,6 +74,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_mpi(self):
@@ -93,6 +96,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_ldconfig(self):
@@ -114,6 +118,29 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     echo "/usr/local/fftw/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
     rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8''')
 
+    @aarch64
+    @ubuntu
+    @docker
+    def test_aarch64(self):
+        """Default fftw building block"""
+        f = fftw(version='3.3.8')
+        self.assertEqual(str(f),
+r'''# FFTW version 3.3.8
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-shared --enable-openmp --enable-threads && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/fftw-3.3.8.tar.gz /var/tmp/fftw-3.3.8
+ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
+
+    @x86_64
     @ubuntu
     @docker
     def test_runtime(self):
@@ -125,6 +152,7 @@ r'''# FFTW
 COPY --from=0 /usr/local/fftw /usr/local/fftw
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_directory(self):

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu, ubuntu18
+from helpers import aarch64, centos, docker, ubuntu, ubuntu18, x86_64
 
 from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
 
@@ -31,6 +31,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @x86_64
     @ubuntu
     @docker
     def test_defaults_ubuntu(self):
@@ -50,6 +51,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
+    @x86_64
     @ubuntu18
     @docker
     def test_defaults_ubuntu(self):
@@ -69,6 +71,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64''')
 
+    @x86_64
     @centos
     @docker
     def test_defaults_centos(self):
@@ -87,6 +90,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     rpm --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibverbs-utils-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibmad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libibumad-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx4-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/libmlx5-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-devel-*.x86_64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_prefix_ubuntu(self):
@@ -120,6 +124,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     dpkg --extract /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb /opt/ofed && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
+    @x86_64
     @centos
     @docker
     def test_prefix_centos(self):
@@ -152,6 +157,66 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     rpm2cpio /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64/RPMS/librdmacm-*.x86_64.rpm | cpio -idm && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
 
+    @aarch64
+    @ubuntu
+    @docker
+    def test_aarch64_ubuntu(self):
+        """aarch64"""
+        mofed = mlnx_ofed(version='4.5-1.0.1.0')
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibverbs1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibverbs-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/ibverbs-utils_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibmad_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibmad-devel_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibumad_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libibumad-devel_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libmlx4-1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libmlx4-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libmlx5-1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/libmlx5-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/librdmacm-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64/DEBS/librdmacm1_*_arm64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64''')
+
+    @aarch64
+    @ubuntu18
+    @docker
+    def test_aarch64_ubuntu18(self):
+        """aarch64"""
+        mofed = mlnx_ofed(version='4.6-1.0.1.1')
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.6-1.0.1.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libnl-3-200 \
+        libnl-route-3-200 \
+        libnuma1 \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz -C /var/tmp -z && \
+    dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibverbs1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibverbs-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/ibverbs-utils_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibmad_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibmad-devel_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibumad_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libibumad-devel_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libmlx4-1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libmlx4-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libmlx5-1_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/libmlx5-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/librdmacm-dev_*_arm64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64/DEBS/librdmacm1_*_arm64.deb && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64''')
+
+    @aarch64
+    @centos
+    @docker
+    def test_aarch64_centos(self):
+        """aarch64"""
+        mofed = mlnx_ofed()
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.6-1.0.1.1
+RUN yum install -y \
+        libnl \
+        libnl3 \
+        numactl-libs \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz -C /var/tmp -z && \
+    rpm --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibverbs-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibverbs-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibverbs-utils-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibmad-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibmad-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibumad-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libibumad-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libmlx4-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libmlx4-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libmlx5-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/libmlx5-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/librdmacm-devel-*.aarch64.rpm /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64/RPMS/librdmacm-*.aarch64.rpm && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64''')
+
+    @x86_64
     @ubuntu
     @docker
     def test_runtime(self):
@@ -172,6 +237,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     dpkg --install /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibverbs-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/ibverbs-utils_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibmad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libibumad-devel_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx4-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-1_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/libmlx5-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm-dev_*_amd64.deb /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64/DEBS/librdmacm1_*_amd64.deb && \
     rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_prefix_runtime(self):

--- a/test/test_ofed.py
+++ b/test/test_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu, ubuntu18
+from helpers import aarch64, centos, docker, ubuntu, ubuntu18, x86_64
 
 from hpccm.building_blocks.ofed import ofed
 
@@ -31,6 +31,7 @@ class Test_ofed(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @x86_64
     @ubuntu
     @docker
     def test_defaults_ubuntu(self):
@@ -61,6 +62,7 @@ RUN apt-get update -y && \
         rdmacm-utils && \
     rm -rf /var/lib/apt/lists/*''')
 
+    @x86_64
     @ubuntu18
     @docker
     def test_defaults_ubuntu18(self):
@@ -86,6 +88,7 @@ RUN apt-get update -y && \
         rdmacm-utils && \
     rm -rf /var/lib/apt/lists/*''')
 
+    @x86_64
     @centos
     @docker
     def test_defaults_centos(self):
@@ -109,6 +112,7 @@ RUN yum install -y \
         rdma-core-devel && \
     rm -rf /var/cache/yum/*''')
 
+    @x86_64
     @ubuntu
     @docker
     def test_prefix_ubuntu16(self):
@@ -149,6 +153,33 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /etc/libibverbs.d''')
 
+    @aarch64
+    @ubuntu
+    @docker
+    def test_aarch64_ubuntu16(self):
+        """aarch64"""
+        o = ofed()
+        self.assertEqual(str(o),
+r'''# OFED
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibutils \
+        ibverbs-utils \
+        infiniband-diags \
+        libibmad-dev \
+        libibmad5 \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 \
+        rdmacm-utils && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    @x86_64
     @ubuntu
     @docker
     def test_runtime(self):

--- a/test/test_yum.py
+++ b/test/test_yum.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker
+from helpers import aarch64, centos, docker, x86_64
 
 from hpccm.building_blocks.yum import yum
 
@@ -31,6 +31,7 @@ class Test_yum(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @x86_64
     @centos
     @docker
     def test_basic(self):
@@ -43,6 +44,7 @@ r'''RUN yum install -y \
         gcc-fortran && \
     rm -rf /var/cache/yum/*''')
 
+    @x86_64
     @centos
     @docker
     def test_add_repo(self):
@@ -57,6 +59,7 @@ r'''RUN rpm --import https://www.example.com/key.pub && \
         example && \
     rm -rf /var/cache/yum/*''')
 
+    @x86_64
     @centos
     @docker
     def test_download(self):
@@ -70,6 +73,21 @@ r'''RUN yum install -y yum-utils && \
         rdma-core && \
     rm -rf /var/cache/yum/*''')
 
+    @aarch64
+    @centos
+    @docker
+    def test_download_aarch64(self):
+        """Download parameter"""
+        y = yum(download=True, download_directory='/tmp/download',
+                ospackages=['rdma-core'])
+        self.assertEqual(str(y),
+r'''RUN yum install -y yum-utils && \
+    mkdir -p /tmp/download && \
+    yumdownloader --destdir=/tmp/download  \
+        rdma-core && \
+    rm -rf /var/cache/yum/*''')
+
+    @x86_64
     @centos
     @docker
     def test_extract(self):


### PR DESCRIPTION
Update the building blocks that have issues on ARM.

- charm: set default `target_architecture` appropriate for the processor architecture
- cmake: add capability to build from source and select that automatically when pre-built binaries for the architecture are not available
- fftw: only use `--enable-sse2` on x86_64 processors
- Intel building blocks: emit warning if used on non-x86_64 processors
- mlnx_ofed: set defaults to use packages appropriate for the processor architecture
- mvapich2_gdr: set defaults to use packages appropriate for the processor architecture (note: no ARM packages are currently available from OSU)
- ofed: exclude DAPL and IB CM packages that are not available from the Ubuntu 16.04 upstream repository for ARM
- openblas: automatically set the target architecture appropriate for the processor architecture
- yum: enable extracting packages for non-x86_64 processors