### PR TITLE
Add pmix and slurm_pmi2 building blocks

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2555,6 +2555,18 @@ and `wget`.  For RHEL-based Linux distributions, the default
 values are `bzip2`, `file`, `hwloc`, `make`, `numactl-devl`,
 `openssh-clients`, `perl`, `tar`, and `wget`.
 
+- __pmi__: Flag to control whether PMI is used by the build.  If True,
+adds `--with-pmi` to the list of `configure` options.  If a
+string, uses the value of the string as the PMI path, e.g.,
+`--with-pmi=/usr/local/slurm-pmi2`.  If False, does nothing.  The
+default is False.
+
+- __pmix__: Flag to control whether PMIX is used by the build.  If True,
+adds `--with-pmix` to the list of `configure` options.  If a
+string, uses the value of the string as the PMIX path, e.g.,
+`--with-pmix=/usr/local/pmix`.  If False, does nothing.  The
+default is False.
+
 - __prefix__: The top level install location.  The default value is
 `/usr/local/openmpi`.
 
@@ -2593,6 +2605,11 @@ openmpi(toolchain=p.toolchain)
 openmpi(configure_opts=['--disable-getpwuid', '--with-slurm'],
         ospackages=['file', 'hwloc', 'libslurm-dev'])
 ```
+
+```python
+openmpi(pmi='/usr/local/slurm-pmi2', pmix='internal')
+```
+
 
 ## runtime
 ```python
@@ -2840,6 +2857,71 @@ pip(packages=['hpccm'], pip='pip3')
 pip(requirements='requirements.txt')
 ```
 
+
+# pmix
+```python
+pmix(self, **kwargs)
+```
+The `pmix` building block configures, builds, and installs the
+[PMIX](https://github.com/openpmix/openpmix) component.
+
+__Parameters__
+
+
+- __check__: Boolean flag to specify whether the `make check` step
+should be performed.  The default is False.
+
+- __configure_opts__: List of options to pass to `configure`.  The
+default is an empty list.
+
+- __environment__: Boolean flag to specify whether the environment
+(`CPATH`, `LD_LIBRARY_PATH`, and `PATH`) should be modified to
+include PMIX. The default is True.
+
+- __ldconfig__: Boolean flag to specify whether the PMIX library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the PMIX library
+directory. The default value is False.
+
+- __ospackages__: List of OS packages to install prior to configuring
+and building.  For Ubuntu, the default values are `file`, `hwloc`,
+`libevent-dev`, `make`, `tar`, and `wget`. For RHEL-based Linux
+distributions, the default values are `file`, `hwloc`,
+`libevent-devel`, `make`, `tar`, and `wget`.
+
+- __prefix__: The top level install location.  The default value is
+`/usr/local/pmix`.
+
+- __toolchain__: The toolchain object.  This should be used if
+non-default compilers or other toolchain options are needed.  The
+default value is empty.
+
+- __version__: The version of PMIX source to download.  The default value
+is `3.1.4`.
+
+__Examples__
+
+
+```python
+pmix(prefix='/opt/pmix/3.1.4', version='3.1.4')
+```
+
+
+## runtime
+```python
+pmix.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+
+```python
+p = pmix(...)
+Stage0 += p
+Stage1 += p.runtime()
+```
 
 # pnetcdf
 ```python
@@ -3110,6 +3192,68 @@ __Examples__
 s = sensei(...)
 Stage0 += s
 Stage1 += s.runtime()
+```
+
+# slurm_pmi2
+```python
+slurm_pmi2(self, **kwargs)
+```
+The `slurm_pmi2` building block configures, builds, and installs
+the PMI2 component from SLURM.
+
+Note: this building block does not install SLURM itself.
+
+__Parameters__
+
+
+- __configure_opts__: List of options to pass to `configure`.  The
+default is an empty list.
+
+- __environment__: Boolean flag to specify whether the environment
+(`CPATH` and `LD_LIBRARY_PATH`) should be modified to include
+PMI2. The default is False.
+
+- __ldconfig__: Boolean flag to specify whether the PMI2 library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the PMI2 library
+directory. The default value is False.
+
+- __ospackages__: List of OS packages to install prior to configuring
+and building.  The default values are `bzip2`, `file`, `make`,
+`perl`, `tar`, and `wget`.
+
+- __prefix__: The top level install location.  The default value is
+`/usr/local/slurm-pmi2`.
+
+- __toolchain__: The toolchain object.  This should be used if
+non-default compilers or other toolchain options are needed.  The
+default value is empty.
+
+- __version__: The version of SLURM source to download.  The default
+value is `19.05.4`.
+
+__Examples__
+
+
+```python
+slurm_pmi2(prefix='/opt/pmi', version='19.05.4')
+```
+
+
+## runtime
+```python
+slurm_pmi2.runtime(self, _from=u'0')
+```
+Generate the set of instructions to install the runtime specific
+components from a build in a previous stage.
+
+__Examples__
+
+
+```python
+p = slurm_pmi2(...)
+Stage0 += p
+Stage1 += p.runtime()
 ```
 
 # ucx

