### PR TITLE
[pmix] Fixed runtime dependency on Ubuntu.

### DIFF
--- a/hpccm/building_blocks/pmix.py
+++ b/hpccm/building_blocks/pmix.py
@@ -135,7 +135,7 @@ class pmix(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
                                      'tar', 'wget']
                 if self.__check:
                     self.__ospackages.append('perl')
-            self.__runtime_ospackages = ['libevent']
+            self.__runtime_ospackages = ['libevent-2.*']
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
                 self.__ospackages = ['file', 'hwloc', 'libevent-devel', 'make',

--- a/hpccm/building_blocks/pmix.py
+++ b/hpccm/building_blocks/pmix.py
@@ -135,7 +135,8 @@ class pmix(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
                                      'tar', 'wget']
                 if self.__check:
                     self.__ospackages.append('perl')
-            self.__runtime_ospackages = ['libevent-2.*']
+            self.__runtime_ospackages = ['libevent-2.*',
+                                         'libevent-pthreads-2.*']
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
                 self.__ospackages = ['file', 'hwloc', 'libevent-devel', 'make',

--- a/test/test_pmix.py
+++ b/test/test_pmix.py
@@ -95,7 +95,7 @@ ENV CPATH=/usr/local/pmix/include:$CPATH \
 r'''# PMIX
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libevent && \
+        libevent-2.* && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/pmix /usr/local/pmix
 ENV CPATH=/usr/local/pmix/include:$CPATH \

--- a/test/test_pmix.py
+++ b/test/test_pmix.py
@@ -95,7 +95,8 @@ ENV CPATH=/usr/local/pmix/include:$CPATH \
 r'''# PMIX
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libevent-2.* && \
+        libevent-2.* \
+        libevent-pthreads-2.* && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/local/pmix /usr/local/pmix
 ENV CPATH=/usr/local/pmix/include:$CPATH \


### PR DESCRIPTION
On Ubuntu the package is called `libevent-2.x.x`:

- https://packages.ubuntu.com/de/xenial/libevent-2.0-5
- https://packages.ubuntu.com/bionic/libevent-2.1-6