### PR TITLE
Bump component versions to latest

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -12,31 +12,32 @@ to use this building block.
 As a side effect, a toolchain is created containing the Arm
 Allinea Studio compilers.  The toolchain can be passed to other
 operations that want to build using the Arm Allinea Studio
-compilers.
+compilers.  However, the environment is not automatically
+configured for the Arm Allinea Studio compilers.  The desired
+environment module must be manually loaded, e.g., `module load
+Generic-AArch64/RHEL/7/arm-linux-compiler/20.0`.
 
 __Parameters__
 
 
-- __armpl_generic_aarch64_only__: Boolean flag to specify whether only
-the aarch64-generic version of the Arm Performance Libraries
-should be installed.  If False, then all variants of the Arm
-Performance Libraries, e.g., Cortex-A72, Generic-SVE,
-ThunderX2CN99, and Generic-AArch64 are installed, but note that
-this will very significantly increase the size of the container
-image. The default is True.
-
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH`, `PATH`, and potentially other variables)
-should be modified to include Arm Allinea Studio. The default is
-True.
+(`MODULEPATH`) should be modified to include Arm Allinea
+Studio. The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [Arm End User License Agreement](https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-allinea-studio/licensing/eula).
 The default value is `False`.
 
+- __microarchitectures__: List of microarchitectures to install.
+Available values are `generic`, `generic-sve`, `neoverse-n1`, and
+`thunderx2t99`.  Irrespective of this setting, the generic
+implementation will always be installed.  The default is
+`generic`.
+
 - __ospackages__: List of OS packages to install prior to installing Arm
 Allinea Studio.  For Ubuntu, the default values are `libc6-dev`,
-`python`, `tar`, `wget`.  For RHEL-based Linux distributions, the
-default values are `glibc-devel`, `tar`, `wget`.
+`lmod`, `python`, `tar`, `wget`.  For RHEL-based Linux
+distributions, the default values are `glibc-devel`, `Lmod`,
+`tar`, `wget`.
 
 - __prefix__: The top level install prefix.  The default value is
 `/opt/arm`.
@@ -47,13 +48,16 @@ defined, the tarball in the local build context will be used
 rather than downloading the tarball from the web.
 
 - __version__: The version of Arm Allinea Studio to install.  The
-default value is `19.3`.
+default value is `20.0`.  Due to differences in the packaging
+scheme, versions prior to 20.0 are not supported.
 
 __Examples__
 
 
 ```python
-arm_allinea_studio(eula=True, version='19.3')
+arm_allinea_studio(eula=True,
+                   microarchitectures=['generic', 'thunderx2t99'],
+                   version='20.0')
 ```
 
 
@@ -165,7 +169,7 @@ repository.  For versions of Boost older than 1.63.0, the
 SourceForge repository should be used.  The default is False.
 
 - __version__: The version of Boost source to download.  The default
-value is `1.70.0`.
+value is `1.72.0`.
 
 __Examples__
 
@@ -453,18 +457,20 @@ building from source.  The default is an empty list.
 The default value is `False`.
 
 - __ospackages__: List of OS packages to install prior to installing.
-The default value is `wget`.
+The default values are `make` and `wget`.
 
 - __prefix__: The top level install location.  The default value is
 `/usr/local`.
 
 - __source__: Boolean flag to specify whether to build CMake from
-source.  For x86_64 processors, the default is False, i.e., use
-the available pre-compiled package.  For all other processors, the
-default is True.
+source.  If True, includes the `libssl-dev` package in the list of
+OS packages for Ubuntu, and `openssl-devel` for RHEL-based
+distributions.  For x86_64 processors, the default is False, i.e.,
+use the available pre-compiled package.  For all other processors,
+the default is True.
 
 - __version__: The version of CMake to download.  The default value is
-`3.14.5`.
+`3.16.3`.
 
 __Examples__
 
@@ -683,7 +689,7 @@ default values are `make` and `wget`.
 `/usr/local/gdrcopy`.
 
 - __version__: The version of gdrcopy source to download.  The default
-value is `1.3`.
+value is `2.0`.
 
 __Examples__
 
@@ -1186,7 +1192,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of HDF5 source to download.  This value is
-ignored if `directory` is set.  The default value is `1.10.5`.
+ignored if `directory` is set.  The default value is `1.10.6`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -1273,7 +1279,7 @@ library directories. This value is ignored if `hpcxinit` is
 
 - __mlnx_ofed__: The version of Mellanox OFED that should be matched.
 This value is ignored if Inbox OFED is selected.  The default
-value is `4.6-1.0.1.1`.
+value is `4.7-1.0.0.1`.
 
 - __multi_thread__: Boolean flag to specify whether the multi-threaded
 version of Mellanox HPC-X should be used.  The default is `False`.
@@ -1363,7 +1369,7 @@ Intel MPI.  For Ubuntu, the default values are
 the default values are `man-db` and `openssh-clients`.
 
 - __version__: The version of Intel MPI to install.  The default value
-is `2019.4-070`.
+is `2019.6-088`.
 
 __Examples__
 
@@ -1495,7 +1501,7 @@ to install via the `runtime` method.  The runtime is installed
 using the [intel_psxe_runtime](#intel_psxe_runtime) building
 block.  This value is passed as its `version` parameter.  In
 general, the major version of the runtime should correspond to the
-tarball version.  The default value is `2019.5-281`.
+tarball version.  The default value is `2020.0-008`.
 
 - __tarball__: Path to the Intel Parallel Studio XE tarball relative to
 the local build context.  The default value is empty.  This
@@ -1599,7 +1605,7 @@ and `which`.
 Blocks runtime should be installed.  The default is True.
 
 - __version__: The version of the Intel Parallel Studio XE runtime to
-install.  The default value is `2019.5-281`.
+install.  The default value is `2020.0-008`.
 
 __Examples__
 
@@ -1672,13 +1678,13 @@ empty list.
 is `/usr/local/julia`.
 
 - __version__: The version of Julia to install.  The default value is
-`1.2.0`.
+`1.3.1`.
 
 __Examples__
 
 
 ```python
-julia(prefix='/usr/local/julia', version='1.2.0')
+julia(prefix='/usr/local/julia', version='1.3.1')
 ```
 
 ```python
@@ -2019,7 +2025,7 @@ MKL.  For Ubuntu, the default values are `apt-transport-https`,
 distributions, the default is an empty list.
 
 - __version__: The version of MKL to install.  The default value is
-`2019.4-070`.
+`2020.0-088`.
 
 __Examples__
 
@@ -2089,7 +2095,7 @@ container entry point.  The default value is empty, i.e., install
 via the package manager to the standard system locations.
 
 - __version__: The version of Mellanox OFED to download.  The default
-value is `4.6-1.0.1.1`.
+value is `4.7-3.2.9.0`.
 
 __Examples__
 
@@ -2168,7 +2174,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of MPICH source to download.  The default
-value is `3.3.1`.
+value is `3.3.2`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -2234,7 +2240,8 @@ parameter for more information.
 - __mlnx_versions__: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
 versions to install.  The default values are `3.3-1.0.4.0`,
 `3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
-`4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`
+`4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and
+`4.7-3.2.9.0`.
 
 - __ospackages__: List of OS packages to install prior to installing
 OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -2342,7 +2349,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of MVAPICH2 source to download.  This value
-is ignored if `directory` is set.  The default value is `2.3.1`.
+is ignored if `directory` is set.  The default value is `2.3.3`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -2470,8 +2477,11 @@ MVAPICH2-GDR version).
 - __pgi__: Boolean flag to specify whether a PGI build should be used.
 The default value is False.
 
+- __release__: The release of MVAPICH2-GDR to download.  The value is
+ignored is `package` is set.  The default value is `2`.
+
 - __version__: The version of MVAPICH2-GDR to download.  The value is
-ignored if `package` is set.  The default value is `2.3.1`.  Due
+ignored if `package` is set.  The default value is `2.3.3`.  Due
 to differences in the packaging scheme, versions prior to 2.3 are
 not supported.
 
@@ -2566,13 +2576,13 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of NetCDF to download.  The default value is
-`4.7.0`.
+`4.7.3`.
 
 - __version_cxx__: The version of NetCDF C++ to download.  The default
-value is `4.3.0`.
+value is `4.3.1`.
 
 - __version_fortran__: The version of NetCDF Fortran to download.  The
-default value is `4.4.5`.
+default value is `4.5.2`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -2721,7 +2731,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of OpenBLAS source to download.  The default
-value is `0.3.6`.
+value is `0.3.7`.
 
 __Examples__
 
@@ -2844,7 +2854,7 @@ list of `configure` options.  The default is False.
 
 - __version__: The version of OpenMPI source to download.  This
 value is ignored if `directory` is set.  The default value is
-`4.0.1`.
+`4.0.3rc3`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -3273,7 +3283,7 @@ used.  The default is to use the standard MPI compiler wrappers,
 e.g., `CC=mpicc`, `CXX=mpicxx`, etc.
 
 - __version__: The version of PnetCDF source to download.  The default
-value is `1.11.2`.
+value is `1.12.1`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -3566,7 +3576,7 @@ non-default compilers or other toolchain options are needed.  The
 default value is empty.
 
 - __version__: The version of SLURM source to download.  The default
-value is `19.05.4`.
+value is `19.05.5`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -3692,7 +3702,7 @@ non-default compilers or other toolchain options are needed.  The
 default value is empty.
 
 - __version__: The version of UCX source to download.  The default value
-is `1.5.2`.
+is `1.7.0`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -35,9 +35,9 @@ implementation will always be installed.  The default is
 
 - __ospackages__: List of OS packages to install prior to installing Arm
 Allinea Studio.  For Ubuntu, the default values are `libc6-dev`,
-`lmod`, `python`, `tar`, `wget`.  For RHEL-based Linux
+`lmod`, `python`, `tar`, `tcl`, and `wget`.  For RHEL-based Linux
 distributions, the default values are `glibc-devel`, `Lmod`,
-`tar`, `wget`.
+`tar`, and `wget`.
 
 - __prefix__: The top level install prefix.  The default value is
 `/opt/arm`.

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -76,9 +76,9 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
     ospackages: List of OS packages to install prior to installing Arm
     Allinea Studio.  For Ubuntu, the default values are `libc6-dev`,
-    `lmod`, `python`, `tar`, `wget`.  For RHEL-based Linux
+    `lmod`, `python`, `tar`, `tcl`, and `wget`.  For RHEL-based Linux
     distributions, the default values are `glibc-devel`, `Lmod`,
-    `tar`, `wget`.
+    `tar`, and `wget`.
 
     prefix: The top level install prefix.  The default value is
     `/opt/arm`.
@@ -175,7 +175,7 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
             if not self.__ospackages:
                 self.__ospackages = ['libc6-dev', 'lmod', 'python', 'tar',
-                                     'wget']
+                                     'tcl', 'wget']
 
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if hpccm.config.g_linux_version >= StrictVersion('8.0'):

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion, StrictVersion
 import logging # pylint: disable=unused-import
 import os
 import posixpath
@@ -54,30 +54,31 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     As a side effect, a toolchain is created containing the Arm
     Allinea Studio compilers.  The toolchain can be passed to other
     operations that want to build using the Arm Allinea Studio