--- a/hpccm/building_blocks/__init__.py
+++ b/hpccm/building_blocks/__init__.py
@@ -50,10 +50,12 @@ from hpccm.building_blocks.openmpi import openmpi
 from hpccm.building_blocks.packages import packages
 from hpccm.building_blocks.pgi import pgi
 from hpccm.building_blocks.pip import pip
+from hpccm.building_blocks.pmix import pmix
 from hpccm.building_blocks.pnetcdf import pnetcdf
 from hpccm.building_blocks.python import python
 from hpccm.building_blocks.scif import scif
 from hpccm.building_blocks.sensei import sensei
+from hpccm.building_blocks.slurm_pmi2 import slurm_pmi2
 from hpccm.building_blocks.ucx import ucx
 from hpccm.building_blocks.xpmem import xpmem
 from hpccm.building_blocks.yum import yum

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -96,6 +96,18 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     values are `bzip2`, `file`, `hwloc`, `make`, `numactl-devl`,
     `openssh-clients`, `perl`, `tar`, and `wget`.
 
+    pmi: Flag to control whether PMI is used by the build.  If True,
+    adds `--with-pmi` to the list of `configure` options.  If a
+    string, uses the value of the string as the PMI path, e.g.,
+    `--with-pmi=/usr/local/slurm-pmi2`.  If False, does nothing.  The
+    default is False.
+
+    pmix: Flag to control whether PMIX is used by the build.  If True,
+    adds `--with-pmix` to the list of `configure` options.  If a
+    string, uses the value of the string as the PMIX path, e.g.,
+    `--with-pmix=/usr/local/pmix`.  If False, does nothing.  The
+    default is False.
+
     prefix: The top level install location.  The default value is
     `/usr/local/openmpi`.
 
