### PR TITLE
Add the ability to include recipes in other recipes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,9 @@ include test/bad_recipe.py
 include test/docker.blob
 include test/global_vars_recipe.py
 include test/helpers.py
+include test/include1.py
+include test/include2.py
+include test/include3.py
 include test/singularity.blob
 graft docs
 graft recipes

--- a/hpccm/__init__.py
+++ b/hpccm/__init__.py
@@ -23,6 +23,7 @@ from hpccm.common import container_type
 from hpccm.common import linux_distro
 
 from hpccm.Stage import Stage
+from hpccm.recipe import include
 from hpccm.recipe import recipe
 from hpccm.toolchain import toolchain
 

--- a/recipes/examples/cloverleaf.py
+++ b/recipes/examples/cloverleaf.py
@@ -1,0 +1,11 @@
+"""
+Demonstrate how to include a recipe in another recipe
+"""
+
+# the gnu-devel recipe file must be in the same directory
+hpccm.include('gnu-devel.py')
+
+Stage0 += generic_build(branch='v1.3',
+                        build=['make COMPILER=GNU'],
+                        install=['cp clover_leaf /usr/local/bin'],
+                        repository='https://github.com/UK-MAC/CloverLeaf_Serial.git')

--- a/recipes/examples/gnu-devel.py
+++ b/recipes/examples/gnu-devel.py
@@ -1,0 +1,14 @@
+"""
+Basic development container image
+"""
+
+Stage0 += baseimage(image='ubuntu:18.04')
+
+# GNU compilers
+compiler = gnu()
+Stage0 += compiler
+
+# Additional development tools
+Stage0 += packages(ospackages=['autoconf', 'autoconf-archive', 'automake',
+                               'bzip2', 'ca-certificates', 'cmake', 'git',
+                               'gzip', 'libtool', 'make', 'patch', 'xz-utils'])

--- a/test/include1.py
+++ b/test/include1.py
@@ -1,0 +1,1 @@
+Stage0 += baseimage(image='ubuntu:16.04')

--- a/test/include2.py
+++ b/test/include2.py
@@ -1,0 +1,2 @@
+include('../test/include1.py')
+compiler = gnu()

--- a/test/include3.py
+++ b/test/include3.py
@@ -1,0 +1,2 @@
+include('include2.py')
+Stage0 += compiler

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -253,3 +253,19 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     rm -rf /var/tmp/openmpi-2.1.2.tar.bz2 /var/tmp/openmpi-2.1.2
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
+
+    def test_include(self):
+        """recipe include"""
+        path = os.path.dirname(__file__)
+        rf = os.path.join(path, 'include3.py')
+        r = recipe(rf)
+        self.assertEqual(r.strip(),
+r'''FROM ubuntu:16.04
+
+# GNU compiler
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        g++ \
+        gcc \
+        gfortran && \
+    rm -rf /var/lib/apt/lists/*''')


### PR DESCRIPTION
## Pull Request Description

This change allows a recipe to include another recipe, as if it had been at the point where it's included.

```
include('common.py')

Stage0 += <application specific content>
```

The intended use case is to allow a common development recipe to be shared among several applications.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
