### PR TITLE
Add get_format() helper

### DIFF
--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -8,6 +8,12 @@ Return the architecture string for the currently configured CPU
 architecture, e.g., `aarch64`, `ppc64le`, or `x86_64`.
 
 
+## get_format
+```python
+get_format()
+```
+Return the container format string for the currently configured
+format, e.g., `bash`, `docker`, or `singularity`.
 ## set_container_format
 ```python
 set_container_format(ctype)

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -58,8 +58,22 @@ def get_cpu_architecture():
   else: # pragma: no cover
     raise RuntimeError('Unrecognized processor architecture')
 
-def set_container_format(ctype):
+def get_format():
+  """Return the container format string for the currently configured
+  format, e.g., `bash`, `docker`, or `singularity`."""
 
+  this = sys.modules[__name__]
+
+  if this.g_ctype == container_type.BASH:
+    return 'bash'
+  elif this.g_ctype == container_type.DOCKER:
+    return 'docker'
+  elif this.g_ctype == container_type.SINGULARITY:
+    return 'singularity'
+  else: # pragma: no cover
+    raise RuntimeError('Unrecognized format')
+
+def set_container_format(ctype):
   """Set the container format
 
   # Arguments
@@ -71,6 +85,7 @@ def set_container_format(ctype):
 
   RuntimeError: invalid container type argument
   """
+
   this = sys.modules[__name__]
   if ctype == 'docker':
     this.g_ctype = container_type.DOCKER

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -23,7 +23,7 @@ from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import docker, singularity
+from helpers import bash, docker, singularity
 
 import hpccm.config
 
@@ -175,3 +175,18 @@ class Test_config(unittest.TestCase):
         """Set CPU architecture to invalid value"""
         hpccm.config.set_cpu_architecture('invalid')
         self.assertEqual(hpccm.config.g_cpu_arch, hpccm.cpu_arch.X86_64)
+
+    @bash
+    def test_get_format_bash(self):
+        """Get container format"""
+        self.assertEqual(hpccm.config.get_format(), 'bash')
+
+    @docker
+    def test_get_format_docker(self):
+        """Get container format"""
+        self.assertEqual(hpccm.config.get_format(), 'docker')
+
+    @singularity
+    def test_get_format_singularity(self):
+        """Get container format"""
+        self.assertEqual(hpccm.config.get_format(), 'singularity')


### PR DESCRIPTION
## Pull Request Description

Add get_format() helper to query the container output format more easily in recipes.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