-    compilers.
+    compilers.  However, the environment is not automatically
+    configured for the Arm Allinea Studio compilers.  The desired
+    environment module must be manually loaded, e.g., `module load
+    Generic-AArch64/RHEL/7/arm-linux-compiler/20.0`.
 
     # Parameters
 
-    armpl_generic_aarch64_only: Boolean flag to specify whether only
-    the aarch64-generic version of the Arm Performance Libraries
-    should be installed.  If False, then all variants of the Arm
-    Performance Libraries, e.g., Cortex-A72, Generic-SVE,
-    ThunderX2CN99, and Generic-AArch64 are installed, but note that
-    this will very significantly increase the size of the container
-    image. The default is True.
-
     environment: Boolean flag to specify whether the environment
-    (`LD_LIBRARY_PATH`, `PATH`, and potentially other variables)
-    should be modified to include Arm Allinea Studio. The default is
-    True.
+    (`MODULEPATH`) should be modified to include Arm Allinea
+    Studio. The default is True.
 
     eula: By setting this value to `True`, you agree to the [Arm End User License Agreement](https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-allinea-studio/licensing/eula).
     The default value is `False`.
 
+    microarchitectures: List of microarchitectures to install.
+    Available values are `generic`, `generic-sve`, `neoverse-n1`, and
+    `thunderx2t99`.  Irrespective of this setting, the generic
+    implementation will always be installed.  The default is
+    `generic`.
+
     ospackages: List of OS packages to install prior to installing Arm
     Allinea Studio.  For Ubuntu, the default values are `libc6-dev`,
-    `python`, `tar`, `wget`.  For RHEL-based Linux distributions, the
-    default values are `glibc-devel`, `tar`, `wget`.
+    `lmod`, `python`, `tar`, `wget`.  For RHEL-based Linux
+    distributions, the default values are `glibc-devel`, `Lmod`,
+    `tar`, `wget`.
 
     prefix: The top level install prefix.  The default value is
     `/opt/arm`.
@@ -88,12 +89,15 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     rather than downloading the tarball from the web.
 
     version: The version of Arm Allinea Studio to install.  The
