### PR TITLE
Adds _arguments option to shell primitive

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -306,6 +306,14 @@ identifier.  This also causes the Singularity block to named
 environment should be also be loaded when executing a SCI-F
 `%appinstall` block.  The default is False.
 
+- ___arguments__: A string of additional arguments to the Docker RUN
+statement. Can be used to mount a host directory into the container
+during build time. Another use case is to supply cached directories
+on the host. This requires the environment variable `DOCKER_BUILDKIT=1`
+and the following line at the beginning of the Dockerfile:
+`# syntax=docker/dockerfile:experimental`. (Docker specific)
+For more info see the [Docker Buildkit docs](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#experimental-syntaxes)
+
 - __chdir__: Boolean flag to specify whether to change the working
 directory to `/` before executing any commands.  Docker
 automatically resets the working directory for each `RUN`
@@ -327,6 +335,11 @@ __Examples__
 shell(commands=['cd /path/to/src', './configure', 'make install'])
 ```
 
+```python
+# Cache Go packages
+shell(_arguments=['--mount=type=cache,target=/root/.cache/go-build']
+      commands=['cd /path/to/go-src', 'go build'])
+```
 
 # user
 ```python

--- a/hpccm/primitives/shell.py
+++ b/hpccm/primitives/shell.py
@@ -40,6 +40,13 @@ class shell(object):
     environment should be also be loaded when executing a SCI-F
     `%appinstall` block.  The default is False.
 
+    _arguments: Using experimental syntax to supply Docker RUN arguments.
+    Can be used to mount a host path into the container during build.
+    Requires env var DOCKER_BUILDKIT=1 and the following line in the Dockerfile:
+    # syntax=docker/dockerfile:experimental
+    (Docker specific), see also:
+    https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#experimental-syntaxes
+
     chdir: Boolean flag to specify whether to change the working
     directory to `/` before executing any commands.  Docker
     automatically resets the working directory for each `RUN`
@@ -69,6 +76,7 @@ class shell(object):
 
         self._app = kwargs.get('_app', '') # Singularity specific
         self._appenv = kwargs.get('_appenv', False) # Singularity specific
+        self._arguments = kwargs.get('_arguments', '') # Docker specific
         self.chdir = kwargs.get('chdir', True)
         self.commands = kwargs.get('commands', [])
         self._test = kwargs.get('_test', False) # Singularity specific
@@ -89,10 +97,16 @@ class shell(object):
                 # RUN cmd1 && \
                 #     cmd2 && \
                 #     cmd3
-                s = ['RUN {}'.format(self.commands[0])]
+                s = ['RUN ']
+                if self._arguments:
+                    s[0] += self._arguments + ' '
+                s[0] += self.commands[0]
                 s.extend(['    {}'.format(x) for x in self.commands[1:]])
                 return ' && \\\n'.join(s)
             elif hpccm.config.g_ctype == container_type.SINGULARITY:
+                if self._arguments:
+                    logging.warning('The Docker specific _arguments was given: '
+                                    'ignoring statement!')
                 # Format:
                 # %post [OR %appinstall app_name]
                 #     cmd1

--- a/test/test_shell.py
+++ b/test/test_shell.py
@@ -159,3 +159,10 @@ class Test_shell(unittest.TestCase):
         s.append(shell(commands=['c']))
         merged = s[0].merge(s)
         self.assertEqual(str(merged), '%post\n    cd /\n    a\n    b\n    c')
+
+    @docker
+    def test_arguments_docker(self):
+        """List of commands specified"""
+        cmds = ['a', 'b', 'c']
+        s = shell(commands=cmds, _arguments='--mount=type=bind,target=/usr/local/mysrc')
+        self.assertEqual(str(s), 'RUN --mount=type=bind,target=/usr/local/mysrc a && \\\n    b && \\\n    c')


### PR DESCRIPTION
Enables the following experimental syntax (Docker specific):

https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#experimental-syntaxes

for mounting host directories and persistent cache directories during container build time.