### PR TITLE
Update Kokkos building block to use cmake and add repository parameters

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1943,52 +1943,72 @@ kokkos(self, **kwargs)
 The `kokkos` building block downloads and installs the
 [Kokkos](https://github.com/kokkos/kokkos) component.
 
+The [CMake](#cmake) building block should be installed prior to
+this building block.
+
 __Parameters__
 
 
 - __annotate__: Boolean flag to specify whether to include annotations
 (labels).  The default is False.
 
-- __arch__: Flag to set the target architecture. If set adds
-`--arch=value` to the list of `generate_makefile.bash` options.
-The default value is `Pascal60`, i.e., sm_60.  If a cuda aware
-build is not selected, then a non-default value should be used.
+- __arch__: List of target architectures to build. If set adds
+`-DKokkos_ARCH_<value>=ON` to the list of CMake options. The
+default value is `VOLTA70`, i.e., sm_70.  If a CUDA aware build is
+not selected, then a non-default value should be used.
+
+- __branch__: The git branch to clone.  Only recognized if the
+`repository` parameter is specified.  The default is empty, i.e.,
+use the default branch for the repository.
+
+- __check__: Boolean flag to specify whether the build should be
+checked.  If True, adds `-DKokkos_ENABLE_TESTS=ON` to the list of
+CMake options. The default is False.
+
+- __cmake_opts__: List of options to pass to `cmake`.  The default is
+`-DCMAKE_BUILD_TYPE=RELEASE`.
+
+- __commit__: The git commit to clone.  Only recognized if the
+`repository` parameter is specified.  The default is empty, i.e.,
+use the latest commit on the default branch for the repository.
 
 - __cuda__: Flag to control whether a CUDA aware build is performed.  If
-True, adds `--with-cuda` to the list of `generate_makefile.bash`
-options.  If a string, uses the value of the string as the CUDA
-path.  If False, does nothing.  The default value is True.
+True, adds `-DKokkos_ENABLE_CUDA=ON` and
+`-DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper` to the list of
+CMake options.  The default value is True.
 
 - __environment__: Boolean flag to specify whether the environment
 (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
 Kokkos. The default is True.
 
 - __hwloc__: Flag to control whether a hwloc aware build is performed.
-If True, adds `--with-hwloc` to the list of
-`generate_makefile.bash` options.  If a string, uses the value of
-the string as the hwloc path.  If False, does nothing.  The
-default value is True.
-
-- __opts__: List of options to pass to `generate_makefile.bash`.  The
-default is an empty list.
+If True, adds `-DKokkos_ENABLE_HWLOC=ON` to the list of CMake
+options. The default value is True.
 
 - __ospackages__: List of OS packages to install prior to building.  For
-Ubuntu, the default values are `bc`, `gzip`, `libhwloc-dev`,
-`make`, `tar`, and `wget`.  For RHEL-based Linux distributions the
-default values are `bc`, `gzip`, `hwloc-devel`, `make`, `tar`,
-`wget`, and `which`.
+Ubuntu, the default values are `gzip`, `libhwloc-dev`, `make`,
+`tar`, and `wget`.  For RHEL-based Linux distributions the default
+values are `gzip`, `hwloc-devel`, `make`, `tar`, and `wget`.
 
 - __prefix__: The top level installation location.  The default value
 is `/usr/local/kokkos`.
 
+- __repository__: The location of the git repository that should be used to build OpenMPI.  If True, then use the default `https://github.com/kokkos/kokkos.git`
+repository.  The default is empty, i.e., use the release package
+specified by `version`.
+
+- __url__: The location of the tarball that should be used to build
+Kokkos.  The default is empty, i.e., use the release package
+specified by `version`.
+
 - __version__: The version of Kokkos source to download.  The default
-value is `2.9.00`.
+value is `3.1.01`.
 
 __Examples__
 
 
 ```python
-kokkos(prefix='/opt/kokkos/2.8.00', version='2.8.00')
+kokkos(prefix='/opt/kokkos/3.1.01', version='3.1.01')
 ```
 
 

--- a/hpccm/building_blocks/kokkos.py
+++ b/hpccm/building_blocks/kokkos.py
@@ -26,62 +26,83 @@ from six import string_types
 from distutils.version import StrictVersion
 
 import hpccm.config
+import hpccm.templates.downloader
 import hpccm.templates.envvars
 
 from hpccm.building_blocks.base import bb_base
-from hpccm.building_blocks.generic_build import generic_build
+from hpccm.building_blocks.generic_cmake import generic_cmake
 from hpccm.building_blocks.packages import packages
 from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
 
-class kokkos(bb_base, hpccm.templates.envvars):
+class kokkos(bb_base, hpccm.templates.downloader, hpccm.templates.envvars):
     """The `kokkos` building block downloads and installs the
     [Kokkos](https://github.com/kokkos/kokkos) component.
+
+    The [CMake](#cmake) building block should be installed prior to
+    this building block.
 
     # Parameters
 
     annotate: Boolean flag to specify whether to include annotations
     (labels).  The default is False.
 
-    arch: Flag to set the target architecture. If set adds
-    `--arch=value` to the list of `generate_makefile.bash` options.
-    The default value is `Pascal60`, i.e., sm_60.  If a cuda aware
-    build is not selected, then a non-default value should be used.
+    arch: List of target architectures to build. If set adds
+    `-DKokkos_ARCH_<value>=ON` to the list of CMake options. The
+    default value is `VOLTA70`, i.e., sm_70.  If a CUDA aware build is
+    not selected, then a non-default value should be used.
+
+    branch: The git branch to clone.  Only recognized if the
+    `repository` parameter is specified.  The default is empty, i.e.,
+    use the default branch for the repository.
+
+    check: Boolean flag to specify whether the build should be
+    checked.  If True, adds `-DKokkos_ENABLE_TESTS=ON` to the list of
+    CMake options. The default is False.
+
+    cmake_opts: List of options to pass to `cmake`.  The default is
+    `-DCMAKE_BUILD_TYPE=RELEASE`.
+
+    commit: The git commit to clone.  Only recognized if the
+    `repository` parameter is specified.  The default is empty, i.e.,
+    use the latest commit on the default branch for the repository.
 
     cuda: Flag to control whether a CUDA aware build is performed.  If
-    True, adds `--with-cuda` to the list of `generate_makefile.bash`
-    options.  If a string, uses the value of the string as the CUDA
-    path.  If False, does nothing.  The default value is True.
+    True, adds `-DKokkos_ENABLE_CUDA=ON` and
+    `-DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper` to the list of
+    CMake options.  The default value is True.
 
     environment: Boolean flag to specify whether the environment
     (`LD_LIBRARY_PATH` and `PATH`) should be modified to include
     Kokkos. The default is True.
 
     hwloc: Flag to control whether a hwloc aware build is performed.
-    If True, adds `--with-hwloc` to the list of
-    `generate_makefile.bash` options.  If a string, uses the value of
-    the string as the hwloc path.  If False, does nothing.  The
-    default value is True.
-
-    opts: List of options to pass to `generate_makefile.bash`.  The
-    default is an empty list.
+    If True, adds `-DKokkos_ENABLE_HWLOC=ON` to the list of CMake
+    options. The default value is True.
 
     ospackages: List of OS packages to install prior to building.  For
-    Ubuntu, the default values are `bc`, `gzip`, `libhwloc-dev`,
-    `make`, `tar`, and `wget`.  For RHEL-based Linux distributions the
-    default values are `bc`, `gzip`, `hwloc-devel`, `make`, `tar`,
-    `wget`, and `which`.
+    Ubuntu, the default values are `gzip`, `libhwloc-dev`, `make`,
+    `tar`, and `wget`.  For RHEL-based Linux distributions the default
+    values are `gzip`, `hwloc-devel`, `make`, `tar`, and `wget`.
 
     prefix: The top level installation location.  The default value
     is `/usr/local/kokkos`.
 
+    repository: The location of the git repository that should be used to build OpenMPI.  If True, then use the default `https://github.com/kokkos/kokkos.git`
+    repository.  The default is empty, i.e., use the release package
+    specified by `version`.
+
+    url: The location of the tarball that should be used to build
+    Kokkos.  The default is empty, i.e., use the release package
+    specified by `version`.
+
     version: The version of Kokkos source to download.  The default
-    value is `2.9.00`.
+    value is `3.1.01`.
 
     # Examples
 
     ```python
-    kokkos(prefix='/opt/kokkos/2.8.00', version='2.8.00')
+    kokkos(prefix='/opt/kokkos/3.1.01', version='3.1.01')
     ```
 
     """
@@ -91,46 +112,51 @@ class kokkos(bb_base, hpccm.templates.envvars):
 
         super(kokkos, self).__init__(**kwargs)
 
-        self.__arch = kwargs.pop('arch', 'Pascal60')
+        self.__arch = kwargs.pop('arch', ['VOLTA70'])
         self.__baseurl = kwargs.pop('baseurl',
                                     'https://github.com/kokkos/kokkos/archive')
-        self.__bootstrap_opts = kwargs.pop('bootstrap_opts', [])
+        self.__check = kwargs.pop('check', False)
+        self.__cmake_opts = kwargs.pop('cmake_opts',
+                                       ['-DCMAKE_BUILD_TYPE=RELEASE'])
         self.__cuda = kwargs.pop('cuda', True)
+        self.__default_repository = 'https://github.com/kokkos/kokkos.git'
         self.__hwloc = kwargs.pop('hwloc', True)
-        self.__opts = kwargs.pop('opts', [])
         self.__ospackages = kwargs.pop('ospackages', [])
-        self.__parallel = kwargs.pop('parallel', '$(nproc)')
         self.__powertools = False # enable the CentOS PowerTools repo
         self.__prefix = kwargs.pop('prefix', '/usr/local/kokkos')
-        self.__version = kwargs.pop('version', '2.9.00')
+        self.__version = kwargs.pop('version', '3.1.01')
 
-        # Set the makefile generator options
-        self.__generate()
+        if self.repository:
+            self.__directory = ''
+        else:
+            self.__directory = kwargs.pop('directory',
+                                          'kokkos-{}'.format(self.__version))
+
+        # Set the CMake options
+        self.__cmake()
 
         # Set the Linux distribution specific parameters
         self.__distro()
+
+        # Set the download specific parameters
+        self.__download()
+        kwargs['repository'] = self.repository
+        kwargs['url'] = self.url
 
         # Setup the environment variables
         self.environment_variables['PATH'] = '{}/bin:$PATH'.format(
             self.__prefix)
 
         # Setup build configuration
-        self.__bb = generic_build(
+        self.__bb = generic_cmake(
             annotations={'version': self.__version},
             base_annotation=self.__class__.__name__,
-            build=['mkdir build',
-                   'cd build',
-                   '../generate_makefile.bash {}'.format(
-                       ' '.join(self.__opts)),
-                   'make kokkoslib -j{}'.format(self.__parallel)],
+            cmake_opts=self.__cmake_opts,
             comment=False,
             devel_environment=self.environment_variables,
-            directory='kokkos-{}'.format(self.__version),
-            install=['cd build',
-                     'make install -j{}'.format(self.__parallel)],
+            directory=self.__directory,
             prefix=self.__prefix,
             runtime_environment=self.environment_variables,
-            url='{0}/{1}.tar.gz'.format(self.__baseurl, self.__version),
             **kwargs)
 
         # Container instructions
@@ -139,18 +165,36 @@ class kokkos(bb_base, hpccm.templates.envvars):
                          powertools=self.__powertools)
         self += self.__bb
 
+    def __cmake(self):
+        """Set CMake options based on user input"""
+
+        # Set options
+        if self.__arch:
+            for arch in self.__arch:
+                self.__cmake_opts.append('-DKokkos_ARCH_{}=ON'.format(
+                    arch.upper()))
+
+        if self.__check:
+            self.__cmake_opts.append('-DKokkos_ENABLE_TESTS=ON')
+
+        if self.__cuda:
+            self.__cmake_opts.append('-DKokkos_ENABLE_CUDA=ON')
+            self.__cmake_opts.append(
+                '-DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper')
+        if self.__hwloc:
+            self.__cmake_opts.append('-DKokkos_ENABLE_HWLOC=ON')
+
     def __distro(self):
         """Based on the Linux distribution, set values accordingly.  A user
         specified value overrides any defaults."""
 
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
-                self.__ospackages = ['bc', 'gzip', 'libhwloc-dev', 'make',
-                                     'tar', 'wget']
+                self.__ospackages = ['libhwloc-dev', 'make']
+
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
-                self.__ospackages = ['bc', 'gzip', 'hwloc-devel', 'make',
-                                     'tar', 'wget', 'which']
+                self.__ospackages = ['hwloc-devel', 'make']
 
             if hpccm.config.g_linux_version >= StrictVersion('8.0'):
                 # hwloc-devel is in the CentOS powertools repository
@@ -158,30 +202,20 @@ class kokkos(bb_base, hpccm.templates.envvars):
         else: # pragma: no cover
             raise RuntimeError('Unknown Linux distribution')
 
-    def __generate(self):
-        """Setup makefile generator options based on user parameters"""
+        if self.repository:
+            self.__ospackages.extend(['ca-certificates', 'git'])
+        else:
+            self.__ospackages.extend(['gzip', 'tar', 'wget'])
 
-        # Set options
-        if self.__arch:
-            self.__opts.append('--arch={}'.format(self.__arch))
-        if self.__cuda:
-            if isinstance(self.__cuda, string_types):
-                # Use specified path
-                self.__opts.append(
-                    '--with-cuda={}'.format(self.__cuda))
-            else:
-                # Let it figure it out
-                self.__opts.append('--with-cuda')
-        if self.__hwloc:
-            if isinstance(self.__hwloc, string_types):
-                # Use specified path
-                self.__opts.append(
-                    '--with-hwloc={}'.format(self.__hwloc))
-            else:
-                # Let it figure it out
-                self.__opts.append('--with-hwloc')
-        if self.__prefix:
-            self.__opts.append('--prefix={}'.format(self.__prefix))
+    def __download(self):
+        """Set download source based on user parameters"""
+
+        # Use the default repository if set to True
+        if self.repository is True:
+            self.repository = self.__default_repository
+
+        if not self.repository and not self.url:
+            self.url='{0}/{1}.tar.gz'.format(self.__baseurl, self.__version)
 
     def runtime(self, _from='0'):
         """Generate the set of instructions to install the runtime specific

--- a/test/test_kokkos.py
+++ b/test/test_kokkos.py
@@ -37,28 +37,21 @@ class Test_kokkos(unittest.TestCase):
         """Default kokkos building block"""
         k = kokkos()
         self.assertEqual(str(k),
-r'''# Kokkos version 2.9.00
+r'''# Kokkos version 3.1.01
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bc \
         gzip \
         libhwloc-dev \
         make \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.9.00.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.9.00.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    mkdir build && \
-    cd build && \
-    ../generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
-    make kokkoslib -j$(nproc) && \
-    mkdir -p /usr/local/kokkos && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    cd build && \
-    make install -j$(nproc) && \
-    rm -rf /var/tmp/kokkos-2.9.00 /var/tmp/2.9.00.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/3.1.01.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/kokkos-3.1.01/build && cd /var/tmp/kokkos-3.1.01/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos -DCMAKE_BUILD_TYPE=RELEASE -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA=ON -DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper -DKokkos_ENABLE_HWLOC=ON /var/tmp/kokkos-3.1.01 && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/kokkos-3.1.01 /var/tmp/3.1.01.tar.gz
 ENV PATH=/usr/local/kokkos/bin:$PATH''')
 
     @centos
@@ -67,28 +60,20 @@ ENV PATH=/usr/local/kokkos/bin:$PATH''')
         """Default kokkos building block"""
         k = kokkos()
         self.assertEqual(str(k),
-r'''# Kokkos version 2.9.00
+r'''# Kokkos version 3.1.01
 RUN yum install -y \
-        bc \
         gzip \
         hwloc-devel \
         make \
         tar \
-        wget \
-        which && \
+        wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.9.00.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.9.00.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    mkdir build && \
-    cd build && \
-    ../generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
-    make kokkoslib -j$(nproc) && \
-    mkdir -p /usr/local/kokkos && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    cd build && \
-    make install -j$(nproc) && \
-    rm -rf /var/tmp/kokkos-2.9.00 /var/tmp/2.9.00.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/3.1.01.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/kokkos-3.1.01/build && cd /var/tmp/kokkos-3.1.01/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos -DCMAKE_BUILD_TYPE=RELEASE -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA=ON -DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper -DKokkos_ENABLE_HWLOC=ON /var/tmp/kokkos-3.1.01 && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/kokkos-3.1.01 /var/tmp/3.1.01.tar.gz
 ENV PATH=/usr/local/kokkos/bin:$PATH''')
 
     @centos8
@@ -97,30 +82,43 @@ ENV PATH=/usr/local/kokkos/bin:$PATH''')
         """Default kokkos building block"""
         k = kokkos()
         self.assertEqual(str(k),
-r'''# Kokkos version 2.9.00
+r'''# Kokkos version 3.1.01
 RUN yum install -y dnf-utils && \
     yum-config-manager --set-enabled PowerTools && \
     yum install -y \
-        bc \
         gzip \
         hwloc-devel \
         make \
         tar \
-        wget \
-        which && \
+        wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/2.9.00.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.9.00.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    mkdir build && \
-    cd build && \
-    ../generate_makefile.bash --arch=Pascal60 --with-cuda --with-hwloc --prefix=/usr/local/kokkos && \
-    make kokkoslib -j$(nproc) && \
-    mkdir -p /usr/local/kokkos && \
-    cd /var/tmp/kokkos-2.9.00 && \
-    cd build && \
-    make install -j$(nproc) && \
-    rm -rf /var/tmp/kokkos-2.9.00 /var/tmp/2.9.00.tar.gz
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/kokkos/kokkos/archive/3.1.01.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/3.1.01.tar.gz -C /var/tmp -z && \
+    mkdir -p /var/tmp/kokkos-3.1.01/build && cd /var/tmp/kokkos-3.1.01/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos -DCMAKE_BUILD_TYPE=RELEASE -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_CUDA=ON -DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper -DKokkos_ENABLE_HWLOC=ON /var/tmp/kokkos-3.1.01 && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/kokkos-3.1.01/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/kokkos-3.1.01 /var/tmp/3.1.01.tar.gz
+ENV PATH=/usr/local/kokkos/bin:$PATH''')
+
+    @ubuntu
+    @docker
+    def test_check_and_repository(self):
+        """Check and repository options"""
+        k = kokkos(check=True, repository=True)
+        self.assertEqual(str(k),
+r'''# Kokkos version 3.1.01
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        libhwloc-dev \
+        make && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 https://github.com/kokkos/kokkos.git kokkos && cd - && \
+    mkdir -p /var/tmp/kokkos/build && cd /var/tmp/kokkos/build && cmake -DCMAKE_INSTALL_PREFIX=/usr/local/kokkos -DCMAKE_BUILD_TYPE=RELEASE -DKokkos_ARCH_VOLTA70=ON -DKokkos_ENABLE_TESTS=ON -DKokkos_ENABLE_CUDA=ON -DCMAKE_CXX_COMPILER=$(pwd)/../bin/nvcc_wrapper -DKokkos_ENABLE_HWLOC=ON /var/tmp/kokkos && \
+    cmake --build /var/tmp/kokkos/build --target all -- -j$(nproc) && \
+    cmake --build /var/tmp/kokkos/build --target install -- -j$(nproc) && \
+    rm -rf /var/tmp/kokkos
 ENV PATH=/usr/local/kokkos/bin:$PATH''')
 
     @ubuntu


### PR DESCRIPTION
## Pull Request Description

Alternative implementation of #273 that uses the `generic_cmake` building block.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
