### PR TITLE
Fix handling of upstream libs in mlnx_ofed building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2256,10 +2256,17 @@ distributions, the default values are `findutils`, `libnl3`,
 `numactl-libs`, and `wget`.
 
 - __packages__: List of packages to install from Mellanox OFED.  For
-Ubuntu, the default values are `libibverbs1`, `libibverbs-dev`,
-`libibmad`, `libibmad-devel`, `libibumad`, `libibumad-devel`,
-`libmlx4-1`, `libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`,
-`librdmacm1`, `librdmacm-dev`, and `ibverbs-utils`.  For
+version 5.0 and later on Ubuntu, `ibverbs-providers`,
+`ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad`,
+`libibumad-dev`, `libibverbs-dev` `libibverbs1`, `librdmacm-dev`,
+and `librdmacm1`. For earlier versions on Ubuntu, the default
+values are `libibverbs1`, `libibverbs-dev`, `libibmad`,
+`libibmad-devel`, `libibumad`, `libibumad-devel`, `libmlx4-1`,
+`libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`, `librdmacm1`,
+`librdmacm-dev`, and `ibverbs-utils`.  For version 5.0 and later
+on RHEL-based Linux distributions, the default values are
+`libibumad`, `libibverbs`, `libibverbs-utils`, `librdmacm`,
+`rdma-core`, and `rdma-core-devel`. For earlier versions on
 RHEL-based Linux distributions, the default values are
 `libibverbs`, `libibverbs-devel`, `libibverbs-utils`, `libibmad`,
 `libibmad-devel`, `libibumad`, `libibumad-devel`, `libmlx4`,

--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -2257,7 +2257,7 @@ distributions, the default values are `findutils`, `libnl3`,
 
 - __packages__: List of packages to install from Mellanox OFED.  For
 version 5.0 and later on Ubuntu, `ibverbs-providers`,
-`ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad`,
+`ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad3`,
 `libibumad-dev`, `libibverbs-dev` `libibverbs1`, `librdmacm-dev`,
 and `librdmacm1`. For earlier versions on Ubuntu, the default
 values are `libibverbs1`, `libibverbs-dev`, `libibmad`,

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion, StrictVersion
 import posixpath
 
 import hpccm.config
@@ -62,10 +62,17 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
     `numactl-libs`, and `wget`.
 
     packages: List of packages to install from Mellanox OFED.  For
-    Ubuntu, the default values are `libibverbs1`, `libibverbs-dev`,
-    `libibmad`, `libibmad-devel`, `libibumad`, `libibumad-devel`,
-    `libmlx4-1`, `libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`,
-    `librdmacm1`, `librdmacm-dev`, and `ibverbs-utils`.  For
+    version 5.0 and later on Ubuntu, `ibverbs-providers`,
+    `ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad`,
+    `libibumad-dev`, `libibverbs-dev` `libibverbs1`, `librdmacm-dev`,
+    and `librdmacm1`. For earlier versions on Ubuntu, the default
+    values are `libibverbs1`, `libibverbs-dev`, `libibmad`,
+    `libibmad-devel`, `libibumad`, `libibumad-devel`, `libmlx4-1`,
+    `libmlx4-dev`, `libmlx5-1`, `libmlx5-dev`, `librdmacm1`,
+    `librdmacm-dev`, and `ibverbs-utils`.  For version 5.0 and later
+    on RHEL-based Linux distributions, the default values are
+    `libibumad`, `libibverbs`, `libibverbs-utils`, `librdmacm`,
+    `rdma-core`, and `rdma-core-devel`. For earlier versions on
     RHEL-based Linux distributions, the default values are
     `libibverbs`, `libibverbs-devel`, `libibverbs-utils`, `libibmad`,
     `libibmad-devel`, `libibumad`, `libibumad-devel`, `libmlx4`,
@@ -167,13 +174,22 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
                     self.__oslabel = 'ubuntu16.04'
 
             if not self.__packages:
