### PR TITLE
Add CMake to PATH and create a prefix directory for binary installation

### DIFF
--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -153,7 +153,6 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             self.__commands.append(
                 '/bin/sh {0} --prefix={1}'.format(
                     posixpath.join(self.__wd, runfile), self.__prefix))
-        
         # Cleanup runfile
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, runfile)]))

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -153,6 +153,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             self.__commands.append(
                 '/bin/sh {0} --prefix={1}'.format(
                     posixpath.join(self.__wd, runfile), self.__prefix))
+                    
         # Cleanup runfile
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, runfile)]))

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -35,6 +35,7 @@ from hpccm.building_blocks.packages import packages
 from hpccm.common import cpu_arch
 from hpccm.primitives.comment import comment
 from hpccm.primitives.shell import shell
+from hpccm.primitives.environment import environment
 
 class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             hpccm.templates.wget):
@@ -109,6 +110,9 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self += comment('CMake version {}'.format(self.__version))
         self += packages(ospackages=self.__ospackages)
         self += shell(commands=self.__commands)
+        self += environment(variables={'PATH': '{}:$PATH'.format(
+            posixpath.join(self.__prefix, 'bin'))})
+
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -137,6 +141,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__commands.append(self.download_step(url=url,
                                                   directory=self.__wd))
 
+        self.__commands.append('mkdir -p {}'.format(self.__prefix))
         # Run the runfile
         if self.__eula:
             self.__commands.append(
@@ -148,7 +153,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             self.__commands.append(
                 '/bin/sh {0} --prefix={1}'.format(
                     posixpath.join(self.__wd, runfile), self.__prefix))
-
+        
         # Cleanup runfile
         self.__commands.append(self.cleanup_step(
             items=[posixpath.join(self.__wd, runfile)]))

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -45,8 +45,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
     @centos
@@ -61,8 +63,10 @@ RUN yum install -y \
         wget && \
     rm -rf /var/cache/yum/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
     @ubuntu
@@ -78,8 +82,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh''')
+    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
     @ubuntu
@@ -95,8 +101,10 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh && \
+    mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.10.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.10.3-Linux-x86_64.sh''')
+    rm -rf /var/tmp/cmake-3.10.3-Linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
     @centos
@@ -115,7 +123,8 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     cd /var/tmp/cmake-3.14.5 && ./bootstrap --prefix=/usr/local --parallel=$(nproc) && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /var/tmp/cmake-3.14.5.tar.gz /var/tmp/cmake-3.14.5''')
+    rm -rf /var/tmp/cmake-3.14.5.tar.gz /var/tmp/cmake-3.14.5
+ENV PATH=/usr/local/bin:$PATH''')
 
     @aarch64
     @centos
@@ -134,4 +143,5 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     cd /var/tmp/cmake-3.14.5 && ./bootstrap --prefix=/usr/local --parallel=$(nproc) && \
     make -j$(nproc) && \
     make install && \
-    rm -rf /var/tmp/cmake-3.14.5.tar.gz /var/tmp/cmake-3.14.5''')
+    rm -rf /var/tmp/cmake-3.14.5.tar.gz /var/tmp/cmake-3.14.5
+ENV PATH=/usr/local/bin:$PATH''')


### PR DESCRIPTION
Installing CMake will fail if the prefix directory doesn't exist. Need to create it first.
Also added CMake bin dir to PATH so it will be in a global namespace