-    default value is `19.3`.
+    default value is `20.0`.  Due to differences in the packaging
+    scheme, versions prior to 20.0 are not supported.
 
     # Examples
 
     ```python
-    arm_allinea_studio(eula=True, version='19.3')
+    arm_allinea_studio(eula=True,
+                       microarchitectures=['generic', 'thunderx2t99'],
+                       version='20.0')
     ```
 
     """
@@ -103,7 +107,6 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
         super(arm_allinea_studio, self).__init__(**kwargs)
 
-        self.__armpl_generic_aarch64_only = kwargs.get('armpl_generic_aarch64_only', True)
         self.__baseurl = kwargs.get('baseurl',
                                     'https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio')
         self.__commands = [] # Filled in by __setup()
@@ -114,15 +117,15 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         # https://developer.arm.com/tools-and-software/server-and-hpc/arm-architecture-tools/arm-allinea-studio/licensing/eula
         self.__eula = kwargs.get('eula', False)
 
-        self.__gcc_version = kwargs.get('gcc_version', '8.2.0')
-        self.__generic_aarch64_only = '' # Filled in by __distro()
+        self.__gcc_version = kwargs.get('gcc_version', '9.2.0')
         self.__installer_template = '' # Filled in by __distro()
-        self.__llvm_version = kwargs.get('llvm_version', '7.1.0')
+        self.__microarchitectures = kwargs.get('microarchitectures',
+                                               ['generic'])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__package_string = '' # Filled in by __distro()
         self.__prefix = kwargs.get('prefix', '/opt/arm')
         self.__tarball = kwargs.get('tarball', None)
-        self.__version = kwargs.get('version', '19.3')
+        self.__version = kwargs.get('version', '20.0')
         self.__wd = '/var/tmp' # working directory
 
         self.toolchain = toolchain(CC='armclang', CXX='armclang++',
@@ -150,7 +153,8 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self += comment('Arm Allinea Studio version {}'.format(self.__version))
 
         if self.__ospackages:
-            self += packages(ospackages=self.__ospackages)
+            # EPEL necessary for Lmod
+            self += packages(epel=True, ospackages=self.__ospackages)
 
         if self.__tarball:
             self += copy(src=self.__tarball, dest=self.__wd)
@@ -164,27 +168,29 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             self.__directory_string = 'Ubuntu-16.04'
-            # By specifying an install prefix, the installer bypasses
-            # the deb package manager (debs are not relocatable like
-            # rpms).  Therefore, remove the files directly rather than
-            # removing packages.
-            self.__generic_aarch64_only = 'find /opt/arm -maxdepth 1 -type d -name "armpl-*" -not -name "*Generic-AArch64*" -print0 | xargs -0 rm -rf'
-            self.__installer_template = 'arm-compiler-for-hpc-{}_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh'
             self.__package_string = 'Ubuntu_16.04'
             self.__url_string = 'Ubuntu16.04'
 
+            self.__installer_template = 'arm-compiler-for-linux-{{}}_Generic-AArch64_{0}_aarch64-linux-deb.sh'.format(self.__directory_string)
+
             if not self.__ospackages:
-                self.__ospackages = ['libc6-dev', 'python', 'tar', 'wget']
+                self.__ospackages = ['libc6-dev', 'lmod', 'python', 'tar',
+                                     'wget']
 
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
-            self.__directory_string = 'RHEL-7'
-            self.__generic_aarch64_only = 'rpm --erase $(rpm -qa | grep armpl | grep -v Generic-AArch64)'
-            self.__installer_template = 'arm-compiler-for-hpc-{}_Generic-AArch64_RHEL-7_aarch64-linux-rpm.sh'
-            self.__package_string = 'RHEL_7'
-            self.__url_string = 'RHEL7'
+            if hpccm.config.g_linux_version >= StrictVersion('8.0'):
+                self.__directory_string = 'RHEL-8'
+                self.__package_string = 'RHEL_8'
+                self.__url_string = 'RHEL8'
+            else:
+                self.__directory_string = 'RHEL-7'
+                self.__package_string = 'RHEL_7'
+                self.__url_string = 'RHEL7'
+
+            self.__installer_template = 'arm-compiler-for-linux-{{}}_Generic-AArch64_{}_aarch64-linux-rpm.sh'.format(self.__directory_string)
 
             if not self.__ospackages:
-                self.__ospackages = ['glibc-devel', 'tar', 'wget']
+                self.__ospackages = ['Lmod', 'glibc-devel', 'tar', 'wget']
 
         else: # pragma: no cover
             raise RuntimeError('Unknown Linux distribution')
@@ -193,11 +199,12 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         """Construct the series of shell commands, i.e., fill in
            self.__commands"""
 
+        # Use a tarball.  Figure out the version from the tarball name.
         if self.__tarball:
             tarball = posixpath.basename(self.__tarball)
 
-            # Figure out the version from the tarbal name
-            match = re.match(r'Arm-Compiler-for-HPC_(?P<year>\d\d)\.0?(?P<month>[1-9][0-9]?)',
+            # Figure out the version from the tarball name
+            match = re.match(r'Arm-Compiler-for-Linux_(?P<year>\d\d)\.0?(?P<month>[0-9][0-9]?)',
                              tarball)
             if match and match.groupdict()['year'] and match.groupdict()['month']:
                 self.__version = '{0}.{1}'.format(match.groupdict()['year'],
@@ -210,7 +217,7 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
             major_minor = '{0}-{1}'.format(match.groupdict()['major'],
                                            match.groupdict()['minor'])
 
-            tarball = 'Arm-Compiler-for-HPC_{0}_{1}_aarch64.tar'.format(
+            tarball = 'Arm-Compiler-for-Linux_{0}_{1}_aarch64.tar'.format(
                 self.__version, self.__package_string)
             url = '{0}/{1}/{2}/{3}'.format(self.__baseurl, major_minor,
                                            self.__url_string, tarball)
@@ -227,17 +234,14 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         install_args = ['--install-to {}'.format(self.__prefix)]
         if self.__eula:
             install_args.append('--accept')
-        package_directory = 'ARM-Compiler-for-HPC_{0}_AArch64_{1}_aarch64'.format(self.__version, self.__package_string)
+        if self.__microarchitectures:
+            install_args.append('--only-install-microarchitectures={}'.format(
+                ','.join(self.__microarchitectures)))
+        package_directory = 'Arm-Compiler-for-linux_{0}_AArch64_{1}_aarch64'.format(self.__version, self.__package_string)
         self.__commands.append('cd {0} && ./{1} {2}'.format(
             posixpath.join(self.__wd, package_directory),
             self.__installer_template.format(self.__version),
             ' '.join(install_args)))
-
-        # The default install includes the Arm Performance Libraries for
-        # multiple Arm variants.  The install is not configurable, and
-        # the non generic aarch64 bits are very large, so remove them.
-        if self.__armpl_generic_aarch64_only:
-            self.__commands.append(self.__generic_aarch64_only)
 
         # Cleanup tarball and directory
         self.__commands.append(self.cleanup_step(
@@ -245,25 +249,8 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
                    posixpath.join(self.__wd, package_directory)]))
 
         # Set environment
-        gcc_path = posixpath.join(
-            self.__prefix,
-            'gcc-{0}_Generic-AArch64_{1}_aarch64-linux'.format(
-                self.__gcc_version, self.__directory_string))
-        llvm_path = posixpath.join(
-            self.__prefix,
-            'arm-hpc-compiler-{0}_Generic-AArch64_{1}_aarch64-linux'.format(self.__version, self.__directory_string))
-        self.environment_variables['COMPILER_PATH'] = '{}:$COMPILER_PATH'.format(gcc_path)
-        self.environment_variables['CPATH'] = '{0}:{1}:$CPATH'.format(
-            posixpath.join(gcc_path, 'include'),
-            posixpath.join(llvm_path, 'include'))
-        self.environment_variables['LD_LIBRARY_PATH'] = '{0}:{1}:{2}:$LD_LIBRARY_PATH'.format(
-            posixpath.join(gcc_path, 'lib'), posixpath.join(gcc_path, 'lib64'),
-            posixpath.join(llvm_path, 'lib'))
-        self.environment_variables['LIBRARY_PATH'] = '{0}:{1}:{2}:$LIBRARY_PATH'.format(
-            posixpath.join(gcc_path, 'lib'), posixpath.join(gcc_path, 'lib64'),
-            posixpath.join(llvm_path, 'lib'))
-        self.environment_variables['PATH'] = '{0}:{1}:$PATH'.format(
-            posixpath.join(gcc_path, 'bin'), posixpath.join(llvm_path, 'bin'))
+        self.environment_variables['MODULEPATH'] = '{}:$MODULEPATH'.format(
+            posixpath.join(self.__prefix, 'modulefiles'))
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific
@@ -280,40 +267,60 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         instructions = []
         instructions.append(comment('Arm Allinea Studio'))
 
-        gcc_path = posixpath.join(
+        paths = []
+
+        # Redistributable libraries from redistributables.txt
+        # The allowed list of redistributable libraries does not
+        # include all Arm Allinea Studio libraries that get typically
+        # linked; consider using '-static-arm-libs'.
+
+        # OpenMP and Fortran runtime libraries
+        compiler_redist_path = posixpath.join(
             self.__prefix,
-            'gcc-{0}_Generic-AArch64_{1}_aarch64-linux'.format(
-                self.__gcc_version, self.__directory_string))
+            'arm-linux-compiler-{0}_Generic-AArch64_{1}_aarch64-linux'.format(
+                self.__version, self.__directory_string),
+            'lib')
+        paths.append(compiler_redist_path)
+        instructions.append(
+            copy(_from=_from,
+                 src=[posixpath.join(compiler_redist_path, lib)
+                      for lib in ['libgomp.so', 'libiomp5.so', 'libomp.so',
+                                  'libflang.so', 'libflangrti.so']],
+                 dest=posixpath.join(compiler_redist_path, '')))
 
-        llvm_path = posixpath.join(
-            self.__prefix,
-            'arm-hpc-compiler-{0}_Generic-AArch64_{1}_aarch64-linux'.format(self.__version, self.__directory_string))
+        # Performance libraries
+        microarch_string = {'generic': 'Generic-AArch64',
+                            'generic-sve': 'Generic-SVE',
+                            'neoverse-n1': 'Neoverse-N1',
+                            'thunderx2t99': 'ThunderX2CN99'}
+        for microarch in self.__microarchitectures:
+            armpl_arm_redist_path = posixpath.join(
+                self.__prefix,
+                'armpl-{0}.0_{1}_{2}_arm-linux-compiler_{0}_aarch64-linux'.format(
+                    self.__version, microarch_string[microarch],
+                    self.__directory_string),
+                'lib')
+            paths.append(armpl_arm_redist_path)
+            instructions.append(
+                copy(_from=_from,
+                     src=[posixpath.join(armpl_arm_redist_path, lib)
+                          for lib in ['libamath.so', 'libamath_dummy.so',
+                                      'libastring.so']],
+                     dest=posixpath.join(armpl_arm_redist_path, '')))
 
-        # This assumes armpl_generic_aarch64_only = True
-        armpl_path = posixpath.join(
-            self.__prefix,
-            'armpl-{0}.0_Generic-AArch64_{1}_arm-hpc-compiler_{0}_aarch64-linux'.format(self.__version, self.__directory_string))
-
-        paths = [posixpath.join(gcc_path, 'lib64'),
-                 posixpath.join(llvm_path, 'lib'),
-                 posixpath.join(llvm_path, 'lib', 'clang', self.__llvm_version,
-                                'lib', 'linux'),
-                 posixpath.join(armpl_path, 'lib')]
-
-        for path in paths:
-            instructions.append(copy(_from=_from,
-                                     src=posixpath.join(path, '*.so*'),
-                                     dest=posixpath.join(path, '')))
-
-        # The armpl_links directory is full of symlinks.  If
-        # armpl_generic_aarch64_only = True, then many of the symlinks
-        # are broken.  Copying broken symlinks directly will fail, so
-        # instead just copy the whole directory.
-        armpl_links = posixpath.join(llvm_path, 'lib', 'clang',
-                                     self.__llvm_version, 'armpl_links',
-                                     'lib')
-        instructions.append(copy(_from=_from, src=armpl_links,
-                                 dest=armpl_links))
+            armpl_gcc_redist_path = posixpath.join(
+                self.__prefix,
+                'armpl-{0}.0_{1}_{2}_gcc_{3}_aarch64-linux'.format(
+                    self.__version, microarch_string[microarch],
+                    self.__directory_string, self.__gcc_version),
+                'lib')
+            paths.append(armpl_gcc_redist_path)
+            instructions.append(
+                copy(_from=_from,
+                     src=[posixpath.join(armpl_gcc_redist_path, lib)
+                          for lib in ['libamath.so', 'libamath_dummy.so',
+                                      'libastring.so']],
+                     dest=posixpath.join(armpl_gcc_redist_path, '')))
 
         paths.append('$LD_LIBRARY_PATH') # tack on existing value at end
         self.runtime_environment_variables['LD_LIBRARY_PATH'] = ':'.join(paths)

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -79,7 +79,7 @@ class boost(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     SourceForge repository should be used.  The default is False.
 
     version: The version of Boost source to download.  The default
-    value is `1.70.0`.
+    value is `1.72.0`.
 
     # Examples
 
@@ -106,7 +106,7 @@ class boost(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__prefix = kwargs.get('prefix', '/usr/local/boost')
         self.__python = kwargs.get('python', False)
         self.__sourceforge = kwargs.get('sourceforge', False)
-        self.__version = kwargs.get('version', '1.70.0')
+        self.__version = kwargs.get('version', '1.72.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -32,7 +32,7 @@ import hpccm.templates.wget
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
-from hpccm.common import cpu_arch
+from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.shell import shell
 from hpccm.primitives.environment import environment
@@ -51,18 +51,20 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     The default value is `False`.
 
     ospackages: List of OS packages to install prior to installing.
-    The default value is `wget`.
+    The default values are `make` and `wget`.
 
     prefix: The top level install location.  The default value is
     `/usr/local`.
 
     source: Boolean flag to specify whether to build CMake from
-    source.  For x86_64 processors, the default is False, i.e., use
-    the available pre-compiled package.  For all other processors, the
-    default is True.
+    source.  If True, includes the `libssl-dev` package in the list of
+    OS packages for Ubuntu, and `openssl-devel` for RHEL-based
+    distributions.  For x86_64 processors, the default is False, i.e.,
+    use the available pre-compiled package.  For all other processors,
+    the default is True.
 
     version: The version of CMake to download.  The default value is
-    `3.14.5`.
+    `3.16.3`.
 
     # Examples
 
@@ -93,7 +95,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__parallel = kwargs.get('parallel', '$(nproc)')
         self.__prefix = kwargs.get('prefix', '/usr/local')
         self.__source = kwargs.get('source', False)
-        self.__version = kwargs.get('version', '3.14.5')
+        self.__version = kwargs.get('version', '3.16.3')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory
@@ -112,7 +114,6 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self += shell(commands=self.__commands)
         self += environment(variables={'PATH': '{}:$PATH'.format(
             posixpath.join(self.__prefix, 'bin'))})
-
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -170,6 +171,14 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
                                        match.groupdict()['minor'])
         tarball = 'cmake-{}.tar.gz'.format(self.__version)
         url = '{0}/v{1}/{2}'.format(self.__baseurl, major_minor, tarball)
+
+        # Include SSL packages
+        if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
+            self.__ospackages.append('libssl-dev')
+        elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
+            self.__ospackages.append('openssl-devel')
+        else: # pragma: no cover
+            raise RuntimeError('Unknown Linux distribution')
 
         # Download source from web
         self.__commands.append(self.download_step(url=url,

--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -61,7 +61,7 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     `/usr/local/gdrcopy`.
 
     version: The version of gdrcopy source to download.  The default
-    value is `1.3`.
+    value is `2.0`.
 
     # Examples
 
@@ -79,7 +79,7 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__baseurl = kwargs.get('baseurl', 'https://github.com/NVIDIA/gdrcopy/archive')
         self.__ospackages = kwargs.get('ospackages', ['make', 'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/gdrcopy')
-        self.__version = kwargs.get('version', '1.3')
+        self.__version = kwargs.get('version', '2.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -97,7 +97,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     default is empty.
 
     version: The version of HDF5 source to download.  This value is
-    ignored if `directory` is set.  The default value is `1.10.5`.
+    ignored if `directory` is set.  The default value is `1.10.6`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -146,7 +146,7 @@ class hdf5(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '1.10.5')
+        self.__version = kwargs.get('version', '1.10.6')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/hpcx.py
+++ b/hpccm/building_blocks/hpcx.py
@@ -75,7 +75,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
     mlnx_ofed: The version of Mellanox OFED that should be matched.
     This value is ignored if Inbox OFED is selected.  The default
-    value is `4.6-1.0.1.1`.
+    value is `4.7-1.0.0.1`.
 
     multi_thread: Boolean flag to specify whether the multi-threaded
     version of Mellanox HPC-X should be used.  The default is `False`.
@@ -117,7 +117,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__bashrc = '' # Filled in by __distro()
         self.__hpcxinit = kwargs.get('hpcxinit', True)
         self.__inbox = kwargs.get('inbox', False)
-        self.__mlnx_ofed = kwargs.get('mlnx_ofed', '4.6-1.0.1.1')
+        self.__mlnx_ofed = kwargs.get('mlnx_ofed', '4.7-1.0.0.1')
         self.__multi_thread = kwargs.get('multi_thread', False)
         self.__oslabel = kwargs.get('oslabel', '') # Filled in by __distro()
         self.__ospackages = kwargs.get('ospackages', []) # Filled in by _distro()

--- a/hpccm/building_blocks/intel_mpi.py
+++ b/hpccm/building_blocks/intel_mpi.py
@@ -78,7 +78,7 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     the default values are `man-db` and `openssh-clients`.
 
     version: The version of Intel MPI to install.  The default value
-    is `2019.4-070`.
+    is `2019.6-088`.
 
     # Examples
 
@@ -99,7 +99,8 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
 
         self.__mpivars = kwargs.get('mpivars', True)
         self.__ospackages = kwargs.get('ospackages', [])
-        self.version = kwargs.get('version', '2019.4-070')
+        self.__version = kwargs.get('version', '2019.6-088')
+        self.__year = '2019' # Also used by 2018 versions
 
         self.__bashrc = ''      # Filled in by __distro()
 
@@ -115,7 +116,7 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     def __instructions(self):
         """Fill in container instructions"""
 
-        self += comment('Intel MPI version {}'.format(self.version))
+        self += comment('Intel MPI version {}'.format(self.__version))
 
         if self.__ospackages:
             self += packages(ospackages=self.__ospackages)
@@ -124,10 +125,10 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
             raise RuntimeError('Intel EULA was not accepted.  To accept, see the documentation for this building block')
 
         self += packages(
-            apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'],
+            apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             apt_repositories=['deb https://apt.repos.intel.com/mpi all main'],
-            ospackages=['intel-mpi-{}'.format(self.version)],
-            yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'],
+            ospackages=['intel-mpi-{}'.format(self.__version)],
+            yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             yum_repositories=['https://yum.repos.intel.com/mpi/setup/intel-mpi.repo'])
 
         # Set the environment
@@ -141,7 +142,7 @@ class intel_mpi(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
             # subsequent build steps and when starting the container,
             # but this may miss some things relative to the mpivars
             # environment script.
-            if LooseVersion(self.version) >= LooseVersion('2019.0'):
+            if LooseVersion(self.__version) >= LooseVersion('2019.0'):
               self.environment_variables={
                   'FI_PROVIDER_PATH': '/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov',
                   'I_MPI_ROOT': '/opt/intel/compilers_and_libraries/linux/mpi',

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -145,7 +145,7 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     using the [intel_psxe_runtime](#intel_psxe_runtime) building
     block.  This value is passed as its `version` parameter.  In
     general, the major version of the runtime should correspond to the
-    tarball version.  The default value is `2019.5-281`.
+    tarball version.  The default value is `2020.0-008`.
 
     tarball: Path to the Intel Parallel Studio XE tarball relative to
     the local build context.  The default value is empty.  This
@@ -193,7 +193,7 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/opt/intel')
         self.__psxevars = kwargs.get('psxevars', True)
-        self.__runtime_version = kwargs.get('runtime_version', '2019.5-281')
+        self.__runtime_version = kwargs.get('runtime_version', '2020.0-008')
         self.__tarball = kwargs.get('tarball', None)
         self.__tbb = kwargs.get('tbb', True)
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/intel_psxe_runtime.py
+++ b/hpccm/building_blocks/intel_psxe_runtime.py
@@ -104,7 +104,7 @@ class intel_psxe_runtime(bb_base, hpccm.templates.envvars):
     Blocks runtime should be installed.  The default is True.
 
     version: The version of the Intel Parallel Studio XE runtime to
-    install.  The default value is `2019.5-281`.
+    install.  The default value is `2020.0-008`.
 
     # Examples
 
@@ -137,7 +137,7 @@ class intel_psxe_runtime(bb_base, hpccm.templates.envvars):
         self.__psxevars = kwargs.get('psxevars', True)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__tbb = kwargs.get('tbb', True)
-        self.__version = kwargs.get('version', '2019.5-281')
+        self.__version = kwargs.get('version', '2020.0-008')
         self.__year = self.__version.split('.')[0]
 
         self.__bashrc = ''            # Filled in by __distro()
@@ -266,6 +266,10 @@ class intel_psxe_runtime(bb_base, hpccm.templates.envvars):
                     basepath, 'mpi', 'intel64', 'libfabric', 'lib'))
                 path.append(posixpath.join(basepath, 'mpi', 'intel64',
                                            'libfabric', 'bin'))
+
+            if LooseVersion(self.__version) >= LooseVersion('2020'):
+                ld_library_path.append(posixpath.join(
+                    basepath, 'mpi', 'intel64', 'lib', 'release'))
 
         if self.__tbb:
             ld_library_path.append(posixpath.join(basepath, 'tbb', 'lib',

--- a/hpccm/building_blocks/julia.py
+++ b/hpccm/building_blocks/julia.py
@@ -80,12 +80,12 @@ class julia(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     is `/usr/local/julia`.
 
     version: The version of Julia to install.  The default value is
-    `1.2.0`.
+    `1.3.1`.
 
     # Examples
 
     ```python
-    julia(prefix='/usr/local/julia', version='1.2.0')
+    julia(prefix='/usr/local/julia', version='1.3.1')
     ```
 
     ```python
@@ -109,7 +109,7 @@ class julia(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__ospackages = kwargs.get('ospackages', ['tar', 'wget'])
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/julia')
-        self.__version = kwargs.get('version', '1.2.0')
+        self.__version = kwargs.get('version', '1.3.1')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -74,7 +74,7 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     distributions, the default is an empty list.
 
     version: The version of MKL to install.  The default value is
-    `2019.4-070`.
+    `2020.0-088`.
 
     # Examples
 
@@ -96,7 +96,8 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
 
         self.__mklvars = kwargs.get('mklvars', True)
         self.__ospackages = kwargs.get('ospackages', [])
-        self.version = kwargs.get('version', '2019.4-070')
+        self.__version = kwargs.get('version', '2020.0-088')
+        self.__year = '2019' # Also used by 2018 and 2020 versions
 
         self.__bashrc = ''      # Filled in by __distro()
 
@@ -112,7 +113,7 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
     def __instructions(self):
         """Fill in container instructions"""
 
-        self += comment('MKL version {}'.format(self.version))
+        self += comment('MKL version {}'.format(self.__version))
 
         if self.__ospackages:
             self += packages(ospackages=self.__ospackages)
@@ -121,10 +122,10 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
             raise RuntimeError('Intel EULA was not accepted.  To accept, see the documentation for this building block')
 
         self += packages(
-            apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'],
+            apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             apt_repositories=['deb https://apt.repos.intel.com/mkl all main'],
-            ospackages=['intel-mkl-64bit-{}'.format(self.version)],
-            yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB'],
+            ospackages=['intel-mkl-64bit-{}'.format(self.__version)],
+            yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             yum_repositories=['https://yum.repos.intel.com/mkl/setup/intel-mkl.repo'])
 
         # Set the environment

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -77,7 +77,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     via the package manager to the standard system locations.
 
     version: The version of Mellanox OFED to download.  The default
-    value is `4.6-1.0.1.1`.
+    value is `4.7-3.2.9.0`.
 
     # Examples
 
@@ -102,7 +102,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', None)
         self.__symlink = kwargs.get('symlink', False)
-        self.__version = kwargs.get('version', '4.6-1.0.1.1')
+        self.__version = kwargs.get('version', '4.7-3.2.9.0')
 
         self.__commands = []
         self.__wd = '/var/tmp'

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -94,7 +94,7 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     default is empty.
 
     version: The version of MPICH source to download.  The default
-    value is `3.3.1`.
+    value is `3.3.2`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -136,7 +136,7 @@ class mpich(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         # MPICH does not accept F90
         self.toolchain_control = {'CC': True, 'CXX': True, 'F77': True,
                                   'F90': False, 'FC': True}
-        self.version = kwargs.get('version', '3.3.1')
+        self.version = kwargs.get('version', '3.3.2')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -56,7 +56,8 @@ class multi_ofed(bb_base):
     mlnx_versions: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
     versions to install.  The default values are `3.3-1.0.4.0`,
     `3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
-    `4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`
+    `4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and
+    `4.7-3.2.9.0`.
 
     ospackages: List of OS packages to install prior to installing
     OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -93,7 +94,7 @@ class multi_ofed(bb_base):
                                            '4.0-2.0.0.1', '4.1-1.0.2.0',
                                            '4.2-1.2.0.0', '4.3-1.0.1.0',
                                            '4.4-2.0.7.0', '4.5-1.0.1.0',
-                                           '4.6-1.0.1.1'])
+                                           '4.6-1.0.1.1', '4.7-3.2.9.0'])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/ofed')
         self.__symlink = kwargs.get('symlink', False)

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -119,7 +119,7 @@ class mvapich2(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     default is empty.
 
     version: The version of MVAPICH2 source to download.  This value
-    is ignored if `directory` is set.  The default value is `2.3.1`.
+    is ignored if `directory` is set.  The default value is `2.3.3`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -171,7 +171,7 @@ class mvapich2(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         # MVAPICH2 does not accept F90
         self.toolchain_control = {'CC': True, 'CXX': True, 'F77': True,
                                   'F90': False, 'FC': True}
-        self.version = kwargs.get('version', '2.3.1')
+        self.version = kwargs.get('version', '2.3.3')
 
         self.__commands = []              # Filled in by __setup()
 

--- a/hpccm/building_blocks/mvapich2_gdr.py
+++ b/hpccm/building_blocks/mvapich2_gdr.py
@@ -116,8 +116,11 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     pgi: Boolean flag to specify whether a PGI build should be used.
     The default value is False.
 
+    release: The release of MVAPICH2-GDR to download.  The value is
+    ignored is `package` is set.  The default value is `2`.
+
     version: The version of MVAPICH2-GDR to download.  The value is
-    ignored if `package` is set.  The default value is `2.3.1`.  Due
+    ignored if `package` is set.  The default value is `2.3.3`.  Due
     to differences in the packaging scheme, versions prior to 2.3 are
     not supported.
 
@@ -148,10 +151,11 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__mofed_version = kwargs.get('mlnx_ofed_version', '4.5')
         self.__ospackages = kwargs.get('ospackages', [])
         self.__package = kwargs.get('package', '')
-        self.__package_template = 'mvapich2-gdr-mcast.{0}.{1}.{2}-{3}-1.el7.{4}.rpm'
+        self.__package_template = 'mvapich2-gdr-mcast.{0}.{1}.{2}-{3}-{4}.el7.{5}.rpm'
         self.__pgi = kwargs.get('pgi', False)
         self.__pgi_version = kwargs.get('pgi_version', '18.10')
-        self.version = kwargs.get('version', '2.3.1')
+        self.__release = kwargs.get('release', '2')
+        self.version = kwargs.get('version', '2.3.3')
         self.__wd = '/var/tmp' # working directory
 
         # Output toolchain
@@ -251,7 +255,7 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
             # Package filename
             package = self.__package_template.format(
                 cuda_string, mofed_string, compiler_string, self.version,
-                self.__arch)
+                self.__release, self.__arch)
 
         self.__install_path = self.__install_path_template.format(
             self.version, cuda_string, mofed_string, compiler_string)

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -104,13 +104,13 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     default is empty.
 
     version: The version of NetCDF to download.  The default value is
-    `4.7.0`.
+    `4.7.3`.
 
     version_cxx: The version of NetCDF C++ to download.  The default
-    value is `4.3.0`.
+    value is `4.3.1`.
 
     version_fortran: The version of NetCDF Fortran to download.  The
-    default value is `4.4.5`.
+    default value is `4.5.2`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -154,9 +154,9 @@ class netcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.prefix = kwargs.get('prefix', '/usr/local/netcdf')
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '4.7.0')
-        self.__version_cxx = kwargs.get('version_cxx', '4.3.0')
-        self.__version_fortran = kwargs.get('version_fortran', '4.4.5')
+        self.__version = kwargs.get('version', '4.7.3')
+        self.__version_cxx = kwargs.get('version_cxx', '4.3.1')
+        self.__version_fortran = kwargs.get('version_fortran', '4.5.2')
         self.__wd = '/var/tmp'
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -73,7 +73,7 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     default is empty.
 
     version: The version of OpenBLAS source to download.  The default
-    value is `0.3.6`.
+    value is `0.3.7`.
 
     # Examples
 
@@ -100,7 +100,7 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
                                                       'wget'])
         self.__prefix = kwargs.get('prefix', '/usr/local/openblas')
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '0.3.6')
+        self.__version = kwargs.get('version', '0.3.7')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -133,7 +133,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
     version: The version of OpenMPI source to download.  This
     value is ignored if `directory` is set.  The default value is
-    `4.0.1`.
+    `4.0.3rc3`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -195,7 +195,7 @@ class openmpi(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
         # Input toolchain, i.e., what to use when building
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.version = kwargs.get('version', '4.0.1')
+        self.version = kwargs.get('version', '4.0.3rc3')
         self.__ucx = kwargs.get('ucx', False)
 
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/pnetcdf.py
+++ b/hpccm/building_blocks/pnetcdf.py
@@ -89,7 +89,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     e.g., `CC=mpicc`, `CXX=mpicxx`, etc.
 
     version: The version of PnetCDF source to download.  The default
-    value is `1.11.2`.
+    value is `1.12.1`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -132,7 +132,7 @@ class pnetcdf(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
                                       toolchain(CC='mpicc', CXX='mpicxx',
                                                 F77='mpif77', F90='mpif90',
                                                 FC='mpifort'))
-        self.__version = kwargs.get('version', '1.11.2')
+        self.__version = kwargs.get('version', '1.12.1')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/slurm_pmi2.py
+++ b/hpccm/building_blocks/slurm_pmi2.py
@@ -86,7 +86,7 @@ class slurm_pmi2(bb_base, hpccm.templates.ConfigureMake,
     default value is empty.
 
     version: The version of SLURM source to download.  The default
-    value is `19.05.4`.
+    value is `19.05.5`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -119,7 +119,7 @@ class slurm_pmi2(bb_base, hpccm.templates.ConfigureMake,
                                                       'perl', 'tar', 'wget'])
         self.prefix = kwargs.get('prefix', '/usr/local/slurm-pmi2')
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '19.05.4')
+        self.__version = kwargs.get('version', '19.05.5')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -132,7 +132,7 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
     default value is empty.
 
     version: The version of UCX source to download.  The default value
-    is `1.5.2`.
+    is `1.7.0`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -189,7 +189,7 @@ class ucx(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.__ospackages = kwargs.get('ospackages', [])
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.get('toolchain', toolchain())
-        self.__version = kwargs.get('version', '1.5.2')
+        self.__version = kwargs.get('version', '1.7.0')
         self.__xpmem = kwargs.get('xpmem', '')
 
         self.__commands = [] # Filled in by __setup()

--- a/test/test_arm_allinea_studio.py
+++ b/test/test_arm_allinea_studio.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, docker, ubuntu
+from helpers import aarch64, centos, centos8, docker, ubuntu
 
 from hpccm.building_blocks.arm_allinea_studio import arm_allinea_studio
 
@@ -38,24 +38,20 @@ class Test_arm_allinea_studio(unittest.TestCase):
         """Default arm_allinea_studio building block"""
         a = arm_allinea_studio(eula=True)
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 19.3
+r'''# Arm Allinea Studio version 20.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6-dev \
+        lmod \
         python \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/19-3/Ubuntu16.04/Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_Ubuntu_16.04_aarch64 && ./arm-compiler-for-hpc-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh --install-to /opt/arm --accept && \
-    find /opt/arm -maxdepth 1 -type d -name "armpl-*" -not -name "*Generic-AArch64*" -print0 | xargs -0 rm -rf && \
-    rm -rf /var/tmp/Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_Ubuntu_16.04_aarch64
-ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux:$COMPILER_PATH \
-    CPATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/include:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/include:$CPATH \
-    LD_LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:$LD_LIBRARY_PATH \
-    LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:$LIBRARY_PATH \
-    PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/20-0/Ubuntu16.04/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_Ubuntu_16.04_aarch64 && ./arm-compiler-for-linux-20.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh --install-to /opt/arm --accept --only-install-microarchitectures=generic && \
+    rm -rf /var/tmp/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_Ubuntu_16.04_aarch64
+ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
     @centos
@@ -64,22 +60,41 @@ ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux:
         """Default arm_allinea_studio building block"""
         a = arm_allinea_studio(eula=True)
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 19.3
-RUN yum install -y \
+r'''# Arm Allinea Studio version 20.0
+RUN yum install -y epel-release && \
+    yum install -y \
+        Lmod \
         glibc-devel \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/19-3/RHEL7/Arm-Compiler-for-HPC_19.3_RHEL_7_aarch64.tar && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-HPC_19.3_RHEL_7_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_RHEL_7_aarch64 && ./arm-compiler-for-hpc-19.3_Generic-AArch64_RHEL-7_aarch64-linux-rpm.sh --install-to /opt/arm --accept && \
-    rpm --erase $(rpm -qa | grep armpl | grep -v Generic-AArch64) && \
-    rm -rf /var/tmp/Arm-Compiler-for-HPC_19.3_RHEL_7_aarch64.tar /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_RHEL_7_aarch64
-ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux:$COMPILER_PATH \
-    CPATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/include:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/include:$CPATH \
-    LD_LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib:$LD_LIBRARY_PATH \
-    LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib:$LIBRARY_PATH \
-    PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/bin:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/20-0/RHEL7/Arm-Compiler-for-Linux_20.0_RHEL_7_aarch64.tar && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-Linux_20.0_RHEL_7_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_RHEL_7_aarch64 && ./arm-compiler-for-linux-20.0_Generic-AArch64_RHEL-7_aarch64-linux-rpm.sh --install-to /opt/arm --accept --only-install-microarchitectures=generic && \
+    rm -rf /var/tmp/Arm-Compiler-for-Linux_20.0_RHEL_7_aarch64.tar /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_RHEL_7_aarch64
+ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
+
+    @aarch64
+    @centos8
+    @docker
+    def test_thunderx2_centos8(self):
+        """Default arm_allinea_studio building block"""
+        a = arm_allinea_studio(eula=True,
+                               microarchitectures=['generic', 'thunderx2t99'])
+        self.assertEqual(str(a),
+r'''# Arm Allinea Studio version 20.0
+RUN yum install -y epel-release && \
+    yum install -y \
+        Lmod \
+        glibc-devel \
+        tar \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/20-0/RHEL8/Arm-Compiler-for-Linux_20.0_RHEL_8_aarch64.tar && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-Linux_20.0_RHEL_8_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_RHEL_8_aarch64 && ./arm-compiler-for-linux-20.0_Generic-AArch64_RHEL-8_aarch64-linux-rpm.sh --install-to /opt/arm --accept --only-install-microarchitectures=generic,thunderx2t99 && \
+    rm -rf /var/tmp/Arm-Compiler-for-Linux_20.0_RHEL_8_aarch64.tar /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_RHEL_8_aarch64
+ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
     @ubuntu
@@ -96,26 +111,22 @@ ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux:$COMPI
     def test_tarball(self):
         """tarball"""
         a = arm_allinea_studio(eula=True,
-                               tarball='Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar')
+                               tarball='Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar')
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 19.3
+r'''# Arm Allinea Studio version 20.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6-dev \
+        lmod \
         python \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-COPY Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar /var/tmp
-RUN mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_Ubuntu_16.04_aarch64 && ./arm-compiler-for-hpc-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh --install-to /opt/arm --accept && \
-    find /opt/arm -maxdepth 1 -type d -name "armpl-*" -not -name "*Generic-AArch64*" -print0 | xargs -0 rm -rf && \
-    rm -rf /var/tmp/Arm-Compiler-for-HPC_19.3_Ubuntu_16.04_aarch64.tar /var/tmp/ARM-Compiler-for-HPC_19.3_AArch64_Ubuntu_16.04_aarch64
-ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux:$COMPILER_PATH \
-    CPATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/include:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/include:$CPATH \
-    LD_LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:$LD_LIBRARY_PATH \
-    LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/lib:$LIBRARY_PATH \
-    PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_Ubuntu-16.04_aarch64-linux/bin:$PATH''')
+COPY Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar /var/tmp
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_Ubuntu_16.04_aarch64 && ./arm-compiler-for-linux-20.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux-deb.sh --install-to /opt/arm --accept --only-install-microarchitectures=generic && \
+    rm -rf /var/tmp/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar /var/tmp/Arm-Compiler-for-linux_20.0_AArch64_Ubuntu_16.04_aarch64
+ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
     @centos
@@ -126,12 +137,21 @@ ENV COMPILER_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_Ubuntu-16.04_aarch64-linux:
         r = a.runtime()
         self.assertEqual(r,
 r'''# Arm Allinea Studio
-COPY --from=0 /opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib64/*.so* /opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib64/
-COPY --from=0 /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/*.so* /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/
-COPY --from=0 /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/clang/7.1.0/lib/linux/*.so* /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/clang/7.1.0/lib/linux/
-COPY --from=0 /opt/arm/armpl-19.3.0_Generic-AArch64_RHEL-7_arm-hpc-compiler_19.3_aarch64-linux/lib/*.so* /opt/arm/armpl-19.3.0_Generic-AArch64_RHEL-7_arm-hpc-compiler_19.3_aarch64-linux/lib/
-COPY --from=0 /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/clang/7.1.0/armpl_links/lib /opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/clang/7.1.0/armpl_links/lib
-ENV LD_LIBRARY_PATH=/opt/arm/gcc-8.2.0_Generic-AArch64_RHEL-7_aarch64-linux/lib64:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/arm-hpc-compiler-19.3_Generic-AArch64_RHEL-7_aarch64-linux/lib/clang/7.1.0/lib/linux:/opt/arm/armpl-19.3.0_Generic-AArch64_RHEL-7_arm-hpc-compiler_19.3_aarch64-linux/lib:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libgomp.so \
+    /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libiomp5.so \
+    /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libomp.so \
+    /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflang.so \
+    /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflangrti.so \
+    /opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/
+COPY --from=0 /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_arm-linux-compiler_20.0_aarch64-linux/lib/libamath.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_arm-linux-compiler_20.0_aarch64-linux/lib/libamath_dummy.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_arm-linux-compiler_20.0_aarch64-linux/lib/libastring.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_arm-linux-compiler_20.0_aarch64-linux/lib/
+COPY --from=0 /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_gcc_9.2.0_aarch64-linux/lib/libamath.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_gcc_9.2.0_aarch64-linux/lib/libamath_dummy.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_gcc_9.2.0_aarch64-linux/lib/libastring.so \
+    /opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_gcc_9.2.0_aarch64-linux/lib/
+ENV LD_LIBRARY_PATH=/opt/arm/arm-linux-compiler-20.0_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_arm-linux-compiler_20.0_aarch64-linux/lib:/opt/arm/armpl-20.0.0_Generic-AArch64_RHEL-7_gcc_9.2.0_aarch64-linux/lib:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_arm_allinea_studio.py
+++ b/test/test_arm_allinea_studio.py
@@ -45,6 +45,7 @@ RUN apt-get update -y && \
         lmod \
         python \
         tar \
+        tcl \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/20-0/Ubuntu16.04/Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar && \
@@ -120,6 +121,7 @@ RUN apt-get update -y && \
         lmod \
         python \
         tar \
+        tcl \
         wget && \
     rm -rf /var/lib/apt/lists/*
 COPY Arm-Compiler-for-Linux_20.0_Ubuntu_16.04_aarch64.tar /var/tmp

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -37,7 +37,7 @@ class Test_boost(unittest.TestCase):
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.70.0
+r'''# Boost version 1.72.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,11 +46,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
+    rm -rf /var/tmp/boost_1_72_0.tar.bz2 /var/tmp/boost_1_72_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -59,7 +59,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.70.0
+r'''# Boost version 1.72.0
 RUN yum install -y \
         bzip2 \
         bzip2-devel \
@@ -68,11 +68,11 @@ RUN yum install -y \
         which \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
+    rm -rf /var/tmp/boost_1_72_0.tar.bz2 /var/tmp/boost_1_72_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
@@ -81,7 +81,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """python option"""
         b = boost(python=True)
         self.assertEqual(str(b),
-r'''# Boost version 1.70.0
+r'''# Boost version 1.72.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -90,11 +90,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.70.0/source/boost_1_70_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_70_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_70_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_70_0.tar.bz2 /var/tmp/boost_1_70_0
+    rm -rf /var/tmp/boost_1_72_0.tar.bz2 /var/tmp/boost_1_72_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -38,16 +38,16 @@ class Test_cmake(unittest.TestCase):
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.14.5
+r'''# CMake version 3.16.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.16.3-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
@@ -57,15 +57,15 @@ ENV PATH=/usr/local/bin:$PATH''')
         """Default cmake building block"""
         c = cmake()
         self.assertEqual(str(c),
-r'''# CMake version 3.14.5
+r'''# CMake version 3.16.3
 RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.16.3-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
@@ -75,16 +75,16 @@ ENV PATH=/usr/local/bin:$PATH''')
         """Accept EULA"""
         c = cmake(eula=True)
         self.assertEqual(str(c),
-r'''# CMake version 3.14.5
+r'''# CMake version 3.16.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
-    /bin/sh /var/tmp/cmake-3.14.5-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
-    rm -rf /var/tmp/cmake-3.14.5-Linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
+    rm -rf /var/tmp/cmake-3.16.3-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH''')
 
     @x86_64
@@ -116,6 +116,7 @@ ENV PATH=/usr/local/bin:$PATH''')
 r'''# CMake version 3.14.5
 RUN yum install -y \
         make \
+        openssl-devel \
         wget && \
     rm -rf /var/cache/yum/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && \
@@ -136,6 +137,7 @@ ENV PATH=/usr/local/bin:$PATH''')
 r'''# CMake version 3.14.5
 RUN yum install -y \
         make \
+        openssl-devel \
         wget && \
     rm -rf /var/cache/yum/*
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && \

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -37,18 +37,18 @@ class Test_gdrcopy(unittest.TestCase):
         """Default gdrcopy building block"""
         g = gdrcopy()
         self.assertEqual(str(g),
-r'''# GDRCOPY version 1.3
+r'''# GDRCOPY version 2.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v1.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v1.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/gdrcopy-1.3 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.0 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
     make PREFIX=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/v1.3.tar.gz /var/tmp/gdrcopy-1.3
+    rm -rf /var/tmp/v2.0.tar.gz /var/tmp/gdrcopy-2.0
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')
@@ -59,17 +59,17 @@ ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
         """Default gdrcopy building block"""
         g = gdrcopy()
         self.assertEqual(str(g),
-r'''# GDRCOPY version 1.3
+r'''# GDRCOPY version 2.0
 RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v1.3.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v1.3.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/gdrcopy-1.3 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.0 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
     make PREFIX=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/v1.3.tar.gz /var/tmp/gdrcopy-1.3
+    rm -rf /var/tmp/v2.0.tar.gz /var/tmp/gdrcopy-2.0
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -37,7 +37,7 @@ class Test_hdf5(unittest.TestCase):
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.5
+r'''# HDF5 version 1.10.6
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.5.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.6.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.6 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.10.5.tar.bz2 /var/tmp/hdf5-1.10.5
+    rm -rf /var/tmp/hdf5-1.10.6.tar.bz2 /var/tmp/hdf5-1.10.6
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')
@@ -62,7 +62,7 @@ ENV HDF5_DIR=/usr/local/hdf5 \
         """Default hdf5 building block"""
         h = hdf5()
         self.assertEqual(str(h),
-r'''# HDF5 version 1.10.5
+r'''# HDF5 version 1.10.6
 RUN yum install -y \
         bzip2 \
         file \
@@ -70,12 +70,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.5/src/hdf5-1.10.5.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.5.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.10.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.6/src/hdf5-1.10.6.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.10.6.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/hdf5-1.10.6 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.10.5.tar.bz2 /var/tmp/hdf5-1.10.5
+    rm -rf /var/tmp/hdf5-1.10.6.tar.bz2 /var/tmp/hdf5-1.10.6
 ENV HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/hdf5/bin:$PATH''')

--- a/test/test_hpcx.py
+++ b/test/test_hpcx.py
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64''')
 
     @x86_64
     @ubuntu18
@@ -68,12 +68,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu18.04-x86_64''')
 
     @x86_64
     @centos
@@ -89,12 +89,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-x86_64''')
 
     @x86_64
     @centos8
@@ -110,12 +110,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat8.0-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat8.0-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat8.0-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat8.0-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat8.0-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat8.0-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat8.0-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat8.0-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat8.0-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat8.0-x86_64''')
 
     @x86_64
     @ubuntu
@@ -132,12 +132,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 /opt/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64 /opt/hpcx && \
     echo "source /opt/hpcx/hpcx-mt-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64''')
 
     @aarch64
     @ubuntu
@@ -175,12 +175,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-ppc64le.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-ppc64le.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-ppc64le /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-ppc64le.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-ppc64le.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-ppc64le /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-ppc64le.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-redhat7.6-ppc64le''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-ppc64le.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-redhat7.6-ppc64le''')
 
     @x86_64
     @ubuntu18
@@ -230,7 +230,8 @@ ENV CPATH=/usr/local/hpcx/hcoll/include:/usr/local/hpcx/ompi/include:/usr/local/
     @docker
     def test_ldconfig_multi_thread(self):
         """ldconfig and multi_thread parameters"""
-        h = hpcx(hpcxinit=False, ldconfig=True, multi_thread=True)
+        h = hpcx(hpcxinit=False, ldconfig=True, mlnx_ofed='4.6-1.0.1.1',
+                 multi_thread=True)
         self.assertEqual(str(h),
 r'''# Mellanox HPC-X version 2.5.0
 RUN yum install -y \
@@ -288,9 +289,9 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://www.mellanox.com/downloads/hpc/hpc-x/v2.5/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.5.0-gcc-MLNX_OFED_LINUX-4.7-1.0.0.1-ubuntu16.04-x86_64''')

--- a/test/test_intel_mpi.py
+++ b/test/test_intel_mpi.py
@@ -44,7 +44,7 @@ class Test_intel_mpi(unittest.TestCase):
         """Default intel_mpi building block"""
         impi = intel_mpi(eula=True)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.4-070
+r'''# Intel MPI version 2019.6-088
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -58,7 +58,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.4-070 && \
+        intel-mpi-2019.6-088 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')
 
@@ -68,7 +68,7 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         """Default intel_mpi building block"""
         impi = intel_mpi(eula=True)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.4-070
+r'''# Intel MPI version 2019.6-088
 RUN yum install -y \
         man-db \
         openssh-clients && \
@@ -77,7 +77,7 @@ RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW
     yum install -y yum-utils && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mpi/setup/intel-mpi.repo && \
     yum install -y \
-        intel-mpi-2019.4-070 && \
+        intel-mpi-2019.6-088 && \
     rm -rf /var/cache/yum/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bashrc''')
 
@@ -111,7 +111,7 @@ RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivar
         """mpivars is False"""
         impi = intel_mpi(eula=True, mpivars=False)
         self.assertEqual(str(impi),
-r'''# Intel MPI version 2019.4-070
+r'''# Intel MPI version 2019.6-088
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -125,7 +125,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.4-070 && \
+        intel-mpi-2019.6-088 && \
     rm -rf /var/lib/apt/lists/*
 ENV FI_PROVIDER_PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfabric/lib/prov \
     I_MPI_ROOT=/opt/intel/compilers_and_libraries/linux/mpi \
@@ -139,7 +139,7 @@ ENV FI_PROVIDER_PATH=/opt/intel/compilers_and_libraries/linux/mpi/intel64/libfab
         impi = intel_mpi(eula=True)
         r = impi.runtime()
         self.assertEqual(r,
-r'''# Intel MPI version 2019.4-070
+r'''# Intel MPI version 2019.6-088
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -153,6 +153,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mpi all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mpi-2019.4-070 && \
+        intel-mpi-2019.6-088 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/compilers_and_libraries/linux/mpi/intel64/bin/mpivars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_intel_psxe_runtime.py
+++ b/test/test_intel_psxe_runtime.py
@@ -46,7 +46,7 @@ class Test_intel_psxe_runtime(unittest.TestCase):
         """eula"""
         psxe_rt = intel_psxe_runtime(eula=True)
         self.assertEqual(str(psxe_rt),
-r'''# Intel Parallel Studio XE runtime version 2019.5-281
+r'''# Intel Parallel Studio XE runtime version 2020.0-008
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -57,12 +57,12 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/2019 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2020.PUB | apt-key add - && \
+    echo "deb https://apt.repos.intel.com/2020 intel-psxe-runtime main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends aptitude && \
     aptitude install -y --without-recommends -o Aptitude::ProblemResolver::SolutionCost='100*canceled-actions,200*removals' \
-        intel-psxe-runtime=2019.5-281 && \
+        intel-psxe-runtime=2020.0-008 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/bash.bashrc''')
 

--- a/test/test_julia.py
+++ b/test/test_julia.py
@@ -38,16 +38,16 @@ class Test_julia(unittest.TestCase):
         """Default julia building block"""
         j = julia()
         self.assertEqual(str(j),
-r'''# Julia version 1.2.0
+r'''# Julia version 1.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://julialang-s3.julialang.org/bin/linux/x64/1.2/julia-1.2.0-linux-x86_64.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/julia-1.2.0-linux-x86_64.tar.gz -C /var/tmp -z && \
-    cp -a /var/tmp/julia-1.2.0 /usr/local/julia && \
-    rm -rf /var/tmp/julia-1.2.0-linux-x86_64.tar.gz /var/tmp/julia-1.2.0
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://julialang-s3.julialang.org/bin/linux/x64/1.3/julia-1.3.1-linux-x86_64.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/julia-1.3.1-linux-x86_64.tar.gz -C /var/tmp -z && \
+    cp -a /var/tmp/julia-1.3.1 /usr/local/julia && \
+    rm -rf /var/tmp/julia-1.3.1-linux-x86_64.tar.gz /var/tmp/julia-1.3.1
 ENV LD_LIBRARY_PATH=/usr/local/julia/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/julia/bin:$PATH''')
 
@@ -58,16 +58,16 @@ ENV LD_LIBRARY_PATH=/usr/local/julia/lib:$LD_LIBRARY_PATH \
         """aarch64"""
         j = julia()
         self.assertEqual(str(j),
-r'''# Julia version 1.2.0
+r'''# Julia version 1.3.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://julialang-s3.julialang.org/bin/linux/aarch64/1.2/julia-1.2.0-linux-aarch64.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/julia-1.2.0-linux-aarch64.tar.gz -C /var/tmp -z && \
-    cp -a /var/tmp/julia-1.2.0 /usr/local/julia && \
-    rm -rf /var/tmp/julia-1.2.0-linux-aarch64.tar.gz /var/tmp/julia-1.2.0
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://julialang-s3.julialang.org/bin/linux/aarch64/1.3/julia-1.3.1-linux-aarch64.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/julia-1.3.1-linux-aarch64.tar.gz -C /var/tmp -z && \
+    cp -a /var/tmp/julia-1.3.1 /usr/local/julia && \
+    rm -rf /var/tmp/julia-1.3.1-linux-aarch64.tar.gz /var/tmp/julia-1.3.1
 ENV LD_LIBRARY_PATH=/usr/local/julia/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/julia/bin:$PATH''')
 
@@ -77,7 +77,8 @@ ENV LD_LIBRARY_PATH=/usr/local/julia/lib:$LD_LIBRARY_PATH \
     def test_depot_history_packages(self):
         """depot, history, and packages options"""
         j = julia(depot='~/.julia-ngc', history='/tmp/julia_history.jl',
-                  packages=['CUDAnative', 'CuArrays'])
+                  packages=['CUDAnative', 'CuArrays'],
+                  version='1.2.0')
         self.assertEqual(str(j),
 r'''# Julia version 1.2.0
 RUN apt-get update -y && \
@@ -100,7 +101,7 @@ ENV JULIA_HISTORY=/tmp/julia_history.jl \
     @docker
     def test_cuda_ldconfig(self):
         """cuda and ldconfig options"""
-        j = julia(cuda=True, ldconfig=True)
+        j = julia(cuda=True, ldconfig=True, version='1.2.0')
         self.assertEqual(str(j),
 r'''# Julia version 1.2.0
 RUN apt-get update -y && \

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -44,7 +44,7 @@ class Test_mkl(unittest.TestCase):
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2019.4-070
+r'''# MKL version 2020.0-088
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -56,7 +56,7 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2019.4-070 && \
+        intel-mkl-64bit-2020.0-088 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
 
@@ -66,12 +66,12 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
         """Default mkl building block"""
         m = mkl(eula=True)
         self.assertEqual(str(m),
-r'''# MKL version 2019.4-070
+r'''# MKL version 2020.0-088
 RUN rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB && \
     yum install -y yum-utils && \
     yum-config-manager --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo && \
     yum install -y \
-        intel-mkl-64bit-2019.4-070 && \
+        intel-mkl-64bit-2020.0-088 && \
     rm -rf /var/cache/yum/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bashrc''')
 
@@ -101,7 +101,7 @@ RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')
     @docker
     def test_mklvars(self):
         """mklvars is False"""
-        m = mkl(eula=True, mklvars=False)
+        m = mkl(eula=True, mklvars=False, version='2019.4-070')
         self.assertEqual(str(m),
 r'''# MKL version 2019.4-070
 RUN apt-get update -y && \
@@ -129,7 +129,7 @@ ENV CPATH=/opt/intel/mkl/include:$CPATH \
         m = mkl(eula=True)
         r = m.runtime()
         self.assertEqual(r,
-r'''# MKL version 2019.4-070
+r'''# MKL version 2020.0-088
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -141,6 +141,6 @@ RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-P
     echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        intel-mkl-64bit-2019.4-070 && \
+        intel-mkl-64bit-2020.0-088 && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc''')

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -38,7 +38,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
+r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         findutils \
@@ -47,10 +47,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64''')
 
     @x86_64
     @ubuntu18
@@ -59,7 +59,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
+r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         findutils \
@@ -68,10 +68,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
+    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64''')
 
     @x86_64
     @centos
@@ -80,7 +80,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
+r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN yum install -y \
         findutils \
         libnl \
@@ -88,17 +88,17 @@ RUN yum install -y \
         numactl-libs \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64 -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*x86_64.rpm" -not -path "*UPSTREAM*" -exec rpm --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
+    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64 -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*x86_64.rpm" -not -path "*UPSTREAM*" -exec rpm --install {} + && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64''')
 
     @x86_64
     @ubuntu
     @docker
     def test_prefix_ubuntu(self):
         """Prefix option"""
-        mofed = mlnx_ofed(prefix='/opt/ofed')
+        mofed = mlnx_ofed(prefix='/opt/ofed', version='4.6-1.0.1.1')
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
@@ -121,7 +121,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     @docker
     def test_prefix_centos(self):
         """Prefix option"""
-        mofed = mlnx_ofed(prefix='/opt/ofed')
+        mofed = mlnx_ofed(prefix='/opt/ofed', version='4.6-1.0.1.1')
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
@@ -185,7 +185,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
     @docker
     def test_aarch64_centos(self):
         """aarch64"""
-        mofed = mlnx_ofed()
+        mofed = mlnx_ofed(version='4.6-1.0.1.1')
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
@@ -270,7 +270,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         mofed = mlnx_ofed()
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.6-1.0.1.1
+r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         findutils \
@@ -279,10 +279,10 @@ RUN apt-get update -y && \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
+    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
+    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64''')
 
     @x86_64
     @ubuntu
@@ -292,7 +292,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         mofed = mlnx_ofed(prefix='/opt/ofed')
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.6-1.0.1.1
+r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         findutils \

--- a/test/test_mpich.py
+++ b/test/test_mpich.py
@@ -38,7 +38,7 @@ class Test_mpich(unittest.TestCase):
         """Default mpich building block"""
         m = mpich()
         self.assertEqual(str(m),
-r'''# MPICH version 3.3.1
+r'''# MPICH version 3.3.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         file \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.2 &&   ./configure --prefix=/usr/local/mpich && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mpich-3.3.1.tar.gz /var/tmp/mpich-3.3.1
+    rm -rf /var/tmp/mpich-3.3.2.tar.gz /var/tmp/mpich-3.3.2
 ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mpich/bin:$PATH''')
 
@@ -64,7 +64,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
         """Default mpich building block"""
         m = mpich()
         self.assertEqual(str(m),
-r'''# MPICH version 3.3.1
+r'''# MPICH version 3.3.2
 RUN yum install -y \
         file \
         gzip \
@@ -74,12 +74,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.1/mpich-3.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mpich-3.3.1 &&   ./configure --prefix=/usr/local/mpich && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.mpich.org/static/downloads/3.3.2/mpich-3.3.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mpich-3.3.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mpich-3.3.2 &&   ./configure --prefix=/usr/local/mpich && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mpich-3.3.1.tar.gz /var/tmp/mpich-3.3.1
+    rm -rf /var/tmp/mpich-3.3.2.tar.gz /var/tmp/mpich-3.3.2
 ENV LD_LIBRARY_PATH=/usr/local/mpich/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mpich/bin:$PATH''')
 

--- a/test/test_mvapich2.py
+++ b/test/test_mvapich2.py
@@ -38,7 +38,7 @@ class Test_mvapich2(unittest.TestCase):
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3.1
+r'''# MVAPICH2 version 2.3.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -49,12 +49,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3.1 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
+    rm -rf /var/tmp/mvapich2-2.3.3.tar.gz /var/tmp/mvapich2-2.3.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -70,7 +70,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         tc.FC = 'pgfortran'
         mv2 = mvapich2(toolchain=tc, cuda=True)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3.1
+r'''# MVAPICH2 version 2.3.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -81,12 +81,12 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3.1 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda --enable-fast=O1 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.3 &&  CC=pgcc CFLAGS=-ta=tesla:nordc CPPFLAGS='-D__x86_64 -D__align__\(n\)=__attribute__\(\(aligned\(n\)\)\) -D__location__\(a\)=__annotate__\(a\) -DCUDARTAPI=' CXX=pgc++ F77=pgfortran FC=pgfortran LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda=basic --with-cuda=/usr/local/cuda --enable-fast=O1 && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
+    rm -rf /var/tmp/mvapich2-2.3.3.tar.gz /var/tmp/mvapich2-2.3.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')
@@ -125,7 +125,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Disable CUDA"""
         mv2 = mvapich2(cuda=False)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3.1
