### PR TITLE
Use Mellanox repositories instead of tarballs

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2238,10 +2238,9 @@ OFED. Please see the corresponding [`mlnx_ofed`](#mlnx_ofed)
 parameter for more information.
 
 - __mlnx_versions__: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
-versions to install.  The default values are `3.3-1.0.4.0`,
-`3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
-`4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and
-`4.7-3.2.9.0`.
+versions to install.  The default values are `3.4-2.0.0.0`,
+`4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`, `4.3-1.0.1.0`,
+`4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and `4.7-3.2.9.0`.
 
 - __ospackages__: List of OS packages to install prior to installing
 OFED.  For Ubuntu, the default values are `libnl-3-200`,

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
 import posixpath
 
 import hpccm.config
@@ -53,10 +54,9 @@ class multi_ofed(bb_base):
     parameter for more information.
 
     mlnx_versions: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
-    versions to install.  The default values are `3.3-1.0.4.0`,
-    `3.4-2.0.0.0`, `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`,
-    `4.3-1.0.1.0`, `4.4-2.0.7.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and
-    `4.7-3.2.9.0`.
+    versions to install.  The default values are `3.4-2.0.0.0`,
+    `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`, `4.3-1.0.1.0`,
+    `4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and `4.7-3.2.9.0`.
 
     ospackages: List of OS packages to install prior to installing
     OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -89,11 +89,11 @@ class multi_ofed(bb_base):
         self.__mlnx_oslabel = kwargs.get('mlnx_oslabel', '')
         self.__mlnx_packages = kwargs.get('mlnx_packages', [])
         self.__mlnx_versions = kwargs.get('mlnx_versions',
-                                          ['3.3-1.0.4.0', '3.4-2.0.0.0',
-                                           '4.0-2.0.0.1', '4.1-1.0.2.0',
-                                           '4.2-1.2.0.0', '4.3-1.0.1.0',
-                                           '4.4-2.0.7.0', '4.5-1.0.1.0',
-                                           '4.6-1.0.1.1', '4.7-3.2.9.0'])
+                                          ['3.4-2.0.0.0', '4.0-2.0.0.1',
+                                           '4.1-1.0.2.0', '4.2-1.2.0.0',
+                                           '4.3-1.0.1.0', '4.4-1.0.0.0',
+                                           '4.5-1.0.1.0', '4.6-1.0.1.1',
+                                           '4.7-3.2.9.0'])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/ofed')
         self.__symlink = kwargs.get('symlink', False)
@@ -113,7 +113,10 @@ class multi_ofed(bb_base):
                                      'libnuma1']
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
-                self.__ospackages = ['libnl', 'libnl3', 'numactl-libs']
+                if hpccm.config.g_linux_version >= StrictVersion('8.0'):
+                    self.__ospackages = ['libnl3', 'numactl-libs']
+                else:
+                    self.__ospackages = ['libnl', 'libnl3', 'numactl-libs']
         else: # pragma: no cover
             raise RuntimeError('Unknown Linux distribution')
 

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -134,6 +134,7 @@ class packages(bb_base):
         self.__download = kwargs.get('download', False)
         self.__download_directory = kwargs.get('download_directory',
                                                '/var/tmp/packages_download')
+        self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__epel = kwargs.get('epel', False)
         self.__ospackages = kwargs.get('ospackages', [])
@@ -159,6 +160,7 @@ class packages(bb_base):
             self += apt_get(aptitude=self.__aptitude,
                             download=self.__download,
                             download_directory=self.__download_directory,
+                            extra_opts=self.__extra_opts,
                             extract=self.__extract,
                             keys=self.__apt_keys,
                             ospackages=ospackages,
@@ -172,6 +174,7 @@ class packages(bb_base):
 
             self += yum(download=self.__download,
                         download_directory=self.__download_directory,
+                        extra_opts=self.__extra_opts,
                         extract=self.__extract,
                         epel=self.__epel,
                         keys=self.__yum_keys,

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -101,8 +101,10 @@ class yum(bb_base):
         self.__download_directory = kwargs.get('download_directory',
                                                '/var/tmp/yum_download')
         self.__epel = kwargs.get('epel', False)
+        self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__keys = kwargs.get('keys', [])
+        self.__opts = ['-y']
         self.ospackages = kwargs.get('ospackages', [])
         self.__powertools = kwargs.get('powertools', False)
         self.__release_stream = kwargs.get('release_stream', False)
@@ -137,6 +139,10 @@ class yum(bb_base):
 
     def __setup(self):
         """Construct the series of commands to execute"""
+
+        if self.__extra_opts:
+            self.__download_args += ' ' + ' '.join(self.__extra_opts)
+            self.__opts.extend(self.__extra_opts)
 
         # Use yum version 4 is requested.  yum 4 is the default on
         # CentOS 8.
@@ -224,7 +230,8 @@ class yum(bb_base):
                         'rm -rf {}'.format(self.__download_directory))
             else:
                 # Install packages
-                install = '{} install -y \\\n'.format(yum)
+                install = '{0} install {1} \\\n'.format(yum,
+                                                        ' '.join(self.__opts))
                 install = install + ' \\\n'.join(packages)
                 self.__commands.append(install)
 

--- a/test/test_apt_get.py
+++ b/test/test_apt_get.py
@@ -68,7 +68,7 @@ r'''RUN wget -qO - https://www.example.com/key.pub | apt-key add - && \
         self.assertEqual(str(a),
 r'''RUN apt-get update -y && \
     mkdir -m 777 -p /tmp/download && cd /tmp/download && \
-    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends \
         libibverbs1 && \
     rm -rf /var/lib/apt/lists/*''')
 
@@ -81,7 +81,7 @@ r'''RUN apt-get update -y && \
         self.assertEqual(str(a),
 r'''RUN apt-get update -y && \
     mkdir -m 777 -p /var/tmp/apt_get_download && cd /var/tmp/apt_get_download && \
-    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends \
         libibverbs1 && \
     mkdir -p /usr/local/ofed && \
     find /var/tmp/apt_get_download -regextype posix-extended -type f -regex "/var/tmp/apt_get_download/(libibverbs1).*deb" -exec dpkg --extract {} /usr/local/ofed \; && \

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, docker, ppc64le, ubuntu, ubuntu18, x86_64
+from helpers import aarch64, centos, centos8, docker, ppc64le, ubuntu, ubuntu18, x86_64
 
 from hpccm.building_blocks.mlnx_ofed import mlnx_ofed
 
@@ -41,16 +41,28 @@ class Test_mlnx_ofed(unittest.TestCase):
 r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
+        ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64''')
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    rm -rf /var/lib/apt/lists/*''')
 
     @x86_64
     @ubuntu18
@@ -62,16 +74,28 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
+        ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu18.04-x86_64''')
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    rm -rf /var/lib/apt/lists/*''')
 
     @x86_64
     @centos
@@ -82,16 +106,60 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN yum install -y \
-        findutils \
-        libnl \
-        libnl3 \
-        numactl-libs \
+        ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64 -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*x86_64.rpm" -not -path "*UPSTREAM*" -exec rpm --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-rhel7.2-x86_64''')
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/rhel7.2/mellanox_mlnx_ofed.repo && \
+    yum install -y \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
+    rm -rf /var/cache/yum/*''')
+
+    @x86_64
+    @centos8
+    @docker
+    def test_defaults_centos8(self):
+        """Default mlnx_ofed building block"""
+        mofed = mlnx_ofed()
+        self.assertEqual(str(mofed),
+r'''# Mellanox OFED version 4.7-3.2.9.0
+RUN yum install -y \
+        ca-certificates \
+        gnupg \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y dnf-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/rhel8.0/mellanox_mlnx_ofed.repo && \
+    yum install -y \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
+    rm -rf /var/cache/yum/*''')
 
     @x86_64
     @ubuntu
@@ -103,18 +171,36 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
+        ca-certificates \
+        gnupg \
         libnl-3-200 \
         libnl-route-3-200 \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    mkdir -p /etc/libibverbs.d && \
-    mkdir -p /opt/ofed && cd /opt/ofed && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --extract {} /opt/ofed \; && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64''')
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.6-1.0.1.1/ubuntu16.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    mkdir -p /opt/ofed && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /opt/ofed \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d''')
 
     @x86_64
     @centos
@@ -125,60 +211,37 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
-        findutils \
+        ca-certificates \
+        gnupg \
         libnl \
         libnl3 \
         numactl-libs \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz -C /var/tmp -z && \
-    mkdir -p /etc/libibverbs.d && \
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.6-1.0.1.1/rhel7.2/mellanox_mlnx_ofed.repo && \
+    yum install -y yum-utils && \
+    mkdir -p /var/tmp/packages_download && \
+    yumdownloader --destdir=/var/tmp/packages_download -x \*i?86 --archlist=x86_64 \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
     mkdir -p /opt/ofed && cd /opt/ofed && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64 -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*x86_64.rpm" -not -path "*UPSTREAM*" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-x86_64''')
-
-    @aarch64
-    @ubuntu
-    @docker
-    def test_aarch64_ubuntu(self):
-        """aarch64"""
-        mofed = mlnx_ofed(version='4.5-1.0.1.0')
-        self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.5-1.0.1.0
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_arm64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-aarch64''')
-
-    @aarch64
-    @ubuntu18
-    @docker
-    def test_aarch64_ubuntu18(self):
-        """aarch64"""
-        mofed = mlnx_ofed(version='4.6-1.0.1.1')
-        self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_arm64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-aarch64''')
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel).*rpm" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /etc/libibverbs.d''')
 
     @aarch64
     @centos
@@ -189,78 +252,28 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
         self.assertEqual(str(mofed),
 r'''# Mellanox OFED version 4.6-1.0.1.1
 RUN yum install -y \
-        findutils \
-        libnl \
-        libnl3 \
-        numactl-libs \
+        ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64 -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*aarch64.rpm" -not -path "*UPSTREAM*" -exec rpm --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.6alternate-aarch64''')
-
-    @ppc64le
-    @ubuntu
-    @docker
-    def test_ppc64le_ubuntu(self):
-        """aarch64"""
-        mofed = mlnx_ofed(version='4.6-1.0.1.1')
-        self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-ppc64le.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-ppc64le.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-ppc64le -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_ppc64el.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-ppc64le.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-ppc64le''')
-
-    @ppc64le
-    @ubuntu18
-    @docker
-    def test_ppc64le_ubuntu18(self):
-        """aarch64"""
-        mofed = mlnx_ofed(version='4.6-1.0.1.1')
-        self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-ppc64le.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-ppc64le.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-ppc64le -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_ppc64el.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-ppc64le.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu18.04-ppc64le''')
-
-    @ppc64le
-    @centos
-    @docker
-    def test_ppc64le_centos(self):
-        """aarch64"""
-        mofed = mlnx_ofed(version='4.6-1.0.1.1')
-        self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.6-1.0.1.1
-RUN yum install -y \
-        findutils \
-        libnl \
-        libnl3 \
-        numactl-libs \
-        wget && \
-    rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-ppc64le.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-ppc64le.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-ppc64le -regextype posix-extended -type f -regex ".*(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel)-[0-9].*ppc64le.rpm" -not -path "*UPSTREAM*" -exec rpm --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-ppc64le.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-rhel7.2-ppc64le''')
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y yum-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.6-1.0.1.1/rhel7.6alternate/mellanox_mlnx_ofed.repo && \
+    yum install -y \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
+    rm -rf /var/cache/yum/*''')
 
     @x86_64
     @ubuntu
@@ -273,16 +286,28 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
-        libnl-3-200 \
-        libnl-route-3-200 \
-        libnuma1 \
+        ca-certificates \
+        gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.7-3.2.9.0/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    find /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --install {} + && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.7-3.2.9.0-ubuntu16.04-x86_64''')
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    rm -rf /var/lib/apt/lists/*''')
 
     @x86_64
     @ubuntu
@@ -295,11 +320,9 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://c
 r'''# Mellanox OFED version 4.7-3.2.9.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
         libnl-3-200 \
         libnl-route-3-200 \
-        libnuma1 \
-        wget && \
+        libnuma1 && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /etc/libibverbs.d
 COPY --from=0 /opt/ofed /opt/ofed''')

--- a/test/test_multi_ofed.py
+++ b/test/test_multi_ofed.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu, ubuntu18, x86_64
+from helpers import centos, centos8, docker, ubuntu, ubuntu18, x86_64
 
 from hpccm.building_blocks.multi_ofed import multi_ofed
 
@@ -32,9 +32,9 @@ class Test_multi_ofed(unittest.TestCase):
         logging.disable(logging.ERROR)
 
     @x86_64
-    @ubuntu
+    @ubuntu18
     @docker
-    def test_versions_ubuntu(self):
+    def test_versions_ubuntu18(self):
         """mlnx_version parameter"""
         # Reduced set of versions to limit gold output
         ofed = multi_ofed(mlnx_versions=['4.5-1.0.1.0', '4.6-1.0.1.1'])
@@ -42,33 +42,69 @@ class Test_multi_ofed(unittest.TestCase):
 r'''# Mellanox OFED version 4.5-1.0.1.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
+        ca-certificates \
+        gnupg \
         libnl-3-200 \
         libnl-route-3-200 \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.5-1.0.1.0/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    mkdir -p /etc/libibverbs.d && \
-    mkdir -p /usr/local/ofed/4.5-1.0.1.0 && cd /usr/local/ofed/4.5-1.0.1.0 && \
-    find /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --extract {} /usr/local/ofed/4.5-1.0.1.0 \; && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.5-1.0.1.0-ubuntu16.04-x86_64
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.5-1.0.1.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    mkdir -p /usr/local/ofed/4.5-1.0.1.0 && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /usr/local/ofed/4.5-1.0.1.0 \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d
 # Mellanox OFED version 4.6-1.0.1.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        findutils \
+        ca-certificates \
+        gnupg \
         libnl-3-200 \
         libnl-route-3-200 \
         libnuma1 \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://content.mellanox.com/ofed/MLNX_OFED-4.6-1.0.1.1/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz -C /var/tmp -z && \
-    mkdir -p /etc/libibverbs.d && \
-    mkdir -p /usr/local/ofed/4.6-1.0.1.1 && cd /usr/local/ofed/4.6-1.0.1.1 && \
-    find /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64 -regextype posix-extended -type f -regex ".*(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1)_.*_amd64.deb" -not -path "*UPSTREAM*" -exec dpkg --extract {} /usr/local/ofed/4.6-1.0.1.1 \; && \
-    rm -rf /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64.tgz /var/tmp/MLNX_OFED_LINUX-4.6-1.0.1.1-ubuntu16.04-x86_64
+RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.6-1.0.1.1/ubuntu18.04/mellanox_mlnx_ofed.list && \
+    apt-get update -y && \
+    mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends \
+        ibverbs-utils \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs-dev \
+        libibverbs1 \
+        libmlx4-1 \
+        libmlx4-dev \
+        libmlx5-1 \
+        libmlx5-dev \
+        librdmacm-dev \
+        librdmacm1 && \
+    mkdir -p /usr/local/ofed/4.6-1.0.1.1 && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /usr/local/ofed/4.6-1.0.1.1 \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d
 # OFED
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -78,30 +114,123 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update -y && \
     mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
-    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends -t bionic \
         dapl2-utils \
         ibutils \
+        ibverbs-providers \
         ibverbs-utils \
         infiniband-diags \
         libdapl-dev \
         libdapl2 \
-        libibcm-dev \
-        libibcm1 \
         libibmad-dev \
         libibmad5 \
         libibverbs-dev \
         libibverbs1 \
-        libmlx4-1 \
-        libmlx4-dev \
-        libmlx5-1 \
-        libmlx5-dev \
         librdmacm-dev \
         librdmacm1 \
         rdmacm-utils && \
     mkdir -p /usr/local/ofed/inbox && \
-    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(dapl2-utils|ibutils|ibverbs-utils|infiniband-diags|libdapl-dev|libdapl2|libibcm-dev|libibcm1|libibmad-dev|libibmad5|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1|rdmacm-utils).*deb" -exec dpkg --extract {} /usr/local/ofed/inbox \; && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(dapl2-utils|ibutils|ibverbs-providers|ibverbs-utils|infiniband-diags|libdapl-dev|libdapl2|libibmad-dev|libibmad5|libibverbs-dev|libibverbs1|librdmacm-dev|librdmacm1|rdmacm-utils).*deb" -exec dpkg --extract {} /usr/local/ofed/inbox \; && \
     rm -rf /var/tmp/packages_download && \
     rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /etc/libibverbs.d
+RUN ln -s /usr/local/ofed/inbox /usr/local/ofed/5.0-0''')
+
+    @x86_64
+    @centos8
+    @docker
+    def test_versions_centos8(self):
+        """mlnx_version parameter"""
+        # Reduced set of versions to limit gold output
+        ofed = multi_ofed(mlnx_versions=['4.5-1.0.1.0', '4.6-1.0.1.1'])
+        self.assertEqual(str(ofed),
+r'''# Mellanox OFED version 4.5-1.0.1.0
+RUN yum install -y \
+        ca-certificates \
+        gnupg \
+        libnl3 \
+        numactl-libs \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y dnf-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.5-1.0.1.0/rhel8.0/mellanox_mlnx_ofed.repo && \
+    yum install -y yum-utils && \
+    mkdir -p /var/tmp/packages_download && \
+    yumdownloader --destdir=/var/tmp/packages_download -x \*i?86 --archlist=x86_64 \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
+    mkdir -p /usr/local/ofed/4.5-1.0.1.0 && cd /usr/local/ofed/4.5-1.0.1.0 && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel).*rpm" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /etc/libibverbs.d
+# Mellanox OFED version 4.6-1.0.1.1
+RUN yum install -y \
+        ca-certificates \
+        gnupg \
+        libnl3 \
+        numactl-libs \
+        wget && \
+    rm -rf /var/cache/yum/*
+RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
+    yum install -y dnf-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.6-1.0.1.1/rhel8.0/mellanox_mlnx_ofed.repo && \
+    yum install -y yum-utils && \
+    mkdir -p /var/tmp/packages_download && \
+    yumdownloader --destdir=/var/tmp/packages_download -x \*i?86 --archlist=x86_64 \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibumad-devel \
+        libibverbs \
+        libibverbs-devel \
+        libibverbs-utils \
+        libmlx4 \
+        libmlx4-devel \
+        libmlx5 \
+        libmlx5-devel \
+        librdmacm \
+        librdmacm-devel && \
+    mkdir -p /usr/local/ofed/4.6-1.0.1.1 && cd /usr/local/ofed/4.6-1.0.1.1 && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs|libibverbs-devel|libibverbs-utils|libmlx4|libmlx4-devel|libmlx5|libmlx5-devel|librdmacm|librdmacm-devel).*rpm" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/cache/yum/*
+RUN mkdir -p /etc/libibverbs.d
+# OFED
+RUN yum install -y \
+        libnl3 \
+        numactl-libs && \
+    rm -rf /var/cache/yum/*
+RUN yum install -y dnf-utils && \
+    yum-config-manager --set-enabled PowerTools && \
+    yum install -y yum-utils && \
+    mkdir -p /var/tmp/packages_download && \
+    yumdownloader --destdir=/var/tmp/packages_download -x \*i?86 --archlist=x86_64 --disablerepo=mlnx\* \
+        libibmad \
+        libibmad-devel \
+        libibumad \
+        libibverbs \
+        libibverbs-utils \
+        libmlx5 \
+        librdmacm \
+        rdma-core \
+        rdma-core-devel && \
+    mkdir -p /usr/local/ofed/inbox && cd /usr/local/ofed/inbox && \
+    find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(libibmad|libibmad-devel|libibumad|libibverbs|libibverbs-utils|libmlx5|librdmacm|rdma-core|rdma-core-devel).*rpm" -exec sh -c "rpm2cpio {} | cpio -idm" \; && \
+    rm -rf /var/tmp/packages_download && \
+    rm -rf /var/cache/yum/*
 RUN mkdir -p /etc/libibverbs.d
 RUN ln -s /usr/local/ofed/inbox /usr/local/ofed/5.0-0''')
 
@@ -123,9 +252,9 @@ RUN mkdir -p /etc/libibverbs.d
 COPY --from=0 /usr/local/ofed /usr/local/ofed''')
 
     @x86_64
-    @ubuntu
+    @ubuntu18
     @docker
-    def test_runtime_ubuntu(self):
+    def test_runtime_ubuntu18(self):
         """Runtime"""
         ofed = multi_ofed()
         r = ofed.runtime()

--- a/test/test_ofed.py
+++ b/test/test_ofed.py
@@ -40,7 +40,7 @@ class Test_ofed(unittest.TestCase):
         self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t xenial \
         dapl2-utils \
         ibutils \
         ibverbs-utils \
@@ -71,7 +71,7 @@ RUN apt-get update -y && \
         self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t bionic \
         dapl2-utils \
         ibutils \
         ibverbs-providers \
@@ -96,7 +96,7 @@ RUN apt-get update -y && \
         o = ofed()
         self.assertEqual(str(o),
 r'''# OFED
-RUN yum install -y \
+RUN yum install -y --disablerepo=mlnx\* \
         dapl \
         dapl-devel \
         ibutils \
@@ -122,7 +122,7 @@ RUN yum install -y \
 r'''# OFED
 RUN yum install -y dnf-utils && \
     yum-config-manager --set-enabled PowerTools && \
-    yum install -y \
+    yum install -y --disablerepo=mlnx\* \
         libibmad \
         libibmad-devel \
         libibumad \
@@ -149,7 +149,7 @@ RUN apt-get update -y && \
     rm -rf /var/lib/apt/lists/*
 RUN apt-get update -y && \
     mkdir -m 777 -p /var/tmp/packages_download && cd /var/tmp/packages_download && \
-    DEBIAN_FRONTEND=noninteractive apt-get download -y \
+    DEBIAN_FRONTEND=noninteractive apt-get download -y --no-install-recommends -t xenial \
         dapl2-utils \
         ibutils \
         ibverbs-utils \
@@ -184,7 +184,7 @@ RUN mkdir -p /etc/libibverbs.d''')
         self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t xenial \
         ibutils \
         ibverbs-utils \
         infiniband-diags \
@@ -210,7 +210,7 @@ RUN apt-get update -y && \
         self.assertEqual(str(o),
 r'''# OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t xenial \
         dapl2-utils \
         ibutils \
         ibverbs-utils \
@@ -240,7 +240,7 @@ RUN apt-get update -y && \
         self.assertEqual(r,
 r'''# OFED
 RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends -t xenial \
         dapl2-utils \
         ibutils \
         ibverbs-utils \


### PR DESCRIPTION
## Pull Request Description

Use [Mellanox repositories](https://www.mellanox.com/support/mlnx-ofed-public-repository) instead of the slightly hacky approach using tarballs.

Since the package names are the same in the Mellanox repos and the Ubuntu / CentOS repositories, modified the `ofed` building block to force use of the distribution repos so that the `multi_ofed` use case is handled correctly.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
