### PR TITLE
Functionality to invalidate the Docker build cache for scif install.

### DIFF
--- a/test/test_scif.py
+++ b/test/test_scif.py
@@ -59,6 +59,7 @@ class Test_scif(unittest.TestCase):
         s = scif(name='foo', file=scif_file.name)
         self.assertEqual(str(s),
 r'''# SCI-F "foo"
+ARG SCIF_foo_HASH=d41d8cd98f00b204e9800998ecf8427e
 COPY {0} /scif/recipes/{1}
 RUN scif install /scif/recipes/{1}'''.format(scif_file.name,
                                              os.path.basename(scif_file.name)))
@@ -78,6 +79,7 @@ RUN scif install /scif/recipes/{1}'''.format(scif_file.name,
                  name='foo')
         self.assertEqual(str(s),
 r'''# SCI-F "foo"
+ARG SCIF_foo_HASH=d41d8cd98f00b204e9800998ecf8427e
 COPY {0} /scif/recipes/{1}
 RUN --mount=type=bind,target=/scif/apps/foo/src scif install /scif/recipes/{1}'''.format(scif_file.name,
                                              os.path.basename(scif_file.name)))


### PR DESCRIPTION
Docker-specific

Before this commit if the contents of the scif file changed the resulting Docker build would use the cached layer from a previous build as the Dockerfile did not changed at all. Now the md5 hash of the contents of the generated scif file is calculated and an additional ARG step is added to the Dockerfile to invalidated the Docker cache for the scif install step.