+r'''# MVAPICH2 version 2.3.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         byacc \
@@ -134,12 +134,12 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3.1 &&   ./configure --prefix=/usr/local/mvapich2 --disable-cuda --disable-mcast && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.3 &&   ./configure --prefix=/usr/local/mvapich2 --disable-cuda --disable-mcast && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
+    rm -rf /var/tmp/mvapich2-2.3.3.tar.gz /var/tmp/mvapich2-2.3.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH''')
 
@@ -149,7 +149,7 @@ ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
         """Default mvapich2 building block"""
         mv2 = mvapich2()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2 version 2.3.1
+r'''# MVAPICH2 version 2.3.3
 RUN yum install -y \
         byacc \
         file \
@@ -159,12 +159,12 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN ln -s /usr/local/cuda/lib64/stubs/libnvidia-ml.so /usr/local/cuda/lib64/stubs/libnvidia-ml.so.1 && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/mvapich2-2.3.1 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/mvapich2-2.3.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/mvapich2-2.3.3 &&  LD_LIBRARY_PATH='/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH' ./configure --prefix=/usr/local/mvapich2 --disable-mcast --enable-cuda --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/mvapich2-2.3.1.tar.gz /var/tmp/mvapich2-2.3.1
+    rm -rf /var/tmp/mvapich2-2.3.3.tar.gz /var/tmp/mvapich2-2.3.3
 ENV LD_LIBRARY_PATH=/usr/local/mvapich2/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/mvapich2/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml -lcuda"''')

