### PR TITLE
Include binutils runtime dependency for the ucx building block

### DIFF
--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -236,6 +236,10 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         r = u.runtime()
         self.assertEqual(r,
 r'''# UCX
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        binutils && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/ucx /usr/local/ucx
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')


### PR DESCRIPTION
UCX version 1.6 requires libbfd at runtime