### PR TITLE
Add the hpccm directory to the python module search path when using the wrapper script

### DIFF
--- a/hpccm.sh
+++ b/hpccm.sh
@@ -14,4 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# add the path where this script resides to the search path for python modules
+wd=$(readlink -e $(dirname $0))
+export PYTHONPATH=${wd}:$PYTHONPATH
+
 python3 -m hpccm.cli $*


### PR DESCRIPTION
@smaintz-nv reported an issue calling the `hpccm.sh` script from a different directory.

Set `PYTHONPATH` to the directory where the hpccm.sh script is located so that the hpccm modules can be found by Python in this case.

## Pull Request Description

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