--- a/test/test_mvapich2_gdr.py
+++ b/test/test_mvapich2_gdr.py
@@ -37,7 +37,7 @@ class Test_mvapich2_gdr(unittest.TestCase):
         """Default mvapich2_gdr building block"""
         mv2 = mvapich2_gdr()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2-GDR version 2.3.1
+r'''# MVAPICH2-GDR version 2.3.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         cpio \
@@ -48,13 +48,13 @@ RUN apt-get update -y && \
         rpm2cpio \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.1/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm && \
-    cd / && rpm2cpio /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm | cpio -id && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.3/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm && \
+    cd / && rpm2cpio /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm | cpio -id && \
     (test -f /usr/bin/bash || ln -s /bin/bash /usr/bin/bash) && \
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
-    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm
-ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
-    PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
+    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @centos
@@ -63,7 +63,7 @@ ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mp
         """Default mvapich2_gdr building block"""
         mv2 = mvapich2_gdr()
         self.assertEqual(str(mv2),
-r'''# MVAPICH2-GDR version 2.3.1
+r'''# MVAPICH2-GDR version 2.3.3
 RUN yum install -y \
         libgfortran \
         libpciaccess \
@@ -71,13 +71,13 @@ RUN yum install -y \
         openssh-clients \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.1/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm && \
-    rpm --install --nodeps /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.3/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm && \
+    rpm --install --nodeps /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm && \
     (test -f /usr/bin/bash || ln -s /bin/bash /usr/bin/bash) && \
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
-    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm
-ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
-    PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
+    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @ubuntu
@@ -86,7 +86,7 @@ ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mp
         """ldconfig option"""
         mv2 = mvapich2_gdr(ldconfig=True)
         self.assertEqual(str(mv2),
-r'''# MVAPICH2-GDR version 2.3.1
+r'''# MVAPICH2-GDR version 2.3.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         cpio \
@@ -97,13 +97,13 @@ RUN apt-get update -y && \
         rpm2cpio \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.1/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm && \
-    cd / && rpm2cpio /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm | cpio -id && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mvapich.cse.ohio-state.edu/download/mvapich/gdr/2.3.3/mofed4.5/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm && \
+    cd / && rpm2cpio /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm | cpio -id && \
     (test -f /usr/bin/bash || ln -s /bin/bash /usr/bin/bash) && \
     ln -s /usr/local/cuda/lib64/stubs/nvidia-ml.so /usr/local/cuda/lib64/stubs/nvidia-ml.so.1 && \
-    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.1-1.el7.x86_64.rpm && \
-    echo "/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
-ENV PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
+    rm -rf /var/tmp/mvapich2-gdr-mcast.cuda9.2.mofed4.5.gnu4.8.5-2.3.3-2.el7.x86_64.rpm && \
+    echo "/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
+ENV PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH \
     PROFILE_POSTLIB="-L/usr/local/cuda/lib64/stubs -lnvidia-ml"''')
 
     @ubuntu
