### PR TITLE
Configure toolchain for gnu source builds

### DIFF
--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -182,6 +182,24 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         # Fill in container instructions
         self.__instructions()
 
+    def __configure_toolchain_on_build(self):
+
+        directory = posixpath.join(self.prefix, 'bin')
+
+        if self.__cc:
+            self.toolchain.CC = posixpath.join(directory, 'gcc')
+
+        if self.__cxx:
+            self.toolchain.CXX = posixpath.join(directory, 'g++')
+
+        if self.__fortran:
+            self.toolchain.FC = posixpath.join(directory, 'gfortran')
+            self.toolchain.F77 = posixpath.join(directory, 'gfortran')
+            self.toolchain.F90 = posixpath.join(directory, 'gfortran')
+
+        if "LD_LIBRARY_PATH" in self.environment_variables:
+            self.toolchain.LD_LIBRARY_PATH = self.environment_variables["LD_LIBRARY_PATH"]
+
     def __build(self):
         """Build compilers from source"""
 
@@ -263,6 +281,9 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
             # Install
             self.__commands.append(accel.install_step())
+
+            #configure toolchain
+            self.__configure_toolchain_on_build()
 
         # Configure host compiler
         if self.__openacc:

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -267,3 +267,13 @@ RUN echo "/usr/local/gnu/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig''')
         self.assertEqual(tc.FC, 'gfortran')
         self.assertEqual(tc.F77, 'gfortran')
         self.assertEqual(tc.F90, 'gfortran')
+
+    def test_toolchain_source(self):
+        g = gnu(source=True, prefix='/usr/local/gnu', version='9.1.0')
+        tc = g.toolchain
+        self.assertEqual(tc.CC, "/usr/local/gnu/bin/gcc")
+        self.assertEqual(tc.CXX, "/usr/local/gnu/bin/g++")
+        self.assertEqual(tc.FC, "/usr/local/gnu/bin/gfortran")
+        self.assertEqual(tc.F77, "/usr/local/gnu/bin/gfortran")
+        self.assertEqual(tc.F90, "/usr/local/gnu/bin/gfortran")
+        self.assertTrue("/usr/local/gnu/lib64" in tc.LD_LIBRARY_PATH)


### PR DESCRIPTION
## Pull Request Description
* Configure toolchain for the GNU building_block when the parameter  `source=True`.
* Add test case for toolchain values when `source=True`. The case tests the values of the variables (`CC`, `FC`, `F77`, `F90`, `CXX` and `LD_LIBRARY_PATH`).
## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified  **no changes**
* [x] Passes all unit tests
