### PR TITLE
Fix issue with duplicate apt repos in multi_ofed building block

### DIFF
--- a/test/test_mlnx_ofed.py
+++ b/test/test_mlnx_ofed.py
@@ -199,6 +199,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /opt/ofed && \
     find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /opt/ofed \; && \
     rm -rf /var/tmp/packages_download && \
+    rm -f /etc/apt/sources.list.d/mellanox_mlnx_ofed.list && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /etc/libibverbs.d''')
 

--- a/test/test_multi_ofed.py
+++ b/test/test_multi_ofed.py
@@ -70,6 +70,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /usr/local/ofed/4.5-1.0.1.0 && \
     find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /usr/local/ofed/4.5-1.0.1.0 \; && \
     rm -rf /var/tmp/packages_download && \
+    rm -f /etc/apt/sources.list.d/mellanox_mlnx_ofed.list && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /etc/libibverbs.d
 # Mellanox OFED version 4.6-1.0.1.1
@@ -103,6 +104,7 @@ RUN wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | ap
     mkdir -p /usr/local/ofed/4.6-1.0.1.1 && \
     find /var/tmp/packages_download -regextype posix-extended -type f -regex "/var/tmp/packages_download/(ibverbs-utils|libibmad|libibmad-devel|libibumad|libibumad-devel|libibverbs-dev|libibverbs1|libmlx4-1|libmlx4-dev|libmlx5-1|libmlx5-dev|librdmacm-dev|librdmacm1).*deb" -exec dpkg --extract {} /usr/local/ofed/4.6-1.0.1.1 \; && \
     rm -rf /var/tmp/packages_download && \
+    rm -f /etc/apt/sources.list.d/mellanox_mlnx_ofed.list && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /etc/libibverbs.d
 # OFED


### PR DESCRIPTION
## Pull Request Description

When using the `multi_ofed` building block to install multiple versions from the Mellanox apt repositories, the repo config file was not getting updated for subsequent versions.  Remove the repo config file after downloading each set of packages.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
