### PR TITLE
Workarounds to enable versioned Intel PSXE runtime installs

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -87,6 +87,9 @@ used instead of `apt_get`.
 __Parameters__
 
 
+- __aptitude__: Boolean flag to specify whether `aptitude` should be
+used instead of `apt-get`.  The default is False.
+
 - __download__: Boolean flag to specify whether to download the deb
 packages instead of installing them.  The default is False.
 
@@ -1303,7 +1306,7 @@ to install via the `runtime` method.  The runtime is installed
 using the [intel_psxe_runtime](#intel_psxe_runtime) building
 block.  This value is passed as its `version` parameter.  In
 general, the major version of the runtime should correspond to the
-tarball version.
+tarball version.  The default value is `2019.5-281`.
 
 - __tarball__: Path to the Intel Parallel Studio XE tarball relative to
 the local build context.  The default value is empty.  This
@@ -1403,20 +1406,17 @@ Intel MPI.  For Ubuntu, the default values are
 distributions, the default values are `man-db`, `openssh-clients`,
 and `which`.
 
-- __version__: The version of the Intel Parallel Studio XE runtime to
-install.  Due to issues in the Intel apt / yum repositories, only
-the major version is used; within a major version, the most recent
-minor version will be installed.  The default value is
-`2019.4-243`.
-
 - __tbb__: Boolean flag to specify whether the Intel Threading Building
 Blocks runtime should be installed.  The default is True.
+
+- __version__: The version of the Intel Parallel Studio XE runtime to
+install.  The default value is `2019.5-281`.
 
 __Examples__
 
 
 ```python
-intel_psxe_runtime(eula=True, version='2018.4-274')
+intel_psxe_runtime(eula=True, version='2018.5-281')
 ```
 
 ```python
@@ -2627,6 +2627,9 @@ __Parameters__
 - __apt__: A list of Debian packages to install.  The default is an
 empty list.
 
+- __aptitude__: Boolean flag to specify whether `aptitude` should be
+used instead of `apt-get`.  The default is False.
+
 - __apt_keys__: A list of GPG keys to add.  The default is an empty
 list.
 
@@ -2671,6 +2674,10 @@ parameter is ignored if the Linux distribution is not RHEL-based.
 
 - __yum__: A list of RPM packages to install.  The default value is an
 empty list.
+
+- __yum4__: Boolean flag to specify whether `yum4` should be used
+instead of `yum`.  The default is False.  This parameter is only
+recognized if the CentOS version is 7.x.
 
 - __yum_keys__: A list of GPG keys to import.  The default is an empty
 list.
@@ -3338,6 +3345,10 @@ an empty list.
 
 - __scl__: - Boolean flag to specify whether to enable the Software
 Collections (SCL) repository.  The default is False.
+
+- __yum4__: Boolean flag to specify whether `yum4` should be used
+instead of `yum`.  The default is False.  This parameter is only
+recognized if the CentOS version is 7.x.
 
 __Examples__
 

--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -39,6 +39,9 @@ class apt_get(bb_base):
 
     # Parameters
 
+    aptitude: Boolean flag to specify whether `aptitude` should be
+    used instead of `apt-get`.  The default is False.
+
     download: Boolean flag to specify whether to download the deb
     packages instead of installing them.  The default is False.
 
@@ -77,6 +80,7 @@ class apt_get(bb_base):
 
         super(apt_get, self).__init__()
 
+        self.__aptitude = kwargs.get('aptitude', False)
         self.__commands = []
         self.__download = kwargs.get('download', False)
         self.__download_directory = kwargs.get('download_directory',
@@ -155,8 +159,14 @@ class apt_get(bb_base):
                     self.__commands.append(
                         'rm -rf {}'.format(self.__download_directory))
             else:
-                install = 'DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\\n'
-                install = install + ' \\\n'.join(packages)
-                self.__commands.append(install)
+                if self.__aptitude:
+                    self.__commands.append('DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends aptitude')
+                    install = 'aptitude install -y --without-recommends -o Aptitude::ProblemResolver::SolutionCost=\'100*canceled-actions,200*removals\' \\\n'
+                    install = install + ' \\\n'.join(packages)
+                    self.__commands.append(install)
+                else:
+                    install = 'DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \\\n'
+                    install = install + ' \\\n'.join(packages)
+                    self.__commands.append(install)
 
             self.__commands.append('rm -rf /var/lib/apt/lists/*')

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -145,7 +145,7 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     using the [intel_psxe_runtime](#intel_psxe_runtime) building
     block.  This value is passed as its `version` parameter.  In
     general, the major version of the runtime should correspond to the
-    tarball version.
+    tarball version.  The default value is `2019.5-281`.
 
     tarball: Path to the Intel Parallel Studio XE tarball relative to
     the local build context.  The default value is empty.  This
@@ -193,7 +193,7 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/opt/intel')
         self.__psxevars = kwargs.get('psxevars', True)
-        self.__runtime_version = kwargs.get('runtime_version', '2019.4-243')
+        self.__runtime_version = kwargs.get('runtime_version', '2019.5-281')
         self.__tarball = kwargs.get('tarball', None)
         self.__tbb = kwargs.get('tbb', True)
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -43,6 +43,9 @@ class packages(bb_base):
     apt: A list of Debian packages to install.  The default is an
     empty list.
 
+    aptitude: Boolean flag to specify whether `aptitude` should be
+    used instead of `apt-get`.  The default is False.
+
     apt_keys: A list of GPG keys to add.  The default is an empty
     list.
 
@@ -88,6 +91,10 @@ class packages(bb_base):
     yum: A list of RPM packages to install.  The default value is an
     empty list.
 
+    yum4: Boolean flag to specify whether `yum4` should be used
+    instead of `yum`.  The default is False.  This parameter is only
+    recognized if the CentOS version is 7.x.
+
     yum_keys: A list of GPG keys to import.  The default is an empty
     list.
 
@@ -119,6 +126,7 @@ class packages(bb_base):
         self.__apt_keys = kwargs.get('apt_keys', [])
         self.__apt_ppas = kwargs.get('apt_ppas', [])
         self.__apt_repositories = kwargs.get('apt_repositories', [])
+        self.__aptitude = kwargs.get('aptitude', False)
         self.__download = kwargs.get('download', False)
         self.__download_directory = kwargs.get('download_directory',
                                                '/var/tmp/packages_download')
@@ -128,6 +136,7 @@ class packages(bb_base):
         self.__powertools = kwargs.get('powertools', False)
         self.__scl = kwargs.get('scl', False)
         self.__yum = kwargs.get('yum', [])
+        self.__yum4 = kwargs.get('yum4', False)
         self.__yum_keys = kwargs.get('yum_keys', [])
         self.__yum_repositories = kwargs.get('yum_repositories', [])
 
@@ -138,36 +147,33 @@ class packages(bb_base):
         """String representation of the building block"""
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if self.__apt:
-                self += apt_get(download=self.__download,
-                                download_directory=self.__download_directory,
-                                extract=self.__extract,
-                                keys=self.__apt_keys, ospackages=self.__apt,
-                                ppas=self.__apt_ppas,
-                                repositories=self.__apt_repositories)
+                ospackages = self.__apt
             else:
-                self += apt_get(download=self.__download,
-                                download_directory=self.__download_directory,
-                                extract=self.__extract,
-                                keys=self.__apt_keys,
-                                ospackages=self.__ospackages,
-                                ppas=self.__apt_ppas,
-                                repositories=self.__apt_repositories)
-        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
-            if self.__yum:
-                self += yum(download=self.__download,
-                            download_directory=self.__download_directory,
-                            extract=self.__extract, epel=self.__epel,
-                            keys=self.__yum_keys,
-                            ospackages=self.__yum,
-                            powertools=self.__powertools, scl=self.__scl,
-                            repositories=self.__yum_repositories)
-            else:
-                self += yum(download=self.__download,
+                ospackages = self.__ospackages
+
+            self += apt_get(aptitude=self.__aptitude,
+                            download=self.__download,
                             download_directory=self.__download_directory,
                             extract=self.__extract,
-                            epel=self.__epel, keys=self.__yum_keys,
-                            ospackages=self.__ospackages,
-                            powertools=self.__powertools, scl=self.__scl,
-                            repositories=self.__yum_repositories)
+                            keys=self.__apt_keys,
+                            ospackages=ospackages,
+                            ppas=self.__apt_ppas,
+                            repositories=self.__apt_repositories)
+        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+            if self.__yum:
+                ospackages = self.__yum
+            else:
+                ospackages = self.__ospackages
+
+            self += yum(download=self.__download,
+                        download_directory=self.__download_directory,
+                        extract=self.__extract,
+                        epel=self.__epel,
+                        keys=self.__yum_keys,
+                        ospackages=ospackages,
+                        powertools=self.__powertools,
+                        scl=self.__scl,
+                        repositories=self.__yum_repositories,
+                        yum4=self.__yum4)
         else:
             raise RuntimeError('Unknown Linux distribution')

--- a/test/test_intel_psxe.py
+++ b/test/test_intel_psxe.py
@@ -140,10 +140,10 @@ ENV CPATH=/opt/intel/compilers_and_libraries/linux/daal/include:/opt/intel/compi
     @docker
     def test_runtime(self):
         """Runtime"""
-        psxe = intel_psxe(eula=True, tarball='parallel_studio_xe_2018_update1_professional_edition.tgz')
+        psxe = intel_psxe(eula=True, tarball='parallel_studio_xe_2018_update1_professional_edition.tgz', runtime_version='2018.4-274')
         r = psxe.runtime()
         self.assertEqual(r,
-r'''# Intel Parallel Studio XE runtime version 2019
+r'''# Intel Parallel Studio XE runtime version 2018.4-274
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -154,11 +154,12 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://apt.repos.intel.com/2019/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-2019 | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/2019 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN wget -qO - https://apt.repos.intel.com/2018/GPG-PUB-KEY-INTEL-PSXE-RUNTIME-2018 | apt-key add - && \
+    echo "deb [trusted=yes] https://apt.repos.intel.com/2018 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-psxe-runtime && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends aptitude && \
+    aptitude install -y --without-recommends -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' \
+        intel-psxe-runtime=2018.4-274 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/bash.bashrc''')
 


### PR DESCRIPTION
Use the Intel provided workarounds to install a specified version of the Intel PSXE runtimes from their apt/yum repository.

Adds an `aptitude` option to the `apt_get` building block and a `yum4` option to the `yum` building block to enable the workarounds.