@@ -112,7 +112,7 @@ ENV PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8
         """PGI compiler and different Mellanox OFED version"""
         mv2 = mvapich2_gdr(pgi=True, gnu=False, cuda_version='9.2',
                            mlnx_ofed_version='3.4', pgi_version='17.10',
-                           version='2.3')
+                           release='1', version='2.3')
         self.assertEqual(str(mv2),
 r'''# MVAPICH2-GDR version 2.3
 RUN apt-get update -y && \
@@ -174,9 +174,9 @@ RUN apt-get update -y && \
         libpciaccess0 \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5
-ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
-    PATH=/opt/mvapich2/gdr/2.3.1/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH''')
+COPY --from=0 /opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5 /opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5
+ENV LD_LIBRARY_PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/lib64:$LD_LIBRARY_PATH \
+    PATH=/opt/mvapich2/gdr/2.3.3/mcast/no-openacc/cuda9.2/mofed4.5/mpirun/gnu4.8.5/bin:$PATH''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -37,8 +37,8 @@ class Test_netcdf(unittest.TestCase):
         """Default netcdf building block"""
         n = netcdf()
         self.assertEqual(str(n),
-r'''# NetCDF version 4.7.0, NetCDF C++ version 4.3.0, NetCDF Fortran
-# version 4.4.5
+r'''# NetCDF version 4.7.3, NetCDF C++ version 4.3.1, NetCDF Fortran
+# version 4.5.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -49,24 +49,24 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-c/archive/v4.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-c-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-c/archive/v4.7.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.7.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-c-4.7.3 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.7.0.tar.gz /var/tmp/netcdf-c-4.7.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-cxx4/archive/v4.3.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.3.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    rm -rf /var/tmp/v4.7.3.tar.gz /var/tmp/netcdf-c-4.7.3 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-cxx4/archive/v4.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-cxx4-4.3.1 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.3.0.tar.gz /var/tmp/netcdf-cxx4-4.3.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-fortran/archive/v4.4.5.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.4.5.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-fortran-4.4.5 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    rm -rf /var/tmp/v4.3.1.tar.gz /var/tmp/netcdf-cxx4-4.3.1 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-fortran/archive/v4.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-fortran-4.5.2 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.4.5.tar.gz /var/tmp/netcdf-fortran-4.4.5
+    rm -rf /var/tmp/v4.5.2.tar.gz /var/tmp/netcdf-fortran-4.5.2
 ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/netcdf/bin:$PATH''')
 
@@ -76,8 +76,8 @@ ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
         """Default netcdf building block"""
         n = netcdf()
         self.assertEqual(str(n),
-r'''# NetCDF version 4.7.0, NetCDF C++ version 4.3.0, NetCDF Fortran
-# version 4.4.5
+r'''# NetCDF version 4.7.3, NetCDF C++ version 4.3.1, NetCDF Fortran
+# version 4.5.2
 RUN yum install -y \
         ca-certificates \
         file \
@@ -87,24 +87,24 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-c/archive/v4.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-c-4.7.0 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-c/archive/v4.7.3.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.7.3.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-c-4.7.3 &&  CPPFLAGS=-I/usr/local/hdf5/include LDFLAGS=-L/usr/local/hdf5/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.7.0.tar.gz /var/tmp/netcdf-c-4.7.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-cxx4/archive/v4.3.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.3.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-cxx4-4.3.0 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    rm -rf /var/tmp/v4.7.3.tar.gz /var/tmp/netcdf-c-4.7.3 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-cxx4/archive/v4.3.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.3.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-cxx4-4.3.1 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.3.0.tar.gz /var/tmp/netcdf-cxx4-4.3.0 && \
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-fortran/archive/v4.4.5.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.4.5.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/netcdf-fortran-4.4.5 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
+    rm -rf /var/tmp/v4.3.1.tar.gz /var/tmp/netcdf-cxx4-4.3.1 && \
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Unidata/netcdf-fortran/archive/v4.5.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v4.5.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/netcdf-fortran-4.5.2 &&  CPPFLAGS='-I/usr/local/netcdf/include -I/usr/local/hdf5/include' LD_LIBRARY_PATH='/usr/local/netcdf/lib:$LD_LIBRARY_PATH' LDFLAGS=-L/usr/local/netcdf/lib ./configure --prefix=/usr/local/netcdf && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/v4.4.5.tar.gz /var/tmp/netcdf-fortran-4.4.5
+    rm -rf /var/tmp/v4.5.2.tar.gz /var/tmp/netcdf-fortran-4.5.2
 ENV LD_LIBRARY_PATH=/usr/local/netcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/netcdf/bin:$PATH''')
 

