### PR TITLE
Fix versioned GNU compilers on CentOS 8

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2968,9 +2968,17 @@ is specified.  The default value is an empty list.
 PowerTools repository.  The default is False.  This parameter is
 ignored if the Linux distribution is not RHEL-based.
 
+- __release_stream__: Boolean flag to specify whether to enable the
+[CentOS release
+- __stream](https__://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+repository.  The default is False.  This parameter is only
+recognized if the Linux distribution is RHEL-based and the version
+is 8.x.
+
 - __scl__: Boolean flag to specify whether to enable the Software
 Collections (SCL) repository.  The default is False.  This
-parameter is ignored if the Linux distribution is not RHEL-based.
+parameter is only recognized if the Linux distribution is
+RHEL-based and the version is 7.x.
 
 - __yum__: A list of RPM packages to install.  The default value is an
 empty list.
@@ -3874,17 +3882,24 @@ empty list.
 
 - __powertools__: Boolean flag to specify whether to enable the
 PowerTools repository.  The default is False.  This parameter is
-only recognized if the CentOS version is 8.x.
+only recognized if the distribution version is 8.x.
+
+- __release_stream__: Boolean flag to specify whether to enable the
+[CentOS release
+- __stream](https__://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+repository.  The default is False.  This parameter is only
+recognized if the distribution version is 8.x.
 
 - __repositories__: A list of yum repositories to add.  The default is
 an empty list.
 
 - __scl__: - Boolean flag to specify whether to enable the Software
-Collections (SCL) repository.  The default is False.
+Collections (SCL) repository.  The default is False.  This
+parameter is only recognized if the distribution version is 7.x.
 
 - __yum4__: Boolean flag to specify whether `yum4` should be used
 instead of `yum`.  The default is False.  This parameter is only
-recognized if the CentOS version is 7.x.
+recognized if the distribution version is 7.x.
 
 __Examples__
 

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2968,9 +2968,7 @@ is specified.  The default value is an empty list.
 PowerTools repository.  The default is False.  This parameter is
 ignored if the Linux distribution is not RHEL-based.
 
-- __release_stream__: Boolean flag to specify whether to enable the
-[CentOS release
-- __stream](https__://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+- __release_stream__: Boolean flag to specify whether to enable the [CentOS release stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
 repository.  The default is False.  This parameter is only
 recognized if the Linux distribution is RHEL-based and the version
 is 8.x.
@@ -3884,9 +3882,7 @@ empty list.
 PowerTools repository.  The default is False.  This parameter is
 only recognized if the distribution version is 8.x.
 
-- __release_stream__: Boolean flag to specify whether to enable the
-[CentOS release
-- __stream](https__://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+- __release_stream__: Boolean flag to specify whether to enable the [CentOS release stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
 repository.  The default is False.  This parameter is only
 recognized if the distribution version is 8.x.
 

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -82,9 +82,17 @@ class packages(bb_base):
     PowerTools repository.  The default is False.  This parameter is
     ignored if the Linux distribution is not RHEL-based.
 
+    release_stream: Boolean flag to specify whether to enable the
+    [CentOS release
+    stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+    repository.  The default is False.  This parameter is only
+    recognized if the Linux distribution is RHEL-based and the version
+    is 8.x.
+
     scl: Boolean flag to specify whether to enable the Software
     Collections (SCL) repository.  The default is False.  This
-    parameter is ignored if the Linux distribution is not RHEL-based.
+    parameter is only recognized if the Linux distribution is
+    RHEL-based and the version is 7.x.
 
     yum: A list of RPM packages to install.  The default value is an
     empty list.
@@ -132,6 +140,7 @@ class packages(bb_base):
         self.__epel = kwargs.get('epel', False)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__powertools = kwargs.get('powertools', False)
+        self.__release_stream = kwargs.get('release_stream', False)
         self.__scl = kwargs.get('scl', False)
         self.__yum = kwargs.get('yum', [])
         self.__yum4 = kwargs.get('yum4', False)
@@ -170,6 +179,7 @@ class packages(bb_base):
                         keys=self.__yum_keys,
                         ospackages=ospackages,
                         powertools=self.__powertools,
+                        release_stream=self.__release_stream,
                         scl=self.__scl,
                         repositories=self.__yum_repositories,
                         yum4=self.__yum4)

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -82,9 +82,7 @@ class packages(bb_base):
     PowerTools repository.  The default is False.  This parameter is
     ignored if the Linux distribution is not RHEL-based.
 
-    release_stream: Boolean flag to specify whether to enable the
-    [CentOS release
-    stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+    release_stream: Boolean flag to specify whether to enable the [CentOS release stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
     repository.  The default is False.  This parameter is only
     recognized if the Linux distribution is RHEL-based and the version
     is 8.x.

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -67,9 +67,7 @@ class yum(bb_base):
     PowerTools repository.  The default is False.  This parameter is
     only recognized if the distribution version is 8.x.
 
-    release_stream: Boolean flag to specify whether to enable the
-    [CentOS release
-    stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+    release_stream: Boolean flag to specify whether to enable the [CentOS release stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
     repository.  The default is False.  This parameter is only
     recognized if the distribution version is 8.x.
 

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -65,17 +65,24 @@ class yum(bb_base):
 
     powertools: Boolean flag to specify whether to enable the
     PowerTools repository.  The default is False.  This parameter is
-    only recognized if the CentOS version is 8.x.
+    only recognized if the distribution version is 8.x.
+
+    release_stream: Boolean flag to specify whether to enable the
+    [CentOS release
+    stream](https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream)
+    repository.  The default is False.  This parameter is only
+    recognized if the distribution version is 8.x.
 
     repositories: A list of yum repositories to add.  The default is
     an empty list.
 
     scl: - Boolean flag to specify whether to enable the Software
-    Collections (SCL) repository.  The default is False.
+    Collections (SCL) repository.  The default is False.  This
+    parameter is only recognized if the distribution version is 7.x.
 
     yum4: Boolean flag to specify whether `yum4` should be used
     instead of `yum`.  The default is False.  This parameter is only
-    recognized if the CentOS version is 7.x.
+    recognized if the distribution version is 7.x.
 
     # Examples
 
@@ -100,6 +107,7 @@ class yum(bb_base):
         self.__keys = kwargs.get('keys', [])
         self.ospackages = kwargs.get('ospackages', [])
         self.__powertools = kwargs.get('powertools', False)
+        self.__release_stream = kwargs.get('release_stream', False)
         self.__repositories = kwargs.get('repositories', [])
         self.__scl = kwargs.get('scl', False)
         self.__yum4 = kwargs.get('yum4', False)
@@ -171,7 +179,14 @@ class yum(bb_base):
                 self.__commands.append('yum install -y dnf-utils')
             self.__commands.append('yum-config-manager --set-enabled PowerTools')
 
-        if self.__scl:
+        if (self.__release_stream and
+            hpccm.config.g_linux_version >= StrictVersion('8.0')):
+            # This needs to be a discrete, preliminary step so that
+            # packages from release stream are available to be installed.
+            self.__commands.append('yum install -y centos-release-stream')
+
+        if (self.__scl and
+            hpccm.config.g_linux_version < StrictVersion('8.0')):
             # This needs to be a discrete, preliminary step so that
             # packages from SCL are available to be installed.
             self.__commands.append('yum install -y centos-release-scl')

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import centos, centos8, docker, ubuntu
 
 from hpccm.building_blocks.gnu import gnu
 
@@ -74,14 +74,14 @@ RUN apt-get update -y && \
         gcc-7 \
         gfortran-7 && \
     rm -rf /var/lib/apt/lists/*
-RUN update-alternatives --install /usr/bin/gcc gcc $(which gcc-7) 30 && \
-    update-alternatives --install /usr/bin/g++ g++ $(which g++-7) 30 && \
-    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-7) 30 && \
-    update-alternatives --install /usr/bin/gcov gcov $(which gcov-7) 30''')
+RUN update-alternatives --install /usr/bin/g++ g++ $(which g++-7) 30 && \
+    update-alternatives --install /usr/bin/gcc gcc $(which gcc-7) 30 && \
+    update-alternatives --install /usr/bin/gcov gcov $(which gcov-7) 30 && \
+    update-alternatives --install /usr/bin/gfortran gfortran $(which gfortran-7) 30''')
 
     @centos
     @docker
-    def test_version_centos(self):
+    def test_version_centos7(self):
         """GNU compiler version"""
         g = gnu(extra_repository=True, version='7')
         self.assertEqual(str(g),
@@ -92,7 +92,28 @@ RUN yum install -y centos-release-scl && \
         devtoolset-7-gcc-c++ \
         devtoolset-7-gcc-gfortran && \
     rm -rf /var/cache/yum/*
-ENV PATH=/opt/rh/devtoolset-7/root/usr/bin:$PATH''')
+RUN update-alternatives --install /usr/bin/g++ g++ /opt/rh/devtoolset-7/root/usr/bin/g++ 30 && \
+    update-alternatives --install /usr/bin/gcc gcc /opt/rh/devtoolset-7/root/usr/bin/gcc 30 && \
+    update-alternatives --install /usr/bin/gcov gcov /opt/rh/devtoolset-7/root/usr/bin/gcov 30 && \
+    update-alternatives --install /usr/bin/gfortran gfortran /opt/rh/devtoolset-7/root/usr/bin/gfortran 30''')
+
+    @centos8
+    @docker
+    def test_version_centos8(self):
+        """GNU compiler version"""
+        g = gnu(version='9')
+        self.assertEqual(str(g),
+r'''# GNU compiler
+RUN yum install -y centos-release-stream && \
+    yum install -y \
+        gcc-toolset-9-gcc \
+        gcc-toolset-9-gcc-c++ \
+        gcc-toolset-9-gcc-gfortran && \
+    rm -rf /var/cache/yum/*
+RUN update-alternatives --install /usr/bin/g++ g++ /opt/rh/gcc-toolset-9/root/usr/bin/g++ 30 && \
+    update-alternatives --install /usr/bin/gcc gcc /opt/rh/gcc-toolset-9/root/usr/bin/gcc 30 && \
+    update-alternatives --install /usr/bin/gcov gcov /opt/rh/gcc-toolset-9/root/usr/bin/gcov 30 && \
+    update-alternatives --install /usr/bin/gfortran gfortran /opt/rh/gcc-toolset-9/root/usr/bin/gfortran 30''')
 
     @ubuntu
     @docker


### PR DESCRIPTION
## Pull Request Description

Resolve CentOS 8 issue reported in #228.

Also adds options to enable the CentOS Release Stream.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
