### PR TITLE
Add Annotations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
+![Python 3](https://github.com/NVIDIA/hpc-container-maker/workflows/Python%203/badge.svg)
+![Python 2](https://github.com/NVIDIA/hpc-container-maker/workflows/Python%202/badge.svg)
+![Conda](https://img.shields.io/conda/dn/conda-forge/hpccm?label=Conda%20downloads)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/hpccm?label=PyPI%20downloads)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/NVIDIA/hpc-container-maker.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/NVIDIA/hpc-container-maker/context:python)
+![License](https://img.shields.io/github/license/NVIDIA/hpc-container-maker)
+
 # HPC Container Maker
 
 HPC Container Maker (HPCCM - pronounced H-P-see-M) is an open source

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -299,6 +299,9 @@ building block.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __check__: Boolean flag to specify whether the test cases should be
 run.  The default is False.
 
@@ -564,6 +567,9 @@ context.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
 
@@ -673,6 +679,9 @@ component.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __environment__: Boolean flag to specify whether the environment
 (`CPATH`, `LIBRARY_PATH`, and `LD_LIBRARY_PATH`) should be
 modified to include the gdrcopy. The default is True.
@@ -724,6 +733,12 @@ builds, and installs a specified GNU Autotools enabled package.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
+- __annotations__: Dictionary of additional annotations to include.  The
+default is an empty dictionary.
 
 - __branch__: The git branch to clone.  Only recognized if the
 `repository` parameter is specified.  The default is empty, i.e.,
@@ -865,6 +880,12 @@ a specified package.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
+- __annotations__: Dictionary of additional annotations to include.  The
+default is an empty dictionary.
+
 - __build__: List of shell commands to run in order to build the
 package.  The working directory is the source directory.  The
 default is an empty list.
@@ -955,6 +976,12 @@ builds, and installs a specified CMake enabled package.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
+- __annotations__: Dictionary of additional annotations to include.  The
+default is an empty dictionary.
 
 - __branch__: The git branch to clone.  Only recognized if the
 `repository` parameter is specified.  The default is empty, i.e.,
@@ -1219,6 +1246,9 @@ context.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
 
@@ -1241,8 +1271,8 @@ configuring.  For instance, `enable_foo=True` maps to
 Underscores in the parameter name are converted to dashes.
 
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
-include HDF5. The default is True.
+(`CPATH`, `LD_LIBRARY_PATH`, `LIBRARY_PATH`, `PATH`, and others)
+should be modified to include HDF5. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the HDF5 library
 directory should be added dynamic linker cache.  If False, then
@@ -1296,6 +1326,7 @@ hdf5(toolchain=p.toolchain)
 hdf5(check=True, configure_opts=['--enable-cxx', '--enable-fortran',
                                  '--enable-profiling=yes'])
 ```
+
 
 ## runtime
 ```python
@@ -1793,6 +1824,9 @@ The `knem` building block install the headers from the
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __environment__: Boolean flag to specify whether the environment
 (`CPATH`) should be modified to include knem. The default is True.
 
@@ -1838,6 +1872,9 @@ The `kokkos` building block downloads and installs the
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __arch__: Flag to set the target architecture. If set adds
 `--arch=value` to the list of `generate_makefile.bash` options.
@@ -2140,6 +2177,9 @@ Linux](http://www.mellanox.com/page/products_dyn?product_family=26).
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __oslabel__: The Linux distribution label assigned by Mellanox to the
 tarball.  For Ubuntu, the default value is `ubuntu16.04`.  For
 RHEL-based Linux distributions, the default value is `rhel7.2` for
@@ -2212,6 +2252,9 @@ that want to build using the MPI compiler wrappers.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __check__: Boolean flag to specify whether the `make check` and `make
 testing` steps should be performed.  The default is False.
@@ -2304,6 +2347,9 @@ building blocks for more information.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __inbox__: Boolean flag to specify whether to install the 'inbox' OFED
 distributed by the Linux distribution.  The default is True.
 
@@ -2369,6 +2415,9 @@ that want to build using the MPI compiler wrappers.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
@@ -2604,6 +2653,9 @@ building block.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
 
@@ -2624,14 +2676,11 @@ configuring.  For instance, `enable_foo=True` maps to
 Underscores in the parameter name are converted to dashes.
 
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
-NetCDF. The default is True.
+(`CPATH`, `LD_LIBRARY_PATH`, `LIBRARY_PATH` and `PATH`) should be
+modified to include NetCDF. The default is True.
 
 - __fortran__: Boolean flag to specify whether the NetCDF Fortran
 library should be installed.  The default is True.
-
-- __hdf5_dir__: Path to the location where HDF5 is installed in the
-container image.  The default value is `/usr/local/hdf5`.
 
 - __ldconfig__: Boolean flag to specify whether the NetCDF library
 directory should be added dynamic linker cache.  If False, then
@@ -2807,6 +2856,9 @@ The `openblas` building block builds and installs the
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __environment__: Boolean flag to specify whether the environment
 (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
 OpenBLAS. The default is True.
@@ -2877,6 +2929,9 @@ that want to build using the MPI compiler wrappers.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __branch__: The git branch to clone.  Only recognized if the
 `repository` parameter is specified.  The default is empty, i.e.,
@@ -3277,6 +3332,9 @@ The `pmix` building block configures, builds, and installs the
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
 
@@ -3364,6 +3422,9 @@ component.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __check__: Boolean flag to specify whether the `make check` step
 should be performed.  The default is False.
@@ -3580,6 +3641,9 @@ recommended.
 __Parameters__
 
 
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
+
 - __branch__: The branch of SENSEI to use.  The default value is
 `v2.1.1`.
 
@@ -3660,6 +3724,9 @@ Note: this building block does not install SLURM itself.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __configure_opts__: List of options to pass to `configure`.  The
 default is an empty list.
@@ -3747,6 +3814,9 @@ this building block.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __branch__: The git branch to clone.  Only recognized if the
 `repository` parameter is specified.  The default is empty, i.e.,
@@ -3904,6 +3974,9 @@ component.
 
 __Parameters__
 
+
+- __annotate__: Boolean flag to specify whether to include annotations
+(labels).  The default is False.
 
 - __branch__: The branch of XPMEM to use.  The default value is
 `master`.

--- a/hpccm/building_blocks/cgns.py
+++ b/hpccm/building_blocks/cgns.py
@@ -116,6 +116,8 @@ class cgns(bb_base):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             comment=False,
             configure_opts=self.__configure_opts,

--- a/hpccm/building_blocks/cgns.py
+++ b/hpccm/building_blocks/cgns.py
@@ -43,6 +43,9 @@ class cgns(bb_base):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the test cases should be
     run.  The default is False.
 

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -147,6 +147,8 @@ class fftw(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             configure_opts=self.__configure_opts,
             comment=False,

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -42,6 +42,9 @@ class fftw(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -38,6 +38,9 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     environment: Boolean flag to specify whether the environment
     (`CPATH`, `LIBRARY_PATH`, and `LD_LIBRARY_PATH`) should be
     modified to include the gdrcopy. The default is True.

--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -86,6 +86,8 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_build(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             # Work around "install -D" issue on CentOS
             build=['mkdir -p {0}/include {0}/lib64'.format(self.__prefix),
                    'make PREFIX={} lib lib_install'.format(self.__prefix)],

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -48,6 +48,12 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
+    annotations: Dictionary of additional annotations to include.  The
+    default is an empty dictionary.
+
     branch: The git branch to clone.  Only recognized if the
     `repository` parameter is specified.  The default is empty, i.e.,
     use the default branch for the repository.

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -25,6 +25,7 @@ import posixpath
 import re
 
 import hpccm.templates.ConfigureMake
+import hpccm.templates.annotate
 import hpccm.templates.downloader
 import hpccm.templates.envvars
 import hpccm.templates.ldconfig
@@ -34,12 +35,14 @@ from hpccm.building_blocks.base import bb_base
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
+from hpccm.primitives.label import label
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
 class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
-                        hpccm.templates.downloader, hpccm.templates.envvars,
-                        hpccm.templates.ldconfig, hpccm.templates.rm):
+                        hpccm.templates.annotate, hpccm.templates.downloader,
+                        hpccm.templates.envvars, hpccm.templates.ldconfig,
+                        hpccm.templates.rm):
     """The `generic_autotools` building block downloads, configures,
     builds, and installs a specified GNU Autotools enabled package.
 
@@ -164,6 +167,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
 
         super(generic_autotools, self).__init__(**kwargs)
 
+        self.__annotations = kwargs.get('annotations', {})
         self.__build_directory = kwargs.get('build_directory', None)
         self.__build_environment = kwargs.get('build_environment', {})
         self.__check = kwargs.get('check', False)
@@ -202,6 +206,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self += shell(_arguments=self.__run_arguments,
                       commands=self.__commands)
         self += environment(variables=self.environment_step())
+        self += label(metadata=self.annotate_step())
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -266,6 +271,10 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
             self.__commands.append(self.ldcache_step(
                 directory=posixpath.join(self.prefix, self.__libdir)))
 
+        # Add annotations
+        for key,value in self.__annotations.items():
+            self.add_annotation(key, value)
+
         # Cleanup
         remove = [self.src_directory]
         if self.url:
@@ -304,6 +313,8 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
             if self.runtime_environment_variables:
                 instructions.append(environment(
                     variables=self.environment_step(runtime=True)))
+            if self.annotate:
+                instructions.append(label(metadata=self.annotate_step()))
             return '\n'.join(str(x) for x in instructions)
         else: # pragma: no cover
             return

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -45,6 +45,12 @@ class generic_build(bb_base, hpccm.templates.annotate,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
+    annotations: Dictionary of additional annotations to include.  The
+    default is an empty dictionary.
+
     build: List of shell commands to run in order to build the
     package.  The working directory is the source directory.  The
     default is an empty list.

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -24,6 +24,7 @@ from __future__ import print_function
 import posixpath
 import re
 
+import hpccm.templates.annotate
 import hpccm.templates.downloader
 import hpccm.templates.envvars
 import hpccm.templates.ldconfig
@@ -33,11 +34,12 @@ from hpccm.building_blocks.base import bb_base
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
+from hpccm.primitives.label import label
 from hpccm.primitives.shell import shell
 
-class generic_build(bb_base, hpccm.templates.downloader,
-                    hpccm.templates.envvars, hpccm.templates.ldconfig,
-                    hpccm.templates.rm):
+class generic_build(bb_base, hpccm.templates.annotate,
+                    hpccm.templates.downloader, hpccm.templates.envvars,
+                    hpccm.templates.ldconfig, hpccm.templates.rm):
     """The `generic_build` building block downloads and builds
     a specified package.
 
@@ -113,6 +115,7 @@ class generic_build(bb_base, hpccm.templates.downloader,
 
         super(generic_build, self).__init__(**kwargs)
 
+        self.__annotations = kwargs.get('annotations', {})
         self.__build = kwargs.get('build', [])
         self.__comment = kwargs.get('comment', True)
         self.__directory = kwargs.get('directory', None)
@@ -144,6 +147,7 @@ class generic_build(bb_base, hpccm.templates.downloader,
         self += shell(_arguments=self.__run_arguments,
                       commands=self.__commands)
         self += environment(variables=self.environment_step())
+        self += label(metadata=self.annotate_step())
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -177,6 +181,10 @@ class generic_build(bb_base, hpccm.templates.downloader,
         if self.ldconfig:
             self.__commands.append(self.ldcache_step(
                 directory=posixpath.join(self.__prefix, self.__libdir)))
+
+        # Add annotations
+        for key,value in self.__annotations.items():
+            self.add_annotation(key, value)
 
         # Cleanup
         remove = [self.src_directory]
@@ -212,6 +220,8 @@ class generic_build(bb_base, hpccm.templates.downloader,
             if self.runtime_environment_variables:
                 instructions.append(environment(
                     variables=self.environment_step(runtime=True)))
+            if self.annotate:
+                instructions.append(label(metadata=self.annotate_step()))
             return '\n'.join(str(x) for x in instructions)
         else: #pragma: no cover
             return

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -25,6 +25,7 @@ import posixpath
 import re
 
 import hpccm.templates.CMakeBuild
+import hpccm.templates.annotate
 import hpccm.templates.downloader
 import hpccm.templates.envvars
 import hpccm.templates.ldconfig
@@ -34,12 +35,14 @@ from hpccm.building_blocks.base import bb_base
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
 from hpccm.primitives.environment import environment
+from hpccm.primitives.label import label
 from hpccm.primitives.shell import shell
 from hpccm.toolchain import toolchain
 
 class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
-                    hpccm.templates.downloader, hpccm.templates.envvars,
-                    hpccm.templates.ldconfig, hpccm.templates.rm):
+                    hpccm.templates.annotate, hpccm.templates.downloader,
+                    hpccm.templates.envvars, hpccm.templates.ldconfig,
+                    hpccm.templates.rm):
     """The `generic_cmake` building block downloads, configures,
     builds, and installs a specified CMake enabled package.
 
@@ -165,6 +168,7 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
 
         super(generic_cmake, self).__init__(**kwargs)
 
+        self.__annotations = kwargs.get('annotations', {})
         self.__build_directory = kwargs.get('build_directory', 'build')
         self.__build_environment = kwargs.get('build_environment', {})
         self.__check = kwargs.get('check', False)
@@ -202,6 +206,7 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
         self += shell(_arguments=self.__run_arguments,
                       commands=self.__commands)
         self += environment(variables=self.environment_step())
+        self += label(metadata=self.annotate_step())
 
     def __setup(self):
         """Construct the series of shell commands, i.e., fill in
@@ -259,6 +264,9 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
             self.__commands.append(self.ldcache_step(
                 directory=posixpath.join(self.prefix, self.__libdir)))
 
+        for key,value in self.__annotations.items():
+            self.add_annotation(key, value)
+
         # Cleanup
         remove = [self.src_directory]
         if self.url:
@@ -298,6 +306,8 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
             if self.runtime_environment_variables:
                 instructions.append(environment(
                     variables=self.environment_step(runtime=True)))
+            if self.annotate:
+                instructions.append(label(metadata=self.annotate_step()))
             return '\n'.join(str(x) for x in instructions)
         else: # pragma: no cover
             return

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -48,6 +48,12 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
+    annotations: Dictionary of additional annotations to include.  The
+    default is an empty dictionary.
+
     branch: The git branch to clone.  Only recognized if the
     `repository` parameter is specified.  The default is empty, i.e.,
     use the default branch for the repository.

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -156,6 +156,8 @@ class hdf5(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             configure_opts=self.__configure_opts,
             comment=False,

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -43,6 +43,9 @@ class hdf5(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/knem.py
+++ b/hpccm/building_blocks/knem.py
@@ -73,6 +73,7 @@ class knem(bb_base, hpccm.templates.envvars):
 
         # Setup build configuration
         self.__bb = generic_build(
+            base_annotation=self.__class__.__name__,
             branch='knem-{}'.format(self.__version),
             comment=False,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/knem.py
+++ b/hpccm/building_blocks/knem.py
@@ -36,6 +36,9 @@ class knem(bb_base, hpccm.templates.envvars):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     environment: Boolean flag to specify whether the environment
     (`CPATH`) should be modified to include knem. The default is True.
 

--- a/hpccm/building_blocks/kokkos.py
+++ b/hpccm/building_blocks/kokkos.py
@@ -114,6 +114,8 @@ class kokkos(bb_base, hpccm.templates.envvars):
 
         # Setup build configuration
         self.__bb = generic_build(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             build=['mkdir build',
                    'cd build',
                    '../generate_makefile.bash {}'.format(

--- a/hpccm/building_blocks/kokkos.py
+++ b/hpccm/building_blocks/kokkos.py
@@ -41,6 +41,9 @@ class kokkos(bb_base, hpccm.templates.envvars):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     arch: Flag to set the target architecture. If set adds
     `--arch=value` to the list of `generate_makefile.bash` options.
     The default value is `Pascal60`, i.e., sm_60.  If a cuda aware

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -45,6 +45,9 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     oslabel: The Linux distribution label assigned by Mellanox to the
     tarball.  For Ubuntu, the default value is `ubuntu16.04`.  For
     RHEL-based Linux distributions, the default value is `rhel7.2` for

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -24,6 +24,7 @@ from distutils.version import StrictVersion
 import posixpath
 
 import hpccm.config
+import hpccm.templates.annotate
 import hpccm.templates.rm
 import hpccm.templates.tar
 import hpccm.templates.wget
@@ -33,10 +34,11 @@ from hpccm.building_blocks.packages import packages
 from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.copy import copy
+from hpccm.primitives.label import label
 from hpccm.primitives.shell import shell
 
-class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
-                hpccm.templates.wget):
+class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
+                hpccm.templates.tar, hpccm.templates.wget):
     """The `mlnx_ofed` building block downloads and installs the [Mellanox
     OpenFabrics Enterprise Distribution for
     Linux](http://www.mellanox.com/page/products_dyn?product_family=26).
@@ -101,6 +103,9 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__symlink = kwargs.get('symlink', False)
         self.__version = kwargs.get('version', '4.7-3.2.9.0')
 
+        # Add annotation
+        self.add_annotation('version', self.__version)
+
         # Set the Linux distribution specific parameters
         self.__distro()
 
@@ -141,6 +146,8 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             commands.append('mkdir -p /etc/libibverbs.d')
 
             self += shell(commands=commands)
+
+        self += label(metadata=self.annotate_step())
 
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -144,6 +144,8 @@ class mpich(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             comment=False,
             configure_opts=self.__configure_opts,

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -46,6 +46,9 @@ class mpich(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` and `make
     testing` steps should be performed.  The default is False.
 

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -44,6 +44,9 @@ class multi_ofed(bb_base, hpccm.templates.annotate):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     inbox: Boolean flag to specify whether to install the 'inbox' OFED
     distributed by the Linux distribution.  The default is True.
 

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -55,6 +55,9 @@ class mvapich2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -191,6 +191,8 @@ class mvapich2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             comment=False,
             configure_opts=self.__configure_opts,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -160,6 +160,8 @@ class netcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
         # Setup build configuration
         comments = ['NetCDF version {}'.format(self.__version)]
         self.__bb = [generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             comment=False,
             devel_environment=self.environment_variables,
@@ -173,6 +175,8 @@ class netcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
         if self.__cxx:
             comments.append('NetCDF C++ version {}'.format(self.__version_cxx))
             self.__bb.append(generic_autotools(
+                annotations={'version': self.__version_cxx},
+                base_annotation='{}-cxx4'.format(self.__class__.__name__),
                 check=self.__check,
                 comment=False,
                 directory='netcdf-cxx4-{}'.format(self.__version_cxx),
@@ -187,6 +191,8 @@ class netcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
         if self.__fortran:
             comments.append('NetCDF Fortran version {}'.format(self.__version_fortran))
             self.__bb.append(generic_autotools(
+                annotations={'version': self.__version_fortran},
+                base_annotation='{}-fortran'.format(self.__class__.__name__),
                 check=self.__check,
                 comment=False,
                 directory='netcdf-fortran-{}'.format(self.__version_fortran),

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -45,6 +45,9 @@ class netcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -104,6 +104,8 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_build(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             build=['make {}'.format(' '.join(self.__make_opts))],
             comment=False,
             directory='OpenBLAS-{}'.format(self.__version),

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -40,6 +40,9 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     environment: Boolean flag to specify whether the environment
     (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
     OpenBLAS. The default is True.

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -224,6 +224,8 @@ class openmpi(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version} if not self.repository else {},
+            base_annotation=self.__class__.__name__,
             comment=False,
             configure_opts=self.__configure_opts,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -48,6 +48,9 @@ class openmpi(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     branch: The git branch to clone.  Only recognized if the
     `repository` parameter is specified.  The default is empty, i.e.,
     use the default branch for the repository.

--- a/hpccm/building_blocks/pmix.py
+++ b/hpccm/building_blocks/pmix.py
@@ -124,6 +124,8 @@ class pmix(bb_base,hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             check=self.__check,
             comment=False,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/pmix.py
+++ b/hpccm/building_blocks/pmix.py
@@ -39,6 +39,9 @@ class pmix(bb_base,hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/pnetcdf.py
+++ b/hpccm/building_blocks/pnetcdf.py
@@ -43,6 +43,9 @@ class pnetcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     check: Boolean flag to specify whether the `make check` step
     should be performed.  The default is False.
 

--- a/hpccm/building_blocks/pnetcdf.py
+++ b/hpccm/building_blocks/pnetcdf.py
@@ -139,6 +139,8 @@ class pnetcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             comment=False,
             configure_opts=self.__configure_opts,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/sensei.py
+++ b/hpccm/building_blocks/sensei.py
@@ -46,6 +46,9 @@ class sensei(bb_base, hpccm.templates.git):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     branch: The branch of SENSEI to use.  The default value is
     `v2.1.1`.
 

--- a/hpccm/building_blocks/sensei.py
+++ b/hpccm/building_blocks/sensei.py
@@ -121,6 +121,7 @@ class sensei(bb_base, hpccm.templates.git):
 
         # Setup build configuration
         self.__bb = generic_cmake(
+            base_annotation=self.__class__.__name__,
             branch=self.__branch,
             comment=False,
             cmake_opts=self.__cmake_opts,

--- a/hpccm/building_blocks/slurm_pmi2.py
+++ b/hpccm/building_blocks/slurm_pmi2.py
@@ -114,6 +114,8 @@ class slurm_pmi2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version},
+            base_annotation=self.__class__.__name__,
             comment=False,
             devel_environment=self.environment_variables,
             environment=self.__environment,

--- a/hpccm/building_blocks/slurm_pmi2.py
+++ b/hpccm/building_blocks/slurm_pmi2.py
@@ -39,6 +39,9 @@ class slurm_pmi2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     configure_opts: List of options to pass to `configure`.  The
     default is an empty list.
 

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -228,6 +228,8 @@ class ucx(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            annotations={'version': self.__version} if not self.repository else {},
+            base_annotation=self.__class__.__name__,
             comment=False,
             configure_opts=self.__configure_opts,
             devel_environment=self.environment_variables,

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -53,6 +53,9 @@ class ucx(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     branch: The git branch to clone.  Only recognized if the
     `repository` parameter is specified.  The default is empty, i.e.,
     use the default branch for the repository.

--- a/hpccm/building_blocks/xpmem.py
+++ b/hpccm/building_blocks/xpmem.py
@@ -121,6 +121,7 @@ class xpmem(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
         # Setup build configuration
         self.__bb = generic_autotools(
+            base_annotation=self.__class__.__name__,
             branch=self.__branch,
             comment=False,
             configure_opts=self.__configure_opts,

--- a/hpccm/building_blocks/xpmem.py
+++ b/hpccm/building_blocks/xpmem.py
@@ -39,6 +39,9 @@ class xpmem(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
 
     # Parameters
 
+    annotate: Boolean flag to specify whether to include annotations
+    (labels).  The default is False.
+
     branch: The branch of XPMEM to use.  The default value is
     `master`.
 

--- a/hpccm/templates/CMakeBuild.py
+++ b/hpccm/templates/CMakeBuild.py
@@ -137,4 +137,10 @@ class CMakeBuild(hpccm.base_object):
         cmd = '{0}{1}cmake {2}{3}'.format(
             change_directory, configure_env, configure_opts, src_directory)
 
+        # Add an annotation if the caller inherits from the annotate template
+        if callable(getattr(self, 'add_annotation', None)):
+            self.add_annotation('cmake', '{1}cmake {2}'.format(
+                change_directory, configure_env, configure_opts,
+                src_directory).strip())
+
         return cmd.strip() # trim whitespace

--- a/hpccm/templates/ConfigureMake.py
+++ b/hpccm/templates/ConfigureMake.py
@@ -162,6 +162,12 @@ class ConfigureMake(hpccm.base_object):
                                        configure_env, configure_opts,
                                        src_directory)
 
+        # Add an annotation if the caller inherits from the annotate template
+        if callable(getattr(self, 'add_annotation', None)):
+            self.add_annotation('configure', '{1} {3}/configure {2}'.format(
+                change_directory, configure_env, configure_opts,
+                src_directory).strip())
+
         return cmd.strip() # trim whitespace
 
     def install_step(self, parallel=None):

--- a/hpccm/templates/__init__.py
+++ b/hpccm/templates/__init__.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 from hpccm.templates.CMakeBuild import CMakeBuild
 from hpccm.templates.ConfigureMake import ConfigureMake
+from hpccm.templates.annotate import annotate
 from hpccm.templates.downloader import downloader
 from hpccm.templates.envvars import envvars
 from hpccm.templates.git import git

--- a/hpccm/templates/annotate.py
+++ b/hpccm/templates/annotate.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""annotate template"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+from six import string_types
+from six.moves import shlex_quote
+
+import hpccm.base_object
+
+class annotate(hpccm.base_object):
+    """Template for setting annotations"""
+
+    def __init__(self, **kwargs):
+        """Initialize template"""
+
+        super(annotate, self).__init__(**kwargs)
+
+        self.annotate = kwargs.get('annotate', False)
+        self.base_annotation = kwargs.get('base_annotation', True)
+        self.__labels = {}
+
+    def add_annotation(self, key, value):
+        if isinstance(self.base_annotation, string_types):
+            key = 'hpccm.' + self.base_annotation + '.' + key
+        elif self.base_annotation:
+            key = 'hpccm.' + self.__class__.__name__ + '.' + key
+
+        self.__labels[key] = shlex_quote(str(value))
+
+    def annotate_step(self):
+        """Return dictionary of annotations"""
+
+        if self.annotate:
+            return self.__labels
+        else:
+            return {}

--- a/hpccm/templates/downloader.py
+++ b/hpccm/templates/downloader.py
@@ -51,6 +51,9 @@ class downloader(hpccm.base_object):
         if self.repository and self.url:
             raise RuntimeError('cannot specify both a repository and a URL')
 
+        # Check if the caller inherits from the annotate template
+        annotate = getattr(self, 'add_annotation', None)
+
         commands = []
 
         if self.url:
@@ -73,6 +76,9 @@ class downloader(hpccm.base_object):
                 else:
                     raise RuntimeError('unrecognized package format')
 
+            if callable(annotate):
+                self.add_annotation('url', self.url)
+
 
         elif self.repository:
             # Clone git repository
@@ -83,6 +89,14 @@ class downloader(hpccm.base_object):
             # Set directory where to find source
             self.src_directory = posixpath.join(wd, posixpath.splitext(
                 posixpath.basename(self.repository))[0])
+
+            # Add annotations
+            if callable(annotate):
+                self.add_annotation('repository', self.repository)
+                if self.branch:
+                    self.add_annotation('branch', self.branch)
+                if self.commit:
+                    self.add_annotation('commit', self.commit)
 
         if hpccm.config.g_ctype == container_type.DOCKER:
             return ' && \\\n    '.join(commands)

--- a/hpccm/templates/git.py
+++ b/hpccm/templates/git.py
@@ -131,4 +131,12 @@ class git(hpccm.base_object):
                           'git checkout {0}'.format(commit),
                           'cd -'])
 
+        # Add labels if the caller inherits from the labels template
+        if callable(getattr(self, 'add_annotation', None)):
+            self.add_annotation('repository', repository)
+            if branch:
+                self.add_annotation('branch', branch)
+            if commit:
+                self.add_annotation('commit', commit)
+
         return ' && '.join(clone)

--- a/hpccm/templates/wget.py
+++ b/hpccm/templates/wget.py
@@ -54,6 +54,10 @@ class wget(hpccm.base_object):
 
         opt_string = ' '.join(self.wget_opts)
 
+        # Add annotation if the caller inherits from the annotate template
+        if callable(getattr(self, 'add_annotation', None)):
+            self.add_annotation('url', url)
+
         # Ensure the directory exists
         return 'mkdir -p {1} && wget {0} -P {1} {2}'.format(opt_string,
                                                             directory, url)

--- a/test/test_annotate.py
+++ b/test/test_annotate.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Test cases for the annotate module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from hpccm.templates.annotate import annotate
+
+class Test_annotate(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    def test_no_annotations(self):
+        """No variables specified"""
+        a = annotate()
+
+        self.assertDictEqual(a.annotate_step(), {})
+
+    def test_no_base(self):
+        """Basic annotations"""
+        a = annotate(annotate=True, base_annotation=False)
+        a.add_annotation('A', 'a')
+        a.add_annotation('one', 1)
+
+        self.assertDictEqual(a.annotate_step(), {'A': 'a', 'one': '1'})
+
+    def test_default_base(self):
+        """Basic annotations"""
+        a = annotate(annotate=True, base_annotation=True)
+        a.add_annotation('A', 'a')
+        a.add_annotation('one', 1)
+
+        self.assertDictEqual(a.annotate_step(), {'hpccm.annotate.A': 'a',
+                                                 'hpccm.annotate.one': '1'})
+
+    def test_custom_base(self):
+        """Basic annotations"""
+        a = annotate(annotate=True, base_annotation='foo')
+        a.add_annotation('A', 'a')
+        a.add_annotation('one', 1)
+
+        self.assertDictEqual(a.annotate_step(), {'hpccm.foo.A': 'a',
+                                                 'hpccm.foo.one': '1'})
+
+    def test_no_annotations(self):
+        """Basic annotations"""
+        a = annotate(annotate=False)
+        a.add_annotation('A', 'a')
+        a.add_annotation('one', 1)
+
+        self.assertDictEqual(a.annotate_step(), {})
+

--- a/test/test_generic_autotools.py
+++ b/test/test_generic_autotools.py
@@ -196,3 +196,20 @@ ENV PATH=/usr/local/zeromq/bin:$PATH''')
         self.assertEqual(r,
 r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
 COPY --from=0 /usr/local/tcl /usr/local/tcl''')
+
+    @ubuntu
+    @docker
+    def test_runtime_annotate(self):
+        """Runtime"""
+        g = generic_autotools(
+            annotate=True,
+            base_annotation='tcl',
+            directory='tcl8.6.9/unix',
+            prefix='/usr/local/tcl',
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+COPY --from=0 /usr/local/tcl /usr/local/tcl
+LABEL hpccm.tcl.configure='./configure --prefix=/usr/local/tcl' \
+    hpccm.tcl.url=https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz''')

--- a/test/test_generic_build.py
+++ b/test/test_generic_build.py
@@ -110,9 +110,11 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
 
     @centos
     @docker
-    def test_environment_ldconfig(self):
+    def test_environment_ldconfig_annotate(self):
         """ldconfig and environment options"""
-        g = generic_build(branch='v0.3.6',
+        g = generic_build(annotate=True,
+                          base_annotation='openblas',
+                          branch='v0.3.6',
                           build=['make USE_OPENMP=1'],
                           devel_environment={'CPATH': '/usr/local/openblas/include:$CPATH'},
                           install=['make install PREFIX=/usr/local/openblas'],
@@ -130,14 +132,18 @@ RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch v0.3.6 http
     make install PREFIX=/usr/local/openblas && \
     echo "/usr/local/openblas/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
     rm -rf /var/tmp/OpenBLAS
-ENV CPATH=/usr/local/openblas/include:$CPATH''')
+ENV CPATH=/usr/local/openblas/include:$CPATH
+LABEL hpccm.openblas.branch=v0.3.6 \
+    hpccm.openblas.repository=https://github.com/xianyi/OpenBLAS.git''')
 
         r = g.runtime()
         self.assertEqual(r,
 r'''# https://github.com/xianyi/OpenBLAS.git
 COPY --from=0 /usr/local/openblas /usr/local/openblas
 RUN echo "/usr/local/openblas/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig
-ENV CPATH=/usr/local/openblas/include:$CPATH''')
+ENV CPATH=/usr/local/openblas/include:$CPATH
+LABEL hpccm.openblas.branch=v0.3.6 \
+    hpccm.openblas.repository=https://github.com/xianyi/OpenBLAS.git''')
 
     @ubuntu
     @docker

--- a/test/test_generic_cmake.py
+++ b/test/test_generic_cmake.py
@@ -228,3 +228,28 @@ RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch v0.8.0 --re
         self.assertEqual(r,
 r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
 COPY --from=0 /usr/local/gromacs /usr/local/gromacs''')
+
+    @ubuntu
+    @docker
+    def test_runtime_annotate(self):
+        """Runtime"""
+        g = generic_cmake(
+            annotate=True,
+            base_annotation='gromacs',
+            cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                        '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                        '-D GMX_BUILD_OWN_FFTW=ON',
+                        '-D GMX_GPU=ON',
+                        '-D GMX_MPI=OFF',
+                        '-D GMX_OPENMP=ON',
+                        '-D GMX_PREFER_STATIC_LIBS=ON',
+                        '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+            directory='gromacs-2018.2',
+            prefix='/usr/local/gromacs',
+            url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
+COPY --from=0 /usr/local/gromacs /usr/local/gromacs
+LABEL hpccm.gromacs.cmake='cmake -DCMAKE_INSTALL_PREFIX=/usr/local/gromacs -D CMAKE_BUILD_TYPE=Release -D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda -D GMX_BUILD_OWN_FFTW=ON -D GMX_GPU=ON -D GMX_MPI=OFF -D GMX_OPENMP=ON -D GMX_PREFER_STATIC_LIBS=ON -D MPIEXEC_PREFLAGS=--allow-run-as-root' \
+    hpccm.gromacs.url=https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz''')


### PR DESCRIPTION
## Pull Request Description

Adds the annotate option to most of the building blocks, e.g., `openmpi(annotate=True, ...)`.  By default annotations are disabled.  When enabled, it will add labels to the container, e.g.,

```
...
LABEL hpccm.openmpi.configure='./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs' \
    hpccm.openmpi.url=https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3rc3.tar.bz2 \
    hpccm.openmpi.version=4.0.3rc3
```

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