--- a/test/test_openblas.py
+++ b/test/test_openblas.py
@@ -40,7 +40,7 @@ class Test_openblas(unittest.TestCase):
         tc = toolchain(CC='gcc', FC='gfortran')
         o = openblas(toolchain=tc)
         self.assertEqual(str(o),
-r'''# OpenBLAS version 0.3.6
+r'''# OpenBLAS version 0.3.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
@@ -48,11 +48,11 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.6.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.6.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/OpenBLAS-0.3.6 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/xianyi/OpenBLAS/archive/v0.3.7.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v0.3.7.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/OpenBLAS-0.3.7 && make CC=gcc FC=gfortran USE_OPENMP=1 && \
     make install PREFIX=/usr/local/openblas && \
-    rm -rf /var/tmp/v0.3.6.tar.gz /var/tmp/OpenBLAS-0.3.6
+    rm -rf /var/tmp/v0.3.7.tar.gz /var/tmp/OpenBLAS-0.3.7
 ENV LD_LIBRARY_PATH=/usr/local/openblas/lib:$LD_LIBRARY_PATH''')
 
     @x86_64

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -37,7 +37,7 @@ class Test_openmpi(unittest.TestCase):
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 4.0.1
+r'''# OpenMPI version 4.0.3rc3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -50,12 +50,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3rc3.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3rc3.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.3rc3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1
+    rm -rf /var/tmp/openmpi-4.0.3rc3.tar.bz2 /var/tmp/openmpi-4.0.3rc3
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
@@ -65,7 +65,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 4.0.1
+r'''# OpenMPI version 4.0.3rc3
 RUN yum install -y \
         bzip2 \
         file \
@@ -77,12 +77,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.1.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.1.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.1 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3rc3.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3rc3.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.3rc3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.1.tar.bz2 /var/tmp/openmpi-4.0.1
+    rm -rf /var/tmp/openmpi-4.0.3rc3.tar.bz2 /var/tmp/openmpi-4.0.3rc3
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 

--- a/test/test_pnetcdf.py
+++ b/test/test_pnetcdf.py
@@ -37,7 +37,7 @@ class Test_pnetcdf(unittest.TestCase):
         """Default pnetcdf building block"""
         p = pnetcdf()
         self.assertEqual(str(p),
-r'''# PnetCDF version 1.11.2
+r'''# PnetCDF version 1.12.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         m4 \
@@ -45,13 +45,13 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://parallel-netcdf.github.io/Release/pnetcdf-1.11.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/pnetcdf-1.11.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/pnetcdf-1.11.2 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
-    sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/pnetcdf-1.11.2/libtool && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://parallel-netcdf.github.io/Release/pnetcdf-1.12.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/pnetcdf-1.12.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/pnetcdf-1.12.1 &&  CC=mpicc CXX=mpicxx F77=mpif77 F90=mpif90 FC=mpifort ./configure --prefix=/usr/local/pnetcdf --enable-shared && \
+    sed -i -e 's#pic_flag=""#pic_flag=" -fpic -DPIC"#' -e 's#wl=""#wl="-Wl,"#' /var/tmp/pnetcdf-1.12.1/libtool && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/pnetcdf-1.11.2.tar.gz /var/tmp/pnetcdf-1.11.2
+    rm -rf /var/tmp/pnetcdf-1.12.1.tar.gz /var/tmp/pnetcdf-1.12.1
 ENV LD_LIBRARY_PATH=/usr/local/pnetcdf/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/pnetcdf/bin:$PATH''')
 

