### PR TITLE
Add ability to download NVSHMEM

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3060,6 +3060,9 @@ __Parameters__
 build context. The default value is empty. Either this parameter
 or `package` must be specified.
 
+- __cuda__: Flag to specify the path to the CUDA installation.  The
+default is `/usr/local/cuda`.
+
 - __environment__: Boolean flag to specify whether the environment
 (`CPATH`, `LIBRARY_PATH`, and `PATH`) should be modified to
 include NVSHMEM. The default is True.
@@ -3090,8 +3093,15 @@ context. The default value is empty. Either this parameter or
 - __shmem__: Flag to specify the path to the SHMEM installation.  The
 default is empty, i.e., do not build NVSHMEM with SHMEM support.
 
+- __version__: The version of NVSHMEM source to download.  The default
+value is `1.0.1-0`.
+
 __Examples__
 
+
+```python
+nvshmem(mpi='/usr/local/openmpi', version='1.0.1-0')
+```
 
 ```python
 nvshmem(binary_tarball='nvshmem_0.4.1-0+cuda10_x86_64.txz')

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -242,6 +242,10 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
                 self.src_directory = posixpath.join(self.__wd,
                                                     self.__directory)
 
+        # sanity check
+        if not self.src_directory:
+            raise RuntimeError('source directory is not defined')
+
         # Preconfigure setup
         if self.__preconfigure:
             # Assume the preconfigure commands should be run from the

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -182,6 +182,10 @@ class generic_build(bb_base, hpccm.templates.annotate,
                 self.src_directory = posixpath.join(self.__wd,
                                                     self.__directory)
 
+        # sanity check
+        if not self.src_directory:
+            raise RuntimeError('source directory is not defined')
+
         # Build
         if self.__build:
             self.__commands.append('cd {}'.format(self.src_directory))

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -241,6 +241,10 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
                 self.src_directory = posixpath.join(self.__wd,
                                                     self.__directory)
 
+        # sanity check
+        if not self.src_directory:
+            raise RuntimeError('source directory is not defined')
+
         # Preconfigure setup
         if self.__preconfigure:
             # Assume the preconfigure commands should be run from the

--- a/test/test_downloader.py
+++ b/test/test_downloader.py
@@ -71,11 +71,21 @@ r'''mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://m
 mkdir -p /var/tmp && tar -x -f /var/tmp/foo.tgz -C /var/tmp -z''')
         self.assertEqual(d.src_directory, '/var/tmp/foo')
 
+    @docker
     def test_bad_url(self):
-        """Unrecognized package format"""
+        """Unrecognized package format, assumes tar can figure it out"""
+        d = downloader(url='http://mysite.com/foo.Z')
+        self.assertEqual(d.download_step(),
+r'''mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://mysite.com/foo.Z && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/foo.Z -C /var/tmp''')
+        self.assertEqual(d.src_directory, None)
+
+    @docker
+    def test_bad_url_noallow(self):
+        """Unrecognzied package format"""
         d = downloader(url='http://mysite.com/foo.Z')
         with self.assertRaises(RuntimeError):
-            d.download_step()
+            d.download_step(allow_unknown_filetype=False)
 
     @docker
     def test_basic_git(self):

--- a/test/test_nvshmem.py
+++ b/test/test_nvshmem.py
@@ -33,6 +33,27 @@ class Test_nvshmem(unittest.TestCase):
 
     @ubuntu
     @docker
+    def test_defaults_ubuntu(self):
+        """nvshmem defaults"""
+        n = nvshmem()
+        self.assertEqual(str(n),
+r'''# NVSHMEM 1.0.1-0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.nvidia.com/nvshmem-src-101-0 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem-src-101-0 -C /var/tmp && \
+    cd /var/tmp/nvshmem_src_1.0.1-0 && \
+    CUDA_HOME=/usr/local/cuda NVSHMEM_PREFIX=/usr/local/nvshmem make -j$(nproc) install && \
+    rm -rf /var/tmp/nvshmem_src_1.0.1-0 /var/tmp/nvshmem-src-101-0
+ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
+    PATH=/usr/local/nvshmem/bin:$PATH''')
+
+    @ubuntu
+    @docker
     def test_binary_tarball_ubuntu(self):
         """nvshmem binary tarball"""
         n = nvshmem(binary_tarball='nvshmem_0.4.1-0+cuda10_x86_64.txz')
@@ -83,7 +104,7 @@ RUN apt-get update -y && \
 COPY nvshmem-0.3.2EA.tar.gz /var/tmp/nvshmem-0.3.2EA.tar.gz
 RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem-0.3.2EA.tar.gz -C /var/tmp -z && \
     cd /var/tmp/nvshmem-0.3.2EA && \
-    NVSHMEM_PREFIX=/usr/local/nvshmem make -j$(nproc) install && \
+    CUDA_HOME=/usr/local/cuda NVSHMEM_PREFIX=/usr/local/nvshmem make -j$(nproc) install && \
     rm -rf /var/tmp/nvshmem-0.3.2EA /var/tmp/nvshmem-0.3.2EA.tar.gz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
@@ -110,7 +131,7 @@ RUN yum install -y \
 COPY nvshmem-0.3.2EA.tar.gz /var/tmp/nvshmem-0.3.2EA.tar.gz
 RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem-0.3.2EA.tar.gz -C /var/tmp -z && \
     cd /var/tmp/nvshmem-0.3.2EA && \
-    GDRCOPY_HOME=/usr/local/gdrcopy MPI_HOME=/usr/local/openmpi NVCC_GENCODE=-gencode=arch=compute_70,code=sm_70 NVSHMEM_MPI_SUPPORT=1 NVSHMEM_PREFIX=/usr/local/nvshmem NVSHMEM_SHMEM_SUPPORT=1 NVSHMEM_VERBOSE=1 SHMEM_HOME=/usr/local/openmpi make -j$(nproc) install && \
+    CUDA_HOME=/usr/local/cuda GDRCOPY_HOME=/usr/local/gdrcopy MPI_HOME=/usr/local/openmpi NVCC_GENCODE=-gencode=arch=compute_70,code=sm_70 NVSHMEM_MPI_SUPPORT=1 NVSHMEM_PREFIX=/usr/local/nvshmem NVSHMEM_SHMEM_SUPPORT=1 NVSHMEM_VERBOSE=1 SHMEM_HOME=/usr/local/openmpi make -j$(nproc) install && \
     ./scripts/install_hydra.sh /var/tmp /usr/local/nvshmem && \
     rm -rf /var/tmp/nvshmem-0.3.2EA /var/tmp/nvshmem-0.3.2EA.tar.gz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \


### PR DESCRIPTION
## Pull Request Description

NVSHMEM is available to download without registration from https://developer.nvidia.com/nvshmem-downloads.
Also add workarounds to deal with the URL redirection and unknown file type.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
