### PR TITLE
Add _run_arguments parameter to generic building blocks

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -799,6 +799,8 @@ must be specified. The default is False.
 - __repository__: The git repository of the package to build.  One of
 this paramter or the `url` parameter must be specified.
 
+- ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
 stage.  The default is an empty dictionary.
@@ -909,6 +911,8 @@ must be specified. The default is False.
 - __repository__: The git repository of the package to build.  One of
 this paramter or the `url` parameter must be specified.
 
+- ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
 stage.  The default is an empty dictionary.
@@ -1015,6 +1019,8 @@ must be specified. The default is False.
 
 - __repository__: The git repository of the package to build.  One of
 this paramter or the `url` parameter must be specified.
+
+- ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
 
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -119,6 +119,8 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
     repository: The git repository of the package to build.  One of
     this paramter or the `url` parameter must be specified.
 
+    _run_arguments: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
     runtime_environment: Dictionary of environment variables and
     values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
     stage.  The default is an empty dictionary.
@@ -174,6 +176,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self.__postinstall = kwargs.get('postinstall', [])
         self.__preconfigure = kwargs.get('preconfigure', [])
         self.__recursive = kwargs.get('recursive', False)
+        self.__run_arguments = kwargs.get('_run_arguments', None)
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__toolchain = kwargs.get('toolchain', toolchain())
 
@@ -193,7 +196,8 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
             self += comment(self.url, reformat=False)
         elif self.repository:
             self += comment(self.repository, reformat=False)
-        self += shell(commands=self.__commands)
+        self += shell(_arguments=self.__run_arguments,
+                      commands=self.__commands)
         self += environment(variables=self.environment_step())
 
     def __setup(self):

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -89,6 +89,8 @@ class generic_build(bb_base, hpccm.templates.downloader,
     repository: The git repository of the package to build.  One of
     this paramter or the `url` parameter must be specified.
 
+    _run_arguments: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
     runtime_environment: Dictionary of environment variables and
     values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
     stage.  The default is an empty dictionary.
@@ -118,6 +120,7 @@ class generic_build(bb_base, hpccm.templates.downloader,
         self.__libdir = kwargs.get('libdir', 'lib')
         self.__prefix = kwargs.get('prefix', None)
         self.__recursive = kwargs.get('recursive', False)
+        self.__run_arguments = kwargs.get('_run_arguments', None)
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
 
         self.__commands = [] # Filled in by __setup()
@@ -136,7 +139,8 @@ class generic_build(bb_base, hpccm.templates.downloader,
             self += comment(self.url, reformat=False)
         elif self.repository:
             self += comment(self.repository, reformat=False)
-        self += shell(commands=self.__commands)
+        self += shell(_arguments=self.__run_arguments,
+                      commands=self.__commands)
         self += environment(variables=self.environment_step())
 
     def __setup(self):

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -109,6 +109,8 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
     repository: The git repository of the package to build.  One of
     this paramter or the `url` parameter must be specified.
 
+    _run_arguments: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
     runtime_environment: Dictionary of environment variables and
     values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
     stage.  The default is an empty dictionary.
@@ -175,6 +177,7 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
         self.__postinstall = kwargs.get('postinstall', [])
         self.__preconfigure = kwargs.get('preconfigure', [])
         self.__recursive = kwargs.get('recursive', False)
+        self.__run_arguments = kwargs.get('_run_arguments', None)
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__toolchain = kwargs.get('toolchain', toolchain())
 
@@ -194,7 +197,8 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
             self += comment(self.url, reformat=False)
         elif self.repository:
             self += comment(self.repository, reformat=False)
-        self += shell(commands=self.__commands)
+        self += shell(_arguments=self.__run_arguments,
+                      commands=self.__commands)
         self += environment(variables=self.environment_step())
 
     def __setup(self):


### PR DESCRIPTION
## Pull Request Description

Add `_run_arguments` parameter to the generic building blocks, passing through to the shell primitive `_arguments` parameter.  For instance, this can be used for build secrets, e.g., git credentials.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
