### PR TITLE
bump ofed, openmpi, and ucx default versions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,10 @@
+![Python 3](https://github.com/NVIDIA/hpc-container-maker/workflows/Python%203/badge.svg)
+![Python 2](https://github.com/NVIDIA/hpc-container-maker/workflows/Python%202/badge.svg)
+![Conda](https://img.shields.io/conda/dn/conda-forge/hpccm?label=Conda%20downloads)
+![PyPI - Downloads](https://img.shields.io/pypi/dm/hpccm?label=PyPI%20downloads)
+[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/NVIDIA/hpc-container-maker.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/NVIDIA/hpc-container-maker/context:python)
+![License](https://img.shields.io/github/license/NVIDIA/hpc-container-maker)
+
 # HPC Container Maker
 
 HPC Container Maker (HPCCM - pronounced H-P-see-M) is an open source

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1241,8 +1241,8 @@ configuring.  For instance, `enable_foo=True` maps to
 Underscores in the parameter name are converted to dashes.
 
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH`, `PATH`, and others) should be modified to
-include HDF5. The default is True.
+(`CPATH`, `LD_LIBRARY_PATH`, `LIBRARY_PATH`, `PATH`, and others)
+should be modified to include HDF5. The default is True.
 
 - __ldconfig__: Boolean flag to specify whether the HDF5 library
 directory should be added dynamic linker cache.  If False, then
@@ -1296,6 +1296,7 @@ hdf5(toolchain=p.toolchain)
 hdf5(check=True, configure_opts=['--enable-cxx', '--enable-fortran',
                                  '--enable-profiling=yes'])
 ```
+
 
 ## runtime
 ```python
@@ -2173,7 +2174,7 @@ container entry point.  The default value is empty, i.e., install
 via the package manager to the standard system locations.
 
 - __version__: The version of Mellanox OFED to download.  The default
-value is `4.7-3.2.9.0`.
+value is `5.0-2.1.8.0`.
 
 __Examples__
 
@@ -2318,7 +2319,8 @@ parameter for more information.
 - __mlnx_versions__: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
 versions to install.  The default values are `3.4-2.0.0.0`,
 `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`, `4.3-1.0.1.0`,
-`4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and `4.7-3.2.9.0`.
+`4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, `4.7-3.2.9.0`, and
+`5.0-2.1.8.0`.
 
 - __ospackages__: List of OS packages to install prior to installing
 OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -2624,14 +2626,11 @@ configuring.  For instance, `enable_foo=True` maps to
 Underscores in the parameter name are converted to dashes.
 
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH` and `PATH`) should be modified to include
-NetCDF. The default is True.
+(`CPATH`, `LD_LIBRARY_PATH`, `LIBRARY_PATH` and `PATH`) should be
+modified to include NetCDF. The default is True.
 
 - __fortran__: Boolean flag to specify whether the NetCDF Fortran
 library should be installed.  The default is True.
-
-- __hdf5_dir__: Path to the location where HDF5 is installed in the
-container image.  The default value is `/usr/local/hdf5`.
 
 - __ldconfig__: Boolean flag to specify whether the NetCDF library
 directory should be added dynamic linker cache.  If False, then
@@ -2967,7 +2966,7 @@ specified by `version`.
 
 - __version__: The version of OpenMPI source to download.  This
 value is ignored if `directory` is set.  The default value is
-`4.0.3rc3`.
+`4.0.3`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -3839,7 +3838,7 @@ The default is empty, i.e., use the release package specified by
 `version`.
 
 - __version__: The version of UCX source to download.  The default value
-is `1.7.0`.
+is `1.8.0`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -76,7 +76,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     via the package manager to the standard system locations.
 
     version: The version of Mellanox OFED to download.  The default
-    value is `4.7-3.2.9.0`.
+    value is `5.0-2.1.8.0`.
 
     # Examples
 
@@ -99,7 +99,7 @@ class mlnx_ofed(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', None)
         self.__symlink = kwargs.get('symlink', False)
-        self.__version = kwargs.get('version', '4.7-3.2.9.0')
+        self.__version = kwargs.get('version', '5.0-2.1.8.0')
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/multi_ofed.py
+++ b/hpccm/building_blocks/multi_ofed.py
@@ -56,7 +56,8 @@ class multi_ofed(bb_base):
     mlnx_versions: A list of [Mellanox OpenFabrics Enterprise Distribution for Linux](http://www.mellanox.com/page/products_dyn?product_family=26)
     versions to install.  The default values are `3.4-2.0.0.0`,
     `4.0-2.0.0.1`, `4.1-1.0.2.0`, `4.2-1.2.0.0`, `4.3-1.0.1.0`,
-    `4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, and `4.7-3.2.9.0`.
+    `4.4-1.0.0.0`, `4.5-1.0.1.0`, `4.6-1.0.1.1`, `4.7-3.2.9.0`, and
+    `5.0-2.1.8.0`.
 
     ospackages: List of OS packages to install prior to installing
     OFED.  For Ubuntu, the default values are `libnl-3-200`,
@@ -93,7 +94,7 @@ class multi_ofed(bb_base):
                                            '4.1-1.0.2.0', '4.2-1.2.0.0',
                                            '4.3-1.0.1.0', '4.4-1.0.0.0',
                                            '4.5-1.0.1.0', '4.6-1.0.1.1',
-                                           '4.7-3.2.9.0'])
+                                           '4.7-3.2.9.0', '5.0-2.1.8.0'])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/ofed')
         self.__symlink = kwargs.get('symlink', False)

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -137,7 +137,7 @@ class openmpi(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     version: The version of OpenMPI source to download.  This
     value is ignored if `directory` is set.  The default value is
-    `4.0.3rc3`.
+    `4.0.3`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -198,7 +198,7 @@ class openmpi(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__runtime_ospackages = [] # Filled in by __distro()
         # Input toolchain, i.e., what to use when building
         self.__toolchain = kwargs.pop('toolchain', toolchain())
-        self.__version = kwargs.pop('version', '4.0.3rc3')
+        self.__version = kwargs.pop('version', '4.0.3')
         self.__ucx = kwargs.pop('ucx', False)
 
         # Output toolchain

--- a/hpccm/building_blocks/ucx.py
+++ b/hpccm/building_blocks/ucx.py
@@ -144,7 +144,7 @@ class ucx(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
     `version`.
 
     version: The version of UCX source to download.  The default value
-    is `1.7.0`.
+    is `1.8.0`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -206,7 +206,7 @@ class ucx(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__prefix = kwargs.pop('prefix', '/usr/local/ucx')
         self.__runtime_ospackages = [] # Filled in by __distro()
         self.__toolchain = kwargs.pop('toolchain', toolchain())
-        self.__version = kwargs.pop('version', '1.7.0')
+        self.__version = kwargs.pop('version', '1.8.0')
         self.__xpmem = kwargs.pop('xpmem', '')
 
         # Set the configure options

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -38,7 +38,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -46,7 +46,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
-    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-utils \
@@ -71,7 +71,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -79,7 +79,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
-    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-utils \
@@ -104,7 +104,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN yum install -y \
         ca-certificates \
         gnupg \
@@ -112,7 +112,7 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
     yum install -y yum-utils && \
-    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/rhel7.2/mellanox_mlnx_ofed.repo && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/rhel7.2/mellanox_mlnx_ofed.repo && \
     yum install -y \
         libibmad \
         libibmad-devel \
@@ -136,7 +136,7 @@ RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox &&
         """Default mlnx_ofed building block"""
         mofed = mlnx_ofed()
         self.assertEqual(str(mofed),
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN yum install -y \
         ca-certificates \
         gnupg \
@@ -144,7 +144,7 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox && \
     yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/rhel8.0/mellanox_mlnx_ofed.repo && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/rhel8.0/mellanox_mlnx_ofed.repo && \
     yum install -y \
         libibmad \
         libibmad-devel \
@@ -283,7 +283,7 @@ RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox &&
         mofed = mlnx_ofed()
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -291,7 +291,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add - && \
-    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/4.7-3.2.9.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-utils \
@@ -317,7 +317,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         mofed = mlnx_ofed(prefix='/opt/ofed')
         r = mofed.runtime()
         self.assertEqual(r,
-r'''# Mellanox OFED version 4.7-3.2.9.0
+r'''# Mellanox OFED version 5.0-2.1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libnl-3-200 \

--- a/test/test_openmpi.py
+++ b/test/test_openmpi.py
@@ -37,7 +37,7 @@ class Test_openmpi(unittest.TestCase):
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 4.0.3rc3
+r'''# OpenMPI version 4.0.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -50,12 +50,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3rc3.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3rc3.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.3rc3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.3rc3 /var/tmp/openmpi-4.0.3rc3.tar.bz2
+    rm -rf /var/tmp/openmpi-4.0.3 /var/tmp/openmpi-4.0.3.tar.bz2
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 
@@ -65,7 +65,7 @@ ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
         """Default openmpi building block"""
         ompi = openmpi()
         self.assertEqual(str(ompi),
-r'''# OpenMPI version 4.0.3rc3
+r'''# OpenMPI version 4.0.3
 RUN yum install -y \
         bzip2 \
         file \
@@ -77,12 +77,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3rc3.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3rc3.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/openmpi-4.0.3rc3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.3.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.3.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/openmpi-4.0.3 &&   ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-cuda --with-verbs && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/openmpi-4.0.3rc3 /var/tmp/openmpi-4.0.3rc3.tar.bz2
+    rm -rf /var/tmp/openmpi-4.0.3 /var/tmp/openmpi-4.0.3.tar.bz2
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/openmpi/bin:$PATH''')
 

--- a/test/test_ucx.py
+++ b/test/test_ucx.py
@@ -38,7 +38,7 @@ class Test_ucx(unittest.TestCase):
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.7.0
+r'''# UCX version 1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -47,12 +47,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.8.0/ucx-1.8.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.8.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.8.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.7.0 /var/tmp/ucx-1.7.0.tar.gz
+    rm -rf /var/tmp/ucx-1.8.0 /var/tmp/ucx-1.8.0.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -63,7 +63,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """Default ucx building block"""
         u = ucx()
         self.assertEqual(str(u),
-r'''# UCX version 1.7.0
+r'''# UCX version 1.8.0
 RUN yum install -y \
         binutils-devel \
         file \
@@ -71,12 +71,12 @@ RUN yum install -y \
         numactl-devel \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.8.0/ucx-1.8.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.8.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.8.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.7.0 /var/tmp/ucx-1.7.0.tar.gz
+    rm -rf /var/tmp/ucx-1.8.0 /var/tmp/ucx-1.8.0.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -88,7 +88,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         u = ucx(cuda='/cuda', gdrcopy='/gdrcopy', knem='/knem', ofed='/ofed',
                 xpmem='/xpmem')
         self.assertEqual(str(u),
-r'''# UCX version 1.7.0
+r'''# UCX version 1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -97,12 +97,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-rdmacm=/ofed --with-verbs=/ofed --with-xpmem=/xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.8.0/ucx-1.8.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.8.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.8.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/cuda --with-gdrcopy=/gdrcopy --with-knem=/knem --with-rdmacm=/ofed --with-verbs=/ofed --with-xpmem=/xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.7.0 /var/tmp/ucx-1.7.0.tar.gz
+    rm -rf /var/tmp/ucx-1.8.0 /var/tmp/ucx-1.8.0.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -113,7 +113,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with True values"""
         u = ucx(cuda=True, gdrcopy=True, knem=True, ofed=True, xpmem=True)
         self.assertEqual(str(u),
-r'''# UCX version 1.7.0
+r'''# UCX version 1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -122,12 +122,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-rdmacm --with-verbs --with-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.8.0/ucx-1.8.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.8.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.8.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-cuda=/usr/local/cuda --with-gdrcopy --with-knem --with-rdmacm --with-verbs --with-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.7.0 /var/tmp/ucx-1.7.0.tar.gz
+    rm -rf /var/tmp/ucx-1.8.0 /var/tmp/ucx-1.8.0.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 
@@ -138,7 +138,7 @@ ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
         """ucx building block with False values"""
         u = ucx(cuda=False, gdrcopy=False, knem=False, ofed=False, xpmem=False)
         self.assertEqual(str(u),
-r'''# UCX version 1.7.0
+r'''# UCX version 1.8.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         binutils-dev \
@@ -147,12 +147,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.7.0/ucx-1.7.0.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.7.0.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/ucx-1.7.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --without-cuda --without-gdrcopy --without-knem --without-rdmacm --without-verbs --without-xpmem && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.8.0/ucx-1.8.0.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.8.0.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/ucx-1.8.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --without-cuda --without-gdrcopy --without-knem --without-rdmacm --without-verbs --without-xpmem && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/ucx-1.7.0 /var/tmp/ucx-1.7.0.tar.gz
+    rm -rf /var/tmp/ucx-1.8.0 /var/tmp/ucx-1.8.0.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/ucx/bin:$PATH''')
 


### PR DESCRIPTION
## Pull Request Description

MLNX OFED: 4.7-3.2.9.0 -> 5.0-2.1.8.0
OpenMPI: 4.0.3rc3 -> 4.0.3
UCX: 1.7.0 -> 1.8.0

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