--- a/test/test_slurm_pmi2.py
+++ b/test/test_slurm_pmi2.py
@@ -38,7 +38,7 @@ class Test_slurm_pmi2(unittest.TestCase):
         """Default slurm_pmi2 building block"""
         p = slurm_pmi2()
         self.assertEqual(str(p),
-r'''# SLURM PMI2 version 19.05.4
+r'''# SLURM PMI2 version 19.05.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -48,11 +48,11 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.4.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.4.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/slurm-19.05.4 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.5.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.5.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-19.05.5 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
     make -C contribs/pmi2 install && \
-    rm -rf /var/tmp/slurm-19.05.4.tar.bz2 /var/tmp/slurm-19.05.4''')
+    rm -rf /var/tmp/slurm-19.05.5.tar.bz2 /var/tmp/slurm-19.05.5''')
 
     @x86_64
     @ubuntu

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -38,7 +38,7 @@ class Test_ucx(unittest.TestCase):
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.5.2
+r'''# UCX version 1.7.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -47,12 +47,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
+    rm -rf /var/tmp/ucx-1.7.0.tar.gz /var/tmp/ucx-1.7.0
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -63,7 +63,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.5.2
+r'''# UCX version 1.7.0
 RUN yum install -y \
         binutils-devel \
         file \
@@ -71,12 +71,12 @@ RUN yum install -y \
         numactl-devel \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
+    rm -rf /var/tmp/ucx-1.7.0.tar.gz /var/tmp/ucx-1.7.0
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -88,7 +88,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         u = ucx(cuda='/cuda', gdrcopy='/gdrcopy', knem='/knem', ofed='/ofed',
                 xpmem='/xpmem')
         self.assertEqual(str(u),
-r'''# UCX version 1.5.2
+r'''# UCX version 1.7.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -97,12 +97,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-rdmacm=/ofed --with-verbs=/ofed --with-xpmem=/xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-rdmacm=/ofed --with-verbs=/ofed --with-xpmem=/xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
+    rm -rf /var/tmp/ucx-1.7.0.tar.gz /var/tmp/ucx-1.7.0
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -113,7 +113,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with True values"""
         u = ucx(cuda=True, gdrcopy=True, knem=True, ofed=True, xpmem=True)
         self.assertEqual(str(u),
-r'''# UCX version 1.5.2
+r'''# UCX version 1.7.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -122,12 +122,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-rdmacm --with-verbs --with-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-rdmacm --with-verbs --with-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
+    rm -rf /var/tmp/ucx-1.7.0.tar.gz /var/tmp/ucx-1.7.0
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -138,7 +138,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with False values"""
         u = ucx(cuda=False, gdrcopy=False, knem=False, ofed=False, xpmem=False)
         self.assertEqual(str(u),
-r'''# UCX version 1.5.2
+r'''# UCX version 1.7.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -147,12 +147,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.5.2/ucx-1.5.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.5.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.5.2 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --without-cuda --without-gdrcopy --without-knem --without-rdmacm --without-verbs --without-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --without-cuda --without-gdrcopy --without-knem --without-rdmacm --without-verbs --without-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.5.2.tar.gz /var/tmp/ucx-1.5.2
+    rm -rf /var/tmp/ucx-1.7.0.tar.gz /var/tmp/ucx-1.7.0
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 


### PR DESCRIPTION
Bump default component versions:

- arm_allinea_studio: 19.3 -> 20.0
- boost: 1.70.0 -> 1.72.0
- cmake: 3.14.5 -> 3.16.3
- gdrcopy: 1.3 -> 2.0
- hdf5: 1.10.5 -> 1.10.6
- intel_mpi: 2019.4-070 -> 2019.6-088
- intel_psxe_runtime: 2019.5-281 -> 2020.0-008
- julia: 1.2.0 -> 1.3.1
- mkl: 2019.4-070 -> 2020.0-088
- mlnx_ofed: 4.6-1.0.1.1 -> 4.7-3.2.9.0
- mpich: 3.3.1 -> 3.3.2
- mvapich2: 2.3.1 -> 2.3.3
- mvapich2_gdr: 2.3.1 -> 2.3.3
- netcdf: 4.7.0 -> 4.7.3
- openblas: 0.3.6 -> 0.3.7
- openmpi: 4.0.1 -> 4.0.3rc3
- pnetcdf: 1.11.2 -> 1.12.1
- slurm_pmi2: 19.05.4 -> 19.05.5
- ucx: 1.5.2 -> 1.7.0