-                self.__packages = ['libibverbs1', 'libibverbs-dev',
-                                   'ibverbs-utils',
-                                   'libibmad',  'libibmad-devel',
-                                   'libibumad', 'libibumad-devel',
-                                   'libmlx4-1', 'libmlx4-dev',
-                                   'libmlx5-1', 'libmlx5-dev',
-                                   'librdmacm-dev', 'librdmacm1']
+                if LooseVersion(self.__version) >= LooseVersion('5.0'):
+                    # Uses UPSTREAM libs
+                    self.__packages = ['libibverbs1', 'libibverbs-dev',
+                                       'ibverbs-providers', 'ibverbs-utils',
+                                       'libibmad5',  'libibmad-dev',
+                                       'libibumad', 'libibumad-dev',
+                                       'librdmacm-dev', 'librdmacm1']
+                else:
+                    # Uses MLNX_OFED libs
+                    self.__packages = ['libibverbs1', 'libibverbs-dev',
+                                       'ibverbs-utils',
+                                       'libibmad',  'libibmad-devel',
+                                       'libibumad', 'libibumad-devel',
+                                       'libmlx4-1', 'libmlx4-dev',
+                                       'libmlx5-1', 'libmlx5-dev',
+                                       'librdmacm-dev', 'librdmacm1']
 
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if hpccm.config.g_linux_version >= StrictVersion('8.0'):
@@ -191,13 +207,20 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
                         self.__oslabel = 'rhel7.2'
 
             if not self.__packages:
-                self.__packages = ['libibverbs', 'libibverbs-devel',
-                                   'libibverbs-utils',
-                                   'libibmad', 'libibmad-devel',
-                                   'libibumad', 'libibumad-devel',
-                                   'libmlx4', 'libmlx4-devel',
-                                   'libmlx5', 'libmlx5-devel',
-                                   'librdmacm-devel', 'librdmacm']
+                if LooseVersion(self.__version) >= LooseVersion('5.0'):
+                    # Uses UPSTREAM libs
+                    self.__packages = ['libibverbs', 'libibverbs-utils',
+                                       'libibumad', 'librdmacm',
+                                       'rdma-core', 'rdma-core-devel']
+                else:
+                    # Uses MLNX_OFED libs
+                    self.__packages = ['libibverbs', 'libibverbs-devel',
+                                       'libibverbs-utils',
+                                       'libibmad', 'libibmad-devel',
+                                       'libibumad', 'libibumad-devel',
+                                       'libmlx4', 'libmlx4-devel',
+                                       'libmlx5', 'libmlx5-devel',
+                                       'librdmacm-devel', 'librdmacm']
 
         else: # pragma: no cover
             raise RuntimeError('Unknown Linux distribution')

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -63,7 +63,7 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
 
     packages: List of packages to install from Mellanox OFED.  For
     version 5.0 and later on Ubuntu, `ibverbs-providers`,
-    `ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad`,
+    `ibverbs-utils` `libibmad-dev`, `libibmad5`, `libibumad3`,
     `libibumad-dev`, `libibverbs-dev` `libibverbs1`, `librdmacm-dev`,
     and `librdmacm1`. For earlier versions on Ubuntu, the default
     values are `libibverbs1`, `libibverbs-dev`, `libibmad`,
@@ -179,7 +179,7 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
                     self.__packages = ['libibverbs1', 'libibverbs-dev',
                                        'ibverbs-providers', 'ibverbs-utils',
                                        'libibmad5',  'libibmad-dev',
-                                       'libibumad', 'libibumad-dev',
+                                       'libibumad3', 'libibumad-dev',
                                        'librdmacm-dev', 'librdmacm1']
                 else:
                     # Uses MLNX_OFED libs

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -53,8 +53,8 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         ibverbs-utils \
         libibmad-dev \
         libibmad5 \
-        libibumad \
         libibumad-dev \
+        libibumad3 \
         libibverbs-dev \
         libibverbs1 \
         librdmacm-dev \
@@ -83,8 +83,8 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         ibverbs-utils \
         libibmad-dev \
         libibmad5 \
-        libibumad \
         libibumad-dev \
+        libibumad3 \
         libibverbs-dev \
         libibverbs1 \
         librdmacm-dev \
@@ -278,8 +278,8 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
         ibverbs-utils \
         libibmad-dev \
         libibmad5 \
-        libibumad \
         libibumad-dev \
+        libibumad3 \
         libibverbs-dev \
         libibverbs1 \
         librdmacm-dev \

--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -49,17 +49,14 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-providers \
         ibverbs-utils \
-        libibmad \
-        libibmad-devel \
+        libibmad-dev \
+        libibmad5 \
         libibumad \
-        libibumad-devel \
+        libibumad-dev \
         libibverbs-dev \
         libibverbs1 \
-        libmlx4-1 \
-        libmlx4-dev \
-        libmlx5-1 \
-        libmlx5-dev \
         librdmacm-dev \
         librdmacm1 && \
     rm -rf /var/lib/apt/lists/*''')
@@ -82,17 +79,14 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu18.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-providers \
         ibverbs-utils \
-        libibmad \
-        libibmad-devel \
+        libibmad-dev \
+        libibmad5 \
         libibumad \
-        libibumad-devel \
+        libibumad-dev \
         libibverbs-dev \
         libibverbs1 \
-        libmlx4-1 \
-        libmlx4-dev \
-        libmlx5-1 \
-        libmlx5-dev \
         librdmacm-dev \
         librdmacm1 && \
     rm -rf /var/lib/apt/lists/*''')
@@ -114,19 +108,12 @@ RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox &&
     yum install -y yum-utils && \
     yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/rhel7.2/mellanox_mlnx_ofed.repo && \
     yum install -y \
-        libibmad \
-        libibmad-devel \
         libibumad \
-        libibumad-devel \
         libibverbs \
-        libibverbs-devel \
         libibverbs-utils \
-        libmlx4 \
-        libmlx4-devel \
-        libmlx5 \
-        libmlx5-devel \
         librdmacm \
-        librdmacm-devel && \
+        rdma-core \
+        rdma-core-devel && \
     rm -rf /var/cache/yum/*''')
 
     @x86_64
@@ -146,19 +133,12 @@ RUN rpm --import https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox &&
     yum install -y dnf-utils && \
     yum-config-manager --add-repo https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/rhel8.0/mellanox_mlnx_ofed.repo && \
     yum install -y \
-        libibmad \
-        libibmad-devel \
         libibumad \
-        libibumad-devel \
         libibverbs \
-        libibverbs-devel \
         libibverbs-utils \
-        libmlx4 \
-        libmlx4-devel \
-        libmlx5 \
-        libmlx5-devel \
         librdmacm \
-        librdmacm-devel && \
+        rdma-core \
+        rdma-core-devel && \
     rm -rf /var/cache/yum/*''')
 
     @x86_64
@@ -294,17 +274,14 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.0-2.1.8.0/ubuntu16.04/mellanox_mlnx_ofed.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ibverbs-providers \
         ibverbs-utils \
-        libibmad \
-        libibmad-devel \
+        libibmad-dev \
+        libibmad5 \
         libibumad \
-        libibumad-devel \
+        libibumad-dev \
         libibverbs-dev \
         libibverbs1 \
-        libmlx4-1 \
-        libmlx4-dev \
-        libmlx5-1 \
-        libmlx5-dev \
         librdmacm-dev \
         librdmacm1 && \
     rm -rf /var/lib/apt/lists/*''')


### PR DESCRIPTION
## Pull Request Description

The Mellanox apt / yum repositories switched to the UPSTREAM libs starting with 5.0 instead of the MLNX_OFED libs.  Update the `mlnx_ofed` building block to match.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