@@ -133,6 +145,11 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     openmpi(configure_opts=['--disable-getpwuid', '--with-slurm'],
             ospackages=['file', 'hwloc', 'libslurm-dev'])
     ```
+
+    ```python
+    openmpi(pmi='/usr/local/slurm-pmi2', pmix='internal')
+    ```
+
     """
 
     def __init__(self, **kwargs):
@@ -150,6 +167,8 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.directory = kwargs.get('directory', '')
         self.infiniband = kwargs.get('infiniband', True)
         self.__ospackages = kwargs.get('ospackages', [])
+        self.__pmi = kwargs.get('pmi', False)
+        self.__pmix = kwargs.get('pmix', False)
         self.prefix = kwargs.get('prefix', '/usr/local/openmpi')
         self.__runtime_ospackages = [] # Filled in by __distro()
 
@@ -234,6 +253,23 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
                 self.configure_opts.append('--with-cuda')
         else:
             self.configure_opts.append('--without-cuda')
+
+        # PMI
+        if self.__pmi:
+            if isinstance(self.__pmi, string_types):
+                # Use specified path
+                self.configure_opts.append('--with-pmi={}'.format(self.__pmi))
+            else:
+                self.configure_opts.append('--with-pmi')
+
+        # PMIX
+        if self.__pmix:
+            if isinstance(self.__pmix, string_types):
+                # Use specified path
+                self.configure_opts.append('--with-pmix={}'.format(
+                    self.__pmix))
+            else:
+                self.configure_opts.append('--with-pmix')
 
         # InfiniBand
         if self.infiniband:

--- a/hpccm/building_blocks/pmix.py
+++ b/hpccm/building_blocks/pmix.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""PMIX building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+from six import string_types
+
+from distutils.version import StrictVersion
+import logging # pylint: disable=unused-import
+import posixpath
+
+import hpccm.config
+import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
+import hpccm.templates.ldconfig
+import hpccm.templates.rm
+import hpccm.templates.tar
+import hpccm.templates.wget
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.building_blocks.packages import packages
+from hpccm.common import linux_distro
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.environment import environment
+from hpccm.primitives.shell import shell
+from hpccm.toolchain import toolchain
+
+class pmix(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
+           hpccm.templates.ldconfig, hpccm.templates.rm, hpccm.templates.tar,
+           hpccm.templates.wget):
+    """The `pmix` building block configures, builds, and installs the
+    [PMIX](https://github.com/openpmix/openpmix) component.
+
+    # Parameters
+
+    check: Boolean flag to specify whether the `make check` step
+    should be performed.  The default is False.
+
+    configure_opts: List of options to pass to `configure`.  The
+    default is an empty list.
+
+    environment: Boolean flag to specify whether the environment
+    (`CPATH`, `LD_LIBRARY_PATH`, and `PATH`) should be modified to
+    include PMIX. The default is True.
+
+    ldconfig: Boolean flag to specify whether the PMIX library
+    directory should be added dynamic linker cache.  If False, then
+    `LD_LIBRARY_PATH` is modified to include the PMIX library
+    directory. The default value is False.
+
+    ospackages: List of OS packages to install prior to configuring
+    and building.  For Ubuntu, the default values are `file`, `hwloc`,
+    `libevent-dev`, `make`, `tar`, and `wget`. For RHEL-based Linux
+    distributions, the default values are `file`, `hwloc`,
+    `libevent-devel`, `make`, `tar`, and `wget`.
+
+    prefix: The top level install location.  The default value is
+    `/usr/local/pmix`.
+
+    toolchain: The toolchain object.  This should be used if
+    non-default compilers or other toolchain options are needed.  The
+    default value is empty.
+
+    version: The version of PMIX source to download.  The default value
+    is `3.1.4`.
+
+    # Examples
+
+    ```python
+    pmix(prefix='/opt/pmix/3.1.4', version='3.1.4')
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(pmix, self).__init__(**kwargs)
+
+        self.__baseurl = kwargs.get('baseurl', 'https://github.com/openpmix/openpmix/releases/download')
+        self.__check = kwargs.get('check', False)
+        self.configure_opts = kwargs.get('configure_opts', [])
+        self.__ospackages = kwargs.get('ospackages', [])
+        self.prefix = kwargs.get('prefix', '/usr/local/pmix')
+        self.__runtime_ospackages = [] # Filled in by __distro()
+        self.__toolchain = kwargs.get('toolchain', toolchain())
+        self.__version = kwargs.get('version', '3.1.4')
+
+        self.__commands = [] # Filled in by __setup()
+        self.__wd = '/var/tmp' # working directory
+
+        # Set the Linux distribution specific parameters
+        self.__distro()
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('PMIX version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
+        self += environment(variables=self.environment_step())
+
+    def __distro(self):
+        """Based on the Linux distribution, set values accordingly.  A user
+        specified value overrides any defaults."""
+
+        if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+            if not self.__ospackages:
+                self.__ospackages = ['file', 'hwloc', 'libevent-dev', 'make',
+                                     'tar', 'wget']
+                if self.__check:
+                    self.__ospackages.append('perl')
+            self.__runtime_ospackages = ['libevent']
+        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+            if not self.__ospackages:
+                self.__ospackages = ['file', 'hwloc', 'libevent-devel', 'make',
+                                     'tar', 'wget']
+                if self.__check:
+                    self.__ospackages.append('perl')
+            self.__runtime_ospackages = ['libevent']
+        else: # pragma: no cover
+            raise RuntimeError('Unknown Linux distribution')
+
+    def __setup(self):
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
+
+        tarball = 'pmix-{}.tar.gz'.format(self.__version)
+        url = '{0}/v{1}/{2}'.format(self.__baseurl, self.__version, tarball)
+
+        # Download source from web
+        self.__commands.append(self.download_step(url=url,
+                                                  directory=self.__wd))
+        self.__commands.append(self.untar_step(
+            tarball=posixpath.join(self.__wd, tarball), directory=self.__wd))
+
+        # Configure
+        self.__commands.append(self.configure_step(
+            directory=posixpath.join(self.__wd, 'pmix-{}'.format(
+                self.__version)),
+            toolchain=self.__toolchain))
+
+        # Build
+        self.__commands.append(self.build_step())
+
+        # Install
+        self.__commands.append(self.install_step())
+
+        # Check
+        if self.__check:
+            self.__commands.append(self.check_step())
+
+        # Set library path
+        libpath = posixpath.join(self.prefix, 'lib')
+        if self.ldconfig:
+            self.__commands.append(self.ldcache_step(directory=libpath))
+        else:
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+
+        # Cleanup tarball and directory
+        self.__commands.append(self.cleanup_step(
+            items=[posixpath.join(self.__wd, tarball),
+                   posixpath.join(self.__wd,
+                                  'pmix-{}'.format(self.__version))]))
+
+        # Set the environment
+        self.environment_variables['CPATH'] = '{}:$CPATH'.format(
+            posixpath.join(self.prefix, 'include'))
+        self.environment_variables['PATH'] = '{}:$PATH'.format(
+            posixpath.join(self.prefix, 'bin'))
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+
+        ```python
+        p = pmix(...)
+        Stage0 += p
+        Stage1 += p.runtime()
+        ```
+        """
+        instructions = []
+        instructions.append(comment('PMIX'))
+        instructions.append(packages(ospackages=self.__runtime_ospackages))
+        instructions.append(copy(_from=_from, src=self.prefix,
+                                 dest=self.prefix))
+        if self.ldconfig:
+            instructions.append(shell(
+                commands=[self.ldcache_step(
+                    directory=posixpath.join(self.prefix, 'lib'))]))
+        instructions.append(environment(variables=self.environment_step()))
+        return '\n'.join(str(x) for x in instructions)

--- a/hpccm/building_blocks/slurm_pmi2.py
+++ b/hpccm/building_blocks/slurm_pmi2.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+# pylint: disable=too-many-instance-attributes
+
+"""SLURM PMI2 building block"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+from six import string_types
+
+import logging # pylint: disable=unused-import
+import posixpath
+
+import hpccm.templates.ConfigureMake
+import hpccm.templates.envvars
+import hpccm.templates.ldconfig
+import hpccm.templates.rm
+import hpccm.templates.tar
+import hpccm.templates.wget
+
+from hpccm.building_blocks.base import bb_base
+from hpccm.building_blocks.packages import packages
+from hpccm.primitives.comment import comment
+from hpccm.primitives.copy import copy
+from hpccm.primitives.environment import environment
+from hpccm.primitives.shell import shell
+from hpccm.toolchain import toolchain
+
+class slurm_pmi2(bb_base, hpccm.templates.ConfigureMake,
+                 hpccm.templates.envvars,
+                 hpccm.templates.ldconfig, hpccm.templates.rm,
+                 hpccm.templates.tar, hpccm.templates.wget):
+    """The `slurm_pmi2` building block configures, builds, and installs
+    the PMI2 component from SLURM.
+
+    Note: this building block does not install SLURM itself.
+
+    # Parameters
+
+    configure_opts: List of options to pass to `configure`.  The
+    default is an empty list.
+
+    environment: Boolean flag to specify whether the environment
+    (`CPATH` and `LD_LIBRARY_PATH`) should be modified to include
+    PMI2. The default is False.
+
+    ldconfig: Boolean flag to specify whether the PMI2 library
+    directory should be added dynamic linker cache.  If False, then
+    `LD_LIBRARY_PATH` is modified to include the PMI2 library
+    directory. The default value is False.
+
+    ospackages: List of OS packages to install prior to configuring
+    and building.  The default values are `bzip2`, `file`, `make`,
+    `perl`, `tar`, and `wget`.
+
+    prefix: The top level install location.  The default value is
+    `/usr/local/slurm-pmi2`.
+
+    toolchain: The toolchain object.  This should be used if
+    non-default compilers or other toolchain options are needed.  The
+    default value is empty.
+
+    version: The version of SLURM source to download.  The default
+    value is `19.05.4`.
+
+    # Examples
+
+    ```python
+    slurm_pmi2(prefix='/opt/pmi', version='19.05.4')
+    ```
+
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize building block"""
+
+        super(slurm_pmi2, self).__init__(**kwargs)
+
+        self.__baseurl = kwargs.get('baseurl', 'https://download.schedmd.com/slurm')
+        self.configure_opts = kwargs.get('configure_opts', [])
+        self.environment = kwargs.get('environment', False)
+        self.__ospackages = kwargs.get('ospackages', ['bzip2', 'file', 'make',
+                                                      'perl', 'tar', 'wget'])
+        self.prefix = kwargs.get('prefix', '/usr/local/slurm-pmi2')
+        self.__toolchain = kwargs.get('toolchain', toolchain())
+        self.__version = kwargs.get('version', '19.05.4')
+
+        self.__commands = [] # Filled in by __setup()
+        self.__wd = '/var/tmp' # working directory
+
+        # Construct the series of steps to execute
+        self.__setup()
+
+        # Fill in container instructions
+        self.__instructions()
+
+    def __instructions(self):
+        """Fill in container instructions"""
+
+        self += comment('SLURM PMI2 version {}'.format(self.__version))
+        self += packages(ospackages=self.__ospackages)
+        self += shell(commands=self.__commands)
+        self += environment(variables=self.environment_step())
+
+    def __setup(self):
+        """Construct the series of shell commands, i.e., fill in
+           self.__commands"""
+
+        tarball = 'slurm-{}.tar.bz2'.format(self.__version)
+        url = '{0}/{1}'.format(self.__baseurl, tarball)
+
+        # Download source from web
+        self.__commands.append(self.download_step(url=url,
+                                                  directory=self.__wd))
+        self.__commands.append(self.untar_step(
+            tarball=posixpath.join(self.__wd, tarball), directory=self.__wd))
+
+        # Configure, but do not build SLURM itself
+        self.__commands.append(self.configure_step(
+            directory=posixpath.join(self.__wd, 'slurm-{}'.format(
+                self.__version)),
+            toolchain=self.__toolchain))
+
+        # Build and install PMI2
+        self.__commands.append('make -C contribs/pmi2 install')
+
+        # Set library path
+        libpath = posixpath.join(self.prefix, 'lib')
+        if self.ldconfig:
+            self.__commands.append(self.ldcache_step(directory=libpath))
+        else:
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(libpath)
+
+        # Set the environment
+        self.environment_variables['CPATH'] = '{}:$CPATH'.format(
+            posixpath.join(self.prefix, 'include', 'slurm'))
+
+        # Cleanup tarball and directory
+        self.__commands.append(self.cleanup_step(
+            items=[posixpath.join(self.__wd, tarball),
+                   posixpath.join(self.__wd,
+                                  'slurm-{}'.format(self.__version))]))
+
+    def runtime(self, _from='0'):
+        """Generate the set of instructions to install the runtime specific
+        components from a build in a previous stage.
+
+        # Examples
+
+        ```python
+        p = slurm_pmi2(...)
+        Stage0 += p
+        Stage1 += p.runtime()
+        ```
+        """
+        instructions = []
+        instructions.append(comment('SLURM PMI2'))
+        instructions.append(copy(_from=_from, src=self.prefix,
+                                 dest=self.prefix))
+        if self.ldconfig:
+            instructions.append(shell(
+                commands=[self.ldcache_step(
+                    directory=posixpath.join(self.prefix, 'lib'))]))
+        instructions.append(environment(variables=self.environment_step()))
+        return '\n'.join(str(x) for x in instructions)

--- a/pydocmd.yml
+++ b/pydocmd.yml
@@ -40,10 +40,12 @@ generate:
   - hpccm.building_blocks.packages+
   - hpccm.building_blocks.pgi+
   - hpccm.building_blocks.pip+
+  - hpccm.building_blocks.pmix+
   - hpccm.building_blocks.pnetcdf+
   - hpccm.building_blocks.python+
   - hpccm.building_blocks.scif+
   - hpccm.building_blocks.sensei+
+  - hpccm.building_blocks.slurm_pmi2+
   - hpccm.building_blocks.ucx+
   - hpccm.building_blocks.xpmem+
   - hpccm.building_blocks.yum+

--- a/recipes/mpi_bandwidth.py
+++ b/recipes/mpi_bandwidth.py
@@ -5,13 +5,35 @@ Contents:
   CentOS 7
   GNU compilers (upstream)
   Mellanox OFED
-  OpenMPI version 3.0.0
+  OpenMPI
+  PMI2 (SLURM)
+  UCX
+
+Building:
+  1. Docker to Singularity
+     $ hpccm --recipe mpi_bandwidth.py > Dockerfile
+     $ sudo docker build -t mpi_bw -f Dockerfile .
+     $ singularity build mpi_bw.sif docker-daemon://mpi_bw:latest
+
+  2. Singularity
+     $ hpccm --recipe mpi_bandwidth.py --format singularity --singularity-version=3.2 > Singularity.def
+     $ sudo singularity build mpi_bw.sif Singularity.def
+
+Running with Singularity:
+  1. Using a compatible host MPI runtime
+     $ mpirun -n 2 singularity run mpi_bw.sif mpi_bandwidth
+
+  2. Using the MPI runtime inside the container
+     $ singularity run mpi_bw.sif mpirun -n 2 -H node1:1,node2:1 --launch-agent "singularity exec \$SINGULARITY_CONTAINER orted" mpi_bandwidth
+
+  3. Using SLURM srun
+     $ srun -n 2 --mpi=pmi2 singularity run mpi_bw.sif mpi_bandwidth
 """
 
 Stage0 += comment(__doc__, reformat=False)
 
 # CentOS base image
-Stage0 += baseimage(image='centos:7')
+Stage0 += baseimage(image='centos:7', _as='build')
 
 # GNU compilers
 Stage0 += gnu(fortran=False)
@@ -19,10 +41,23 @@ Stage0 += gnu(fortran=False)
 # Mellanox OFED
 Stage0 += mlnx_ofed()
 
-# OpenMPI
-Stage0 += openmpi(cuda=False, version='3.0.0')
+# UCX
+Stage0 += ucx(cuda=False)
+
+# PMI2
+Stage0 += slurm_pmi2()
+
+# OpenMPI (use UCX instead of IB directly)
+Stage0 += openmpi(cuda=False, infiniband=False, pmi='/usr/local/slurm-pmi2',
+                  ucx='/usr/local/ucx')
 
 # MPI Bandwidth
 Stage0 += shell(commands=[
     'wget -q -nc --no-check-certificate -P /var/tmp https://computing.llnl.gov/tutorials/mpi/samples/C/mpi_bandwidth.c',
     'mpicc -o /usr/local/bin/mpi_bandwidth /var/tmp/mpi_bandwidth.c'])
+
+### Runtime distributable stage
+Stage1 += baseimage(image='centos:7')
+Stage1 += Stage0.runtime()
+Stage1 += copy(_from='build', src='/usr/local/bin/mpi_bandwidth',
+               dest='/usr/local/bin/mpi_bandwidth')

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -143,6 +143,35 @@ ENV PATH=/usr/local/openmpi/bin:$PATH''')
 
     @ubuntu
     @docker
+    def test_pmi(self):
+        """pmi options"""
+        ompi = openmpi(pmi='/usr/local/slurm-pmi2', pmix='internal',
+                       version='4.0.1')
+        self.assertEqual(str(ompi),
+r'''# OpenMPI version 4.0.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        hwloc \
+        libnuma-dev \
+        make \
+        openssh-client \
+        perl \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-pmi=/usr/local/slurm-pmi2 --with-pmix=internal --with-verbs && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1
+ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/openmpi/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_runtime(self):
         """Runtime"""
         ompi = openmpi()

--- a/test/test_pmix.py
+++ b/test/test_pmix.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the pmix module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu, x86_64
+
+from hpccm.building_blocks.pmix import pmix
+
+class Test_pmix(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_defaults_ubuntu(self):
+        """Default pmix building block"""
+        p = pmix()
+        self.assertEqual(str(p),
+r'''# PMIX version 3.1.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        file \
+        hwloc \
+        libevent-dev \
+        make \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openpmix/openpmix/releases/download/v3.1.4/pmix-3.1.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/pmix-3.1.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/pmix-3.1.4 &&   ./configure --prefix=/usr/local/pmix && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/pmix-3.1.4.tar.gz /var/tmp/pmix-3.1.4
+ENV CPATH=/usr/local/pmix/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/pmix/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/pmix/bin:$PATH''')
+
+    @x86_64
+    @centos
+    @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        p = pmix(ldconfig=True, version='3.1.4')
+        self.assertEqual(str(p),
+r'''# PMIX version 3.1.4
+RUN yum install -y \
+        file \
+        hwloc \
+        libevent-devel \
+        make \
+        tar \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openpmix/openpmix/releases/download/v3.1.4/pmix-3.1.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/pmix-3.1.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/pmix-3.1.4 &&   ./configure --prefix=/usr/local/pmix && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    echo "/usr/local/pmix/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/pmix-3.1.4.tar.gz /var/tmp/pmix-3.1.4
+ENV CPATH=/usr/local/pmix/include:$CPATH \
+    PATH=/usr/local/pmix/bin:$PATH''')
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        p = pmix()
+        r = p.runtime()
+        self.assertEqual(r,
+r'''# PMIX
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libevent && \
+    rm -rf /var/lib/apt/lists/*
+COPY --from=0 /usr/local/pmix /usr/local/pmix
+ENV CPATH=/usr/local/pmix/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/pmix/lib:$LD_LIBRARY_PATH \
+    PATH=/usr/local/pmix/bin:$PATH''')

--- a/test/test_slurm_pmi2.py
+++ b/test/test_slurm_pmi2.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the slurm_pmi2 module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import centos, docker, ubuntu, x86_64
+
+from hpccm.building_blocks.slurm_pmi2 import slurm_pmi2
+
+class Test_slurm_pmi2(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_defaults_ubuntu(self):
+        """Default slurm_pmi2 building block"""
+        p = slurm_pmi2()
+        self.assertEqual(str(p),
+r'''# SLURM PMI2 version 19.05.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        make \
+        perl \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.4.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.4.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-19.05.4 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    make -C contribs/pmi2 install && \
+    rm -rf /var/tmp/slurm-19.05.4.tar.bz2 /var/tmp/slurm-19.05.4''')
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_ldconfig(self):
+        """ldconfig option"""
+        p = slurm_pmi2(ldconfig=True, version='19.05.4')
+        self.assertEqual(str(p),
+r'''# SLURM PMI2 version 19.05.4
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        file \
+        make \
+        perl \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.4.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.4.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-19.05.4 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    make -C contribs/pmi2 install && \
+    echo "/usr/local/slurm-pmi2/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
+    rm -rf /var/tmp/slurm-19.05.4.tar.bz2 /var/tmp/slurm-19.05.4''')
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_runtime(self):
+        """Runtime"""
+        p = slurm_pmi2()
+        r = p.runtime()
+        self.assertEqual(r,
+r'''# SLURM PMI2
+COPY --from=0 /usr/local/slurm-pmi2 /usr/local/slurm-pmi2
+''')


### PR DESCRIPTION
Adds 2 PMI building blocks.  `slurm_pmi2` provides the PMI2 library bundled with SLURM (it does not install SLURM itself).  `pmix` provides the PMIx library.

Adds corresponding options to the `openmpi` building block to specify a PMI implementation.

Reworks the MPI Bandwidth example recipe to enable the `srun --mpi=pmi2 singularity run ...` use case.