### PR TITLE
Add building blocks for generic Autotools and CMake packages

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -664,6 +664,159 @@ Stage0 += g
 Stage1 += g.runtime()
 ```
 
+# generic_autotools
+```python
+generic_autotools(self, **kwargs)
+```
+The `generic_autotools` building block downloads, configures,
+builds, and installs a specified GNU Autotools enabled package.
+
+__Parameters__
+
+
+- __build_directory__: The location to build the package.  The default
+value is the source code location.
+
+- __check__: Boolean flag to specify whether the `make check` step
+should be performed.  The default is False.
+
+- __configure_opts__: List of options to pass to `configure`.  The
+default value is an empty list.
+
+- __directory__: The source code location.  The default value is the
+basename of the downloaded package.  If the value is not an
+absolute path, then the temporary working directory is prepended.
+
+- __install__: Boolean flag to specify whether the `make install` step
+should be performed.  The default is True.
+
+- __make__: Boolean flag to specify whether the `make` step should be
+performed.  The default is True.
+
+- __postinstall__: List of shell commands to run after running 'make
+install'.  The working directory is the install prefix.  The
+default is an empty list.
+
+- __preconfigure__: List of shell commands to run prior to running
+`configure`.  The working directory is the source code location.
+The default is an empty list.
+
+- __prefix__: The top level install location.  The default value is
+`/usr/local`. It is highly recommended not use use this default
+and instead set the prefix to a package specific directory.
+
+- __toolchain__: The toolchain object.  This should be used if
+non-default compilers or other toolchain options are needed.  The
+default is empty.
+
+- __url__: The URL of the tarball package to build.  This parameter must
+be specified.
+
+__Examples__
+
+
+```python
+generic_autotools(directory='tcl8.6.9/unix',
+                  prefix='/usr/local/tcl',
+                  url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+```
+
+
+## runtime
+```python
+generic_autotools.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+
+```python
+g = generic_autotools(...)
+Stage0 += g
+Stage1 += g.runtime()
+```
+
+# generic_cmake
+```python
+generic_cmake(self, **kwargs)
+```
+The `generic_cmake` building block downloads, configures,
+builds, and installs a specified CMake enabled package.
+
+__Parameters__
+
+
+- __build_directory__: The location to build the package.  The default
+value is a `build` subdirectory in the source code location.
+
+- __configure_opts__: List of options to pass to `cmake`.  The default
+value is an empty list.
+
+- __directory__: The source code location.  The default value is the
+basename of the downloaded package.  If the value is not an
+absolute path, then the temporary working directory is prepended.
+
+- __install__: Boolean flag to specify whether the `make install` step
+should be performed.  The default is True.
+
+- __make__: Boolean flag to specify whether the `make` step should be
+performed.  The default is True.
+
+- __postinstall__: List of shell commands to run after running 'make
+install'.  The working directory is the install prefix.  The
+default is an empty list.
+
+- __preconfigure__: List of shell commands to run prior to running
+`cmake`.  The working directory is the source code location.  The
+default is an empty list.
+
+- __prefix__: The top level install location.  The default value is
+`/usr/local`. It is highly recommended not to use this default and
+instead set the prefix to a package specific directory.
+
+- __toolchain__: The toolchain object.  This should be used if
+non-default compilers or other toolchain options are needed.  The
+default is empty.
+
+- __url__: The URL of the tarball package to build.  This parameter must
+be specified.
+
+__Examples__
+
+
+```python
+generic_cmake(cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                          '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                          '-D GMX_BUILD_OWN_FFTW=ON',
+                          '-D GMX_GPU=ON',
+                          '-D GMX_MPI=OFF',
+                          '-D GMX_OPENMP=ON',
+                          '-D GMX_PREFER_STATIC_LIBS=ON',
+                          '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+              directory='gromacs-2018.2',
+              prefix='/usr/local/gromacs',
+              url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+```
+
+
+## runtime
+```python
+generic_cmake.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+
+```python
+g = generic_cmake(...)
+Stage0 += g
+Stage1 += g.runtime()
+```
+
 # gnu
 ```python
 gnu(self, **kwargs)

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -24,6 +24,8 @@ from hpccm.building_blocks.cmake import cmake
 from hpccm.building_blocks.conda import conda
 from hpccm.building_blocks.fftw import fftw
 from hpccm.building_blocks.gdrcopy import gdrcopy
+from hpccm.building_blocks.generic_autotools import generic_autotools
+from hpccm.building_blocks.generic_cmake import generic_cmake
 from hpccm.building_blocks.gnu import gnu
 from hpccm.building_blocks.hdf5 import hdf5
 from hpccm.building_blocks.intel_mpi import intel_mpi

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""Generic autotools building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import posixpath
+import re
+
+import hpccm.templates.ConfigureMake
+import hpccm.templates.rm
+import hpccm.templates.tar
+import hpccm.templates.wget
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.shell import shell
+from hpccm.toolchain import toolchain
+
+class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
+                        hpccm.templates.rm, hpccm.templates.tar,
+                        hpccm.templates.wget):
+    """The `generic_autotools` building block downloads, configures,
+    builds, and installs a specified GNU Autotools enabled package.
+
+    # Parameters
+
+    build_directory: The location to build the package.  The default
+    value is the source code location.
+
+    check: Boolean flag to specify whether the `make check` step
+    should be performed.  The default is False.
+
+    configure_opts: List of options to pass to `configure`.  The
+    default value is an empty list.
+
+    directory: The source code location.  The default value is the
+    basename of the downloaded package.  If the value is not an
+    absolute path, then the temporary working directory is prepended.
+
+    install: Boolean flag to specify whether the `make install` step
+    should be performed.  The default is True.
+
+    make: Boolean flag to specify whether the `make` step should be
+    performed.  The default is True.
+
+    postinstall: List of shell commands to run after running 'make
+    install'.  The working directory is the install prefix.  The
+    default is an empty list.
+
+    preconfigure: List of shell commands to run prior to running
+    `configure`.  The working directory is the source code location.
+    The default is an empty list.
+
+    prefix: The top level install location.  The default value is
+    `/usr/local`. It is highly recommended not use use this default
+    and instead set the prefix to a package specific directory.
+
+    toolchain: The toolchain object.  This should be used if
+    non-default compilers or other toolchain options are needed.  The
+    default is empty.
+
+    url: The URL of the tarball package to build.  This parameter must
+    be specified.
+
+    # Examples
+
+    ```python
+    generic_autotools(directory='tcl8.6.9/unix',
+                      prefix='/usr/local/tcl',
+                      url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(generic_autotools, self).__init__(**kwargs)
+
+        self.__build_directory = kwargs.get('build_directory', None)
+        self.__check = kwargs.get('check', False)
+        self.configure_opts = kwargs.get('configure_opts', [])
+        self.__directory = kwargs.get('directory', None)
+        self.__environment = kwargs.get('environment', {})
+        self.__install = kwargs.get('install', True)
+        self.__make = kwargs.get('make', True)
+        self.__postinstall = kwargs.get('postinstall', [])
+        self.__preconfigure = kwargs.get('preconfigure', [])
+        self.__toolchain = kwargs.get('toolchain', toolchain())
+        self.__url = kwargs.get('url', None)
+
+        self.__commands = [] # Filled in by __setup()
+        self.__wd = '/var/tmp' # working directory
+
+        if not self.__url:
+            raise RuntimeError('must specify a URL')
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment(self.__url, reformat=False)
+        self += shell(commands=self.__commands)
+
+    def __setup(self):
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
+
+        # Set the name of the tarball, untarred package directory, and
+        # source directory inside the extracted directory
+        tarball = posixpath.basename(self.__url)
+        match = re.search(r'(.*)(?:(?:\.tar)|(?:\.tar\.gz)|(?:\.tgz)|(?:\.tar\.bz2)|(?:\.tar\.xz))$',
+                          tarball)
+        if match:
+            pkgdir = match.group(1)
+        else:
+            raise RuntimeError('unrecognized package format')
+
+        # directory containing the unarchived package
+        if self.__directory:
+            if posixpath.isabs(self.__directory):
+                directory = self.__directory
+            else:
+                directory = posixpath.join(self.__wd, self.__directory)
+        else:
+            directory = posixpath.join(self.__wd, pkgdir)
+
+        # Download source from web
+        self.__commands.append(self.download_step(url=self.__url,
+                                                  directory=self.__wd))
+
+        # Untar source package
+        self.__commands.append(self.untar_step(
+            tarball=posixpath.join(self.__wd, tarball),
+            directory=self.__wd))
+
+        # Preconfigure setup
+        if self.__preconfigure:
+            # Assume the preconfigure commands should be run from the
+            # source directory
+            self.__commands.append('cd {}'.format(directory))
+            self.__commands.extend(self.__preconfigure)
+
+        # Configure
+        environment = []
+        if self.__environment:
+            for key, val in sorted(self.__environment.items()):
+                environment.append('{0}={1}'.format(key, val))
+        self.__commands.append(self.configure_step(
+            build_directory=self.__build_directory,
+            directory=directory, environment=environment,
+            toolchain=self.__toolchain))
+
+        # Build
+        if self.__make:
+            self.__commands.append(self.build_step())
+
+        # Check the build
+        if self.__check:
+            self.__commands.append(self.check_step())
+
+        # Install
+        if self.__install:
+            self.__commands.append(self.install_step())
+
+        if self.__postinstall:
+            # Assume the postinstall commands should be run from the
+            # install directory
+            self.__commands.append('cd {}'.format(self.prefix))
+            self.__commands.extend(self.__postinstall)
+
+        # Cleanup
+        remove = [posixpath.join(self.__wd, tarball), directory]
+        if self.__build_directory:
+            remove.append(self.__build_directory)
+        self.__commands.append(self.cleanup_step(items=remove))
+
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+
+        ```python
+        g = generic_autotools(...)
+        Stage0 += g
+        Stage1 += g.runtime()
+        ```
+        """
+        instructions = []
+        instructions.append(comment(self.__url, reformat=False))
+        instructions.append(copy(_from=_from, src=self.prefix,
+                                 dest=self.prefix))
+        return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""Generic cmake building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import posixpath
+import re
+
+import hpccm.templates.CMakeBuild
+import hpccm.templates.rm
+import hpccm.templates.tar
+import hpccm.templates.wget
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.shell import shell
+from hpccm.toolchain import toolchain
+
+class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
+                    hpccm.templates.rm, hpccm.templates.tar,
+                    hpccm.templates.wget):
+    """The `generic_cmake` building block downloads, configures,
+    builds, and installs a specified CMake enabled package.
+
+    # Parameters
+
+    build_directory: The location to build the package.  The default
+    value is a `build` subdirectory in the source code location.
+
+    configure_opts: List of options to pass to `cmake`.  The default
+    value is an empty list.
+
+    directory: The source code location.  The default value is the
+    basename of the downloaded package.  If the value is not an
+    absolute path, then the temporary working directory is prepended.
+
+    install: Boolean flag to specify whether the `make install` step
+    should be performed.  The default is True.
+
+    make: Boolean flag to specify whether the `make` step should be
+    performed.  The default is True.
+
+    postinstall: List of shell commands to run after running 'make
+    install'.  The working directory is the install prefix.  The
+    default is an empty list.
+
+    preconfigure: List of shell commands to run prior to running
+    `cmake`.  The working directory is the source code location.  The
+    default is an empty list.
+
+    prefix: The top level install location.  The default value is
+    `/usr/local`. It is highly recommended not to use this default and
+    instead set the prefix to a package specific directory.
+
+    toolchain: The toolchain object.  This should be used if
+    non-default compilers or other toolchain options are needed.  The
+    default is empty.
+
+    url: The URL of the tarball package to build.  This parameter must
+    be specified.
+
+    # Examples
+
+    ```python
+    generic_cmake(cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                              '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                              '-D GMX_BUILD_OWN_FFTW=ON',
+                              '-D GMX_GPU=ON',
+                              '-D GMX_MPI=OFF',
+                              '-D GMX_OPENMP=ON',
+                              '-D GMX_PREFER_STATIC_LIBS=ON',
+                              '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+                  directory='gromacs-2018.2',
+                  prefix='/usr/local/gromacs',
+                  url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(generic_cmake, self).__init__(**kwargs)
+
+        self.__build_directory = kwargs.get('build_directory', 'build')
+        self.cmake_opts = kwargs.get('cmake_opts', [])
+        self.__directory = kwargs.get('directory', None)
+        self.__environment = kwargs.get('environment', {})
+        self.__install = kwargs.get('install', True)
+        self.__make = kwargs.get('make', True)
+        self.__postinstall = kwargs.get('postinstall', [])
+        self.__preconfigure = kwargs.get('preconfigure', [])
+        self.__toolchain = kwargs.get('toolchain', toolchain())
+        self.__url = kwargs.get('url', None)
+
+        self.__commands = [] # Filled in by __setup()
+        self.__wd = '/var/tmp' # working directory
+
+        if not self.__url:
+            raise RuntimeError('must specify a URL')
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment(self.__url, reformat=False)
+        self += shell(commands=self.__commands)
+
+    def __setup(self):
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
+
+        # Set the name of the tarball, untarred package directory, and
+        # source directory inside the extracted directory
+        tarball = posixpath.basename(self.__url)
+        match = re.search(r'(.*)(?:(?:\.tar)|(?:\.tar\.gz)|(?:\.tgz)|(?:\.tar\.bz2)|(?:\.tar\.xz))$',
+                          tarball)
+        if match:
+            pkgdir = match.group(1)
+        else:
+            raise RuntimeError('unrecognized package format')
+
+        # directory containing the unarchived package
+        if self.__directory:
+            if posixpath.isabs(self.__directory):
+                directory = self.__directory
+            else:
+                directory = posixpath.join(self.__wd, self.__directory)
+        else:
+            directory = posixpath.join(self.__wd, pkgdir)
+
+        # Download source from web
+        self.__commands.append(self.download_step(url=self.__url,
+                                                  directory=self.__wd))
+
+        # Untar source package
+        self.__commands.append(self.untar_step(
+            tarball=posixpath.join(self.__wd, tarball),
+            directory=self.__wd))
+
+        # Preconfigure setup
+        if self.__preconfigure:
+            # Assume the preconfigure commands should be run from the
+            # source directory
+            self.__commands.append('cd {}'.format(directory))
+            self.__commands.extend(self.__preconfigure)
+
+        # Configure
+        environment = []
+        if self.__environment:
+            for key, val in sorted(self.__environment.items()):
+                environment.append('{0}={1}'.format(key, val))
+        self.__commands.append(self.configure_step(
+            build_directory=self.__build_directory,
+            directory=directory, environment=environment,
+            toolchain=self.__toolchain))
+
+        # Build
+        if self.__make:
+            self.__commands.append(self.build_step())
+
+        # Install
+        if self.__install:
+            self.__commands.append(self.build_step(target='install'))
+
+        if self.__postinstall:
+            # Assume the postinstall commands should be run from the
+            # install directory
+            self.__commands.append('cd {}'.format(self.prefix))
+            self.__commands.extend(self.__postinstall)
+
+        # Cleanup
+        remove = [posixpath.join(self.__wd, tarball), directory]
+        if self.__build_directory:
+            if posixpath.isabs(self.__build_directory):
+                remove.append(self.__build_directory)
+        self.__commands.append(self.cleanup_step(items=remove))
+
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+
+        ```python
+        g = generic_cmake(...)
+        Stage0 += g
+        Stage1 += g.runtime()
+        ```
+        """
+        instructions = []
+        instructions.append(comment(self.__url, reformat=False))
+        instructions.append(copy(_from=_from, src=self.prefix,
+                                 dest=self.prefix))
+        return '\n'.join(str(x) for x in instructions)

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -14,6 +14,8 @@ generate:
   - hpccm.building_blocks.conda+
   - hpccm.building_blocks.fftw+
   - hpccm.building_blocks.gdrcopy+
+  - hpccm.building_blocks.generic_autotools+
+  - hpccm.building_blocks.generic_cmake+
   - hpccm.building_blocks.gnu+
   - hpccm.building_blocks.hdf5+
   - hpccm.building_blocks.intel_mpi+

--- a/test/test_generic_autotools.py
+++ b/test/test_generic_autotools.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the generic_autotools module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu
+
+from hpccm.building_blocks.generic_autotools import generic_autotools
+from hpccm.toolchain import toolchain
+
+class Test_generic_autotools(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @ubuntu
+    @docker
+    def test_defaults_ubuntu(self):
+        """Default generic_autotools building block"""
+        g = generic_autotools(
+            directory='tcl8.6.9/unix',
+            prefix='/usr/local/tcl',
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/tcl8.6.9-src.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/tcl8.6.9/unix &&   ./configure --prefix=/usr/local/tcl && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/tcl8.6.9-src.tar.gz /var/tmp/tcl8.6.9/unix''')
+
+    @ubuntu
+    @docker
+    def test_no_url(self):
+        """missing url"""
+        with self.assertRaises(RuntimeError):
+            g = generic_autotools()
+
+    @ubuntu
+    @docker
+    def test_invalid_package(self):
+        """invalid package url"""
+        with self.assertRaises(RuntimeError):
+            g = generic_autotools(url='https://foo/bar.sh')
+
+    @ubuntu
+    @docker
+    def test_pre_and_post(self):
+        """Preconfigure and postinstall options"""
+        g = generic_autotools(
+            directory='tcl8.6.9/unix',
+            postinstall=['echo "post"'],
+            preconfigure=['echo "pre"'],
+            prefix='/usr/local/tcl',
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/tcl8.6.9-src.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/tcl8.6.9/unix && \
+    echo "pre" && \
+    cd /var/tmp/tcl8.6.9/unix &&   ./configure --prefix=/usr/local/tcl && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    cd /usr/local/tcl && \
+    echo "post" && \
+    rm -rf /var/tmp/tcl8.6.9-src.tar.gz /var/tmp/tcl8.6.9/unix''')
+
+    @ubuntu
+    @docker
+    def test_configure_opts_check(self):
+        """Configure options and check enabled"""
+        g = generic_autotools(
+            check=True,
+            configure_opts=['--disable-getpwuid',
+                            '--enable-orterun-prefix-by-default'],
+            prefix='/usr/local/openmpi',
+            url='https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2')
+        self.assertEqual(str(g),
+r'''# https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default && \
+    make -j$(nproc) && \
+    make -j$(nproc) check && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1''')
+
+    @ubuntu
+    @docker
+    def test_environment_and_toolchain(self):
+        """environment and toolchain"""
+        tc = toolchain(CC='gcc', CXX='g++', FC='gfortran')
+        g = generic_autotools(
+            build_directory='/tmp/build',
+            directory='/var/tmp/tcl8.6.9/unix',
+            environment={'FOO': 'BAR'},
+            prefix='/usr/local/tcl',
+            toolchain=tc,
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/tcl8.6.9-src.tar.gz -C /var/tmp -z && \
+    mkdir -p /tmp/build && cd /tmp/build &&  FOO=BAR CC=gcc CXX=g++ FC=gfortran /var/tmp/tcl8.6.9/unix/configure --prefix=/usr/local/tcl && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/tcl8.6.9-src.tar.gz /var/tmp/tcl8.6.9/unix /tmp/build''')
+
+    @ubuntu
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        g = generic_autotools(
+            directory='tcl8.6.9/unix',
+            prefix='/usr/local/tcl',
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+COPY --from=0 /usr/local/tcl /usr/local/tcl''')

--- a/test/test_generic_cmake.py
+++ b/test/test_generic_cmake.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the generic_cmake module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu
+
+from hpccm.building_blocks.generic_cmake import generic_cmake
+from hpccm.toolchain import toolchain
+
+class Test_generic_cmake(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @ubuntu
+    @docker
+    def test_defaults_ubuntu(self):
+        """Default generic_cmake building block"""
+        g = generic_cmake(
+            cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                        '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                        '-D GMX_BUILD_OWN_FFTW=ON',
+                        '-D GMX_GPU=ON',
+                        '-D GMX_MPI=OFF',
+                        '-D GMX_OPENMP=ON',
+                        '-D GMX_PREFER_STATIC_LIBS=ON',
+                        '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+            directory='gromacs-2018.2',
+            prefix='/usr/local/gromacs',
+            url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2018.2.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/gromacs-2018.2/build && cd /var/tmp/gromacs-2018.2/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/gromacs -D CMAKE_BUILD_TYPE=Release -D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda -D GMX_BUILD_OWN_FFTW=ON -D GMX_GPU=ON -D GMX_MPI=OFF -D GMX_OPENMP=ON -D GMX_PREFER_STATIC_LIBS=ON -D MPIEXEC_PREFLAGS=--allow-run-as-root /var/tmp/gromacs-2018.2 && \
+    cmake --build /var/tmp/gromacs-2018.2/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/gromacs-2018.2/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/v2018.2.tar.gz /var/tmp/gromacs-2018.2''')
+
+    @ubuntu
+    @docker
+    def test_no_url(self):
+        """missing url"""
+        with self.assertRaises(RuntimeError):
+            g = generic_cmake()
+
+    @ubuntu
+    @docker
+    def test_invalid_package(self):
+        """invalid package url"""
+        with self.assertRaises(RuntimeError):
+            g = generic_cmake(url='https://foo/bar.sh')
+
+    @ubuntu
+    @docker
+    def test_build_directory(self):
+        """build directory option"""
+        g = generic_cmake(
+            build_directory='/tmp/build',
+            directory='spdlog-1.4.2',
+            url='https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v1.4.2.tar.gz -C /var/tmp -z && \
+    mkdir -p /tmp/build && cd /tmp/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local /var/tmp/spdlog-1.4.2 && \
+    cmake --build /tmp/build --target all -- -j$(nproc) && \
+    cmake --build /tmp/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/v1.4.2.tar.gz /var/tmp/spdlog-1.4.2 /tmp/build''')    
+
+    @ubuntu
+    @docker
+    def test_pre_and_post(self):
+        """Preconfigure and postinstall options"""
+        g = generic_cmake(
+            directory='/var/tmp/spdlog-1.4.2',
+            postinstall=['echo "post"'],
+            preconfigure=['echo "pre"'],
+            prefix='/usr/local/spdlog',
+            url='https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/gabime/spdlog/archive/v1.4.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v1.4.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/spdlog-1.4.2 && \
+    echo "pre" && \
+    mkdir -p /var/tmp/spdlog-1.4.2/build && cd /var/tmp/spdlog-1.4.2/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/spdlog /var/tmp/spdlog-1.4.2 && \
+    cmake --build /var/tmp/spdlog-1.4.2/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/spdlog-1.4.2/build --target install -- -j$(nproc) && \
+    cd /usr/local/spdlog && \
+    echo "post" && \
+    rm -rf /var/tmp/v1.4.2.tar.gz /var/tmp/spdlog-1.4.2''')    
+
+    @ubuntu
+    @docker
+    def test_environment_and_toolchain(self):
+        """environment and toolchain"""
+        tc = toolchain(CC='gcc', CXX='g++', FC='gfortran')
+        g = generic_cmake(
+            cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                        '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                        '-D GMX_BUILD_OWN_FFTW=ON',
+                        '-D GMX_GPU=ON',
+                        '-D GMX_MPI=OFF',
+                        '-D GMX_OPENMP=ON',
+                        '-D GMX_PREFER_STATIC_LIBS=ON',
+                        '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+            directory='gromacs-2018.2',
+            environment={'FOO': 'BAR'},
+            prefix='/usr/local/gromacs',
+            toolchain=tc,
+            url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+        self.assertEqual(str(g),
+r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2018.2.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/gromacs-2018.2/build && cd /var/tmp/gromacs-2018.2/build && FOO=BAR CC=gcc CXX=g++ FC=gfortran cmake -DCMAKE_INSTALL_PREFIX=/usr/local/gromacs -D CMAKE_BUILD_TYPE=Release -D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda -D GMX_BUILD_OWN_FFTW=ON -D GMX_GPU=ON -D GMX_MPI=OFF -D GMX_OPENMP=ON -D GMX_PREFER_STATIC_LIBS=ON -D MPIEXEC_PREFLAGS=--allow-run-as-root /var/tmp/gromacs-2018.2 && \
+    cmake --build /var/tmp/gromacs-2018.2/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/gromacs-2018.2/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/v2018.2.tar.gz /var/tmp/gromacs-2018.2''')
+
+    @ubuntu
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        g = generic_cmake(
+            cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                        '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                        '-D GMX_BUILD_OWN_FFTW=ON',
+                        '-D GMX_GPU=ON',
+                        '-D GMX_MPI=OFF',
+                        '-D GMX_OPENMP=ON',
+                        '-D GMX_PREFER_STATIC_LIBS=ON',
+                        '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+            directory='gromacs-2018.2',
+            prefix='/usr/local/gromacs',
+            url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
+COPY --from=0 /usr/local/gromacs /usr/local/gromacs''')


### PR DESCRIPTION
Adds 2 new building blocks, `generic_autotools` and `generic_cmake` for automating workflows based on GNU autotools and Cmake, respectively.  The idea is that you should just need to specify a url and the building block will generate the instructions to install it.  Lots of parameters to let you tailor the behavior for a specific package.  A really cool side benefit is that it will automatically copy the installed package into the runtime stage with `Stage1 += Stage0.runtime()`. (You would still need to manually set the environment, if necessary).