### PR TITLE
Gg/cmake from local files

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1152,6 +1152,9 @@ default is empty.
 - __url__: The URL of the package to build.  One of this parameter or
 the `repository` or `package` parameters must be specified.
 
+- __unpack_download__: if the `url` or `package` specified needs to be unpacked.
+The default is True
+
 __Examples__
 
 
@@ -4546,5 +4549,3 @@ __Examples__
 ```python
 yum(ospackages=['make', 'wget'])
 ```
-
-

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -234,14 +234,13 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
            self.__commands"""
 
         # Get source
-        if self.repository or self.package or self.url:
-            self.__commands.append(
-                self.download_step(
-                    recursive=self.__recursive,
-                    wd=self.__wd,
-                    unpack=self.__unpack_download
-                )
+        self.__commands.append(
+            self.download_step(
+                recursive=self.__recursive,
+                wd=self.__wd,
+                unpack=self.__unpack_download
             )
+        )
 
         # directory containing the unarchived package
         if self.__directory:

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -136,6 +136,9 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
     url: The URL of the package to build.  One of this parameter or
     the `repository` or `package` parameters must be specified.
 
+    unpack_download: if the URL or package specified needs to be unpacked.
+    The default is True
+
     # Examples
 
     ```python

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -196,6 +196,7 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
         self.__run_arguments = kwargs.get('_run_arguments', None)
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__toolchain = kwargs.get('toolchain', toolchain())
+        self.__unpack_download = kwargs.get('unpack_download', True)
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = '/var/tmp' # working directory
@@ -230,8 +231,14 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
            self.__commands"""
 
         # Get source
-        self.__commands.append(self.download_step(recursive=self.__recursive,
-                                                  wd=self.__wd))
+        if self.repository or self.package or self.url:
+            self.__commands.append(
+                self.download_step(
+                    recursive=self.__recursive,
+                    wd=self.__wd,
+                    unpack=self.__unpack_download
+                )
+            )
 
         # directory containing the unarchived package
         if self.__directory:


### PR DESCRIPTION
## Pull Request Description
Hey Scott, in one of our workflows, a warning from the download_step (and in downloader.__unpack()) within generic_cmake.__setup() was getting slurped into the dockerfile.
I'm working with Adam to not pull in STDERR into the dockerfile as its not necessary but I thought this update might still be valuable for users who are copying a directory into their image like myself.

The update is simply exposing the download_step's unpack kwarg as an option to generic_cmake "unpack_download".

If there is already a supported way to do this, I'm happy to hear about it.  

## Author Checklist
* [X] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [X] Passes all unit tests
