### PR TITLE
intel_psxe: respect psxevars option during runtime

### DIFF
--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -397,5 +397,6 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
                                       ipp=self.__ipp,
                                       mkl=self.__mkl,
                                       mpi=self.__mpi,
+                                      psxevars=self.__psxevars,
                                       tbb=self.__tbb,
                                       version=self.__runtime_version))

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -136,7 +136,8 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     then the environment is set such that the environment is visible
     to both subsequent container image build steps and when the
     container image is run.  However, the environment may differ
-    slightly from that set by `compilervars.sh`.  The default value is
+    slightly from that set by `compilervars.sh`. This option will be
+    used with the `runtime` method. The default value is
     `True`.
 
     runtime_version: The version of Intel Parallel Studio XE runtime


### PR DESCRIPTION
## Pull Request Description
Hey Scott, ran into this today. Simple one-line fix to pass the option along to runtime.

When running a container without "-ti" and without calling bash, the existing method of relying on /etc/bash.bashrc to source psxevars.sh is not taken. This results in no Environment setup being taken.

P.S. I did not run pydocmd generate because it stripped a TON of formatting. Is there an additional flag/option s.t. it doesn't?
Ex) 
"- __ospackages__: List of OS"...
to
"ospackages: List of OS"...


## Author Checklist
* [ X ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ - ] Passes all unit tests
