### PR TITLE
Update PGI building block to reflect NVIDIA HPC SDK changes

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -718,8 +718,8 @@ fftw(directory='sources/fftw-3.3.7')
 ```
 
 ```python
-p = pgi(eula=True)
-fftw(toolchain=p.toolchain)
+n = nvhpc(eula=True)
+fftw(toolchain=n.toolchain)
 ```
 
 ```python
@@ -1410,8 +1410,8 @@ hdf5(directory='sources/hdf5-1.10.1')
 ```
 
 ```python
-p = pgi(eula=True)
-hdf5(toolchain=p.toolchain)
+n = nvhpc(eula=True)
+hdf5(toolchain=n.toolchain)
 ```
 
 ```python
@@ -2494,10 +2494,6 @@ __Examples__
 mpich(prefix='/opt/mpich/3.3', version='3.3')
 ```
 
-```python
-p = pgi(eula=True)
-mpich(toolchain=p.toolchain)
-```
 
 ## runtime
 ```python
@@ -2680,8 +2676,8 @@ mvapich2(directory='sources/mvapich2-2.3b')
 ```
 
 ```python
-p = pgi(eula=True)
-mvapich2(toolchain=p.toolchain)
+n = nvhpc(eula=True)
+mvapich2(toolchain=n.toolchain)
 ```
 
 ```python
@@ -2980,11 +2976,6 @@ __Examples__
 
 ```python
 netcdf(prefix='/opt/netcdf/4.6.1', version='4.6.1')
-```
-
-```python
-p = pgi(eula=True)
-netcdf(toolchain=p.toolchain)
 ```
 
 
@@ -3330,11 +3321,6 @@ __Examples__
 openblas(prefix='/opt/openblas/0.3.1', version='0.3.1')
 ```
 
-```python
-p = pgi(eula=True)
-openblas(toolchain=p.toolchain)
-```
-
 
 ## runtime
 ```python
@@ -3484,8 +3470,8 @@ openmpi(repository='https://github.com/open-mpi/ompi.git')
 ```
 
 ```python
-p = pgi(eula=True)
-openmpi(toolchain=p.toolchain)
+n = nvhpc(eula=True)
+openmpi(toolchain=n.toolchain)
 ```
 
 ```python
@@ -3615,9 +3601,12 @@ packages(apt=['python3'], yum=['python34'], epel=True)
 ```python
 pgi(self, **kwargs)
 ```
-The `pgi` building block downloads and installs the PGI compiler.
-Currently, the only option is to install the latest community
-edition.
+The `pgi` building block installs the PGI compiler from a
+manually downloaded package.
+
+Note: The [NVIDIA HPC SDK](https://developer.nvidia.com/hpc-sdk)
+has replaced the PGI compilers.  The [nvhpc](#nvhpc) building
+block should be used instead of this building block.
 
 You must agree to the [PGI End-User License Agreement](https://www.pgroup.com/doc/LICENSE.txt) to use this
 building block.
@@ -3669,29 +3658,14 @@ bundled with the PGI compiler will be installed.  The default
 value is False.
 
 - __tarball__: Path to the PGI compiler tarball relative to the local
-build context.  The default value is empty.  If this is defined,
-the tarball in the local build context will be used rather than
-downloading the tarball from the web.
-
-- __version__: The version of the PGI compiler to use.  Note this value
-is currently only used when setting the environment and does not
-control the version of the compiler downloaded.  The default value
-is `19.10`.
+build context.  The default value is empty.  This parameter is
+required.
 
 __Examples__
 
 
 ```python
-pgi(eula=True)
-```
-
-```python
-pgi(eula=True, tarball='pgilinux-2017-1710-x86_64.tar.gz')
-```
-
-```python
-p = pgi(eula=True)
-openmpi(..., toolchain=p.toolchain, ...)
+pgi(eula=True, tarball='pgilinux-2019-1910-x86_64.tar.gz')
 ```
 
 

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -116,8 +116,8 @@ class fftw(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     ```
 
     ```python
-    p = pgi(eula=True)
-    fftw(toolchain=p.toolchain)
+    n = nvhpc(eula=True)
+    fftw(toolchain=n.toolchain)
     ```
 
     ```python

--- a/hpccm/building_blocks/hdf5.py
+++ b/hpccm/building_blocks/hdf5.py
@@ -116,8 +116,8 @@ class hdf5(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     ```
 
     ```python
-    p = pgi(eula=True)
-    hdf5(toolchain=p.toolchain)
+    n = nvhpc(eula=True)
+    hdf5(toolchain=n.toolchain)
     ```
 
     ```python

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -107,10 +107,6 @@ class mpich(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     mpich(prefix='/opt/mpich/3.3', version='3.3')
     ```
 
-    ```python
-    p = pgi(eula=True)
-    mpich(toolchain=p.toolchain)
-    ```
     """
 
     def __init__(self, **kwargs):

--- a/hpccm/building_blocks/mvapich2.py
+++ b/hpccm/building_blocks/mvapich2.py
@@ -138,8 +138,8 @@ class mvapich2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     ```
 
     ```python
-    p = pgi(eula=True)
-    mvapich2(toolchain=p.toolchain)
+    n = nvhpc(eula=True)
+    mvapich2(toolchain=n.toolchain)
     ```
 
     ```python

--- a/hpccm/building_blocks/netcdf.py
+++ b/hpccm/building_blocks/netcdf.py
@@ -118,11 +118,6 @@ class netcdf(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     netcdf(prefix='/opt/netcdf/4.6.1', version='4.6.1')
     ```
 
-    ```python
-    p = pgi(eula=True)
-    netcdf(toolchain=p.toolchain)
-    ```
-
     """
 
     def __init__(self, **kwargs):

--- a/hpccm/building_blocks/openblas.py
+++ b/hpccm/building_blocks/openblas.py
@@ -77,11 +77,6 @@ class openblas(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     openblas(prefix='/opt/openblas/0.3.1', version='0.3.1')
     ```
 
-    ```python
-    p = pgi(eula=True)
-    openblas(toolchain=p.toolchain)
-    ```
-
     """
 
     def __init__(self, **kwargs):

--- a/hpccm/building_blocks/openmpi.py
+++ b/hpccm/building_blocks/openmpi.py
@@ -166,8 +166,8 @@ class openmpi(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
     ```
 
     ```python
-    p = pgi(eula=True)
-    openmpi(toolchain=p.toolchain)
+    n = nvhpc(eula=True)
+    openmpi(toolchain=n.toolchain)
     ```
 
     ```python

--- a/test/test_pgi.py
+++ b/test/test_pgi.py
@@ -36,83 +36,36 @@ class Test_pgi(unittest.TestCase):
     @docker
     def test_defaults_ubuntu(self):
         """Default pgi building block"""
-        p = pgi()
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libnuma1 \
-        perl \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=false ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/19.10/bin:$PATH''')
-
-    @x86_64
-    @centos
-    @docker
-    def test_defaults_centos(self):
-        """Default pgi building block"""
-        p = pgi()
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN yum install -y \
-        gcc \
-        gcc-c++ \
-        numactl-libs \
-        perl \
-        wget && \
-    rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=false ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib64/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib64/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/19.10/bin:$PATH''')
+        with self.assertRaises(RuntimeError):
+            # no tarball specified
+            p = pgi()
 
     @x86_64
     @ubuntu
     @docker
     def test_eula(self):
-        """Accept EULA"""
-        p = pgi(eula=True)
+        """Test EULA"""
+        p = pgi(tarball='pgilinux-2017-1710-x86_64.tar.gz')
         self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
+r'''# PGI compiler version 17.10
+COPY pgilinux-2017-1710-x86_64.tar.gz /var/tmp/pgilinux-2017-1710-x86_64.tar.gz
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         g++ \
         gcc \
         libnuma1 \
-        perl \
-        wget && \
+        perl && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/19.10/bin:$PATH''')
+RUN mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgilinux-2017-1710-x86_64.tar.gz -C /var/tmp/pgi -z && \
+    cd /var/tmp/pgi && PGI_ACCEPT_EULA=decline PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=false ./install && \
+    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/17.10/bin/siterc && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/17.10/lib/libnuma.so && \
+    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/17.10/lib/libnuma.so.1 && \
+    rm -rf /var/tmp/pgilinux-2017-1710-x86_64.tar.gz /var/tmp/pgi
+ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/17.10/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/pgi/linux86-64/17.10/bin:$PATH''')
 
     @x86_64
     @ubuntu
@@ -198,167 +151,9 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/18.4/lib:$LD_LIBRARY_PATH \
     @x86_64
     @ubuntu
     @docker
-    def test_system_cuda(self):
-        """System CUDA"""
-        p = pgi(eula=True, system_cuda=True)
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libnuma1 \
-        perl \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=false PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "set CUDAROOT=/usr/local/cuda;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/19.10/bin:$PATH''')
-
-    @x86_64
-    @ubuntu
-    @docker
-    def test_mpi(self):
-        """System CUDA"""
-        p = pgi(eula=True, mpi=True)
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libnuma1 \
-        openssh-client \
-        perl \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=true PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=true PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/lib:/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/bin:/opt/pgi/linux86-64/19.10/bin:$PATH''')
-
-    @x86_64
-    @ubuntu
-    @docker
-    def test_extended_environment(self):
-        """Extended environment without MPI"""
-        p = pgi(eula=True, extended_environment=True, mpi=False)
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libnuma1 \
-        perl \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV CC=/opt/pgi/linux86-64/19.10/bin/pgcc \
-    CPP="/opt/pgi/linux86-64/19.10/bin/pgcc -Mcpp" \
-    CXX=/opt/pgi/linux86-64/19.10/bin/pgc++ \
-    F77=/opt/pgi/linux86-64/19.10/bin/pgf77 \
-    F90=/opt/pgi/linux86-64/19.10/bin/pgf90 \
-    FC=/opt/pgi/linux86-64/19.10/bin/pgfortran \
-    LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    MODULEPATH=/opt/pgi/modulefiles:$MODULEPATH \
-    PATH=/opt/pgi/linux86-64/19.10/bin:$PATH''')
-
-    @x86_64
-    @ubuntu
-    @docker
-    def test_extended_environment_mpi(self):
-        """Extended environment with MPI"""
-        p = pgi(eula=True, extended_environment=True, mpi=True)
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        g++ \
-        gcc \
-        libnuma1 \
-        openssh-client \
-        perl \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-x64-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-x64 && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-x64-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=true PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=true PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linux86-64/19.10/bin/siterc && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib/x86_64-linux-gnu/libnuma.so.1 /opt/pgi/linux86-64/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-x64-latest.tar.gz /var/tmp/pgi
-ENV CC=/opt/pgi/linux86-64/19.10/bin/pgcc \
-    CPP="/opt/pgi/linux86-64/19.10/bin/pgcc -Mcpp" \
-    CXX=/opt/pgi/linux86-64/19.10/bin/pgc++ \
-    F77=/opt/pgi/linux86-64/19.10/bin/pgf77 \
-    F90=/opt/pgi/linux86-64/19.10/bin/pgf90 \
-    FC=/opt/pgi/linux86-64/19.10/bin/pgfortran \
-    LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/lib:/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH \
-    MODULEPATH=/opt/pgi/modulefiles:$MODULEPATH \
-    PATH=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/bin:/opt/pgi/linux86-64/19.10/bin:$PATH \
-    PGI_OPTL_INCLUDE_DIRS=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/include \
-    PGI_OPTL_LIB_DIRS=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/lib''')
-
-    @ppc64le
-    @centos
-    @docker
-    def test_ppc64le(self):
-        """Default PGI building block on ppc64le"""
-        p = pgi(eula=True)
-        self.assertEqual(str(p),
-r'''# PGI compiler version 19.10
-RUN yum install -y \
-        gcc \
-        gcc-c++ \
-        numactl-libs \
-        perl \
-        wget && \
-    rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -O /var/tmp/pgi-community-linux-openpower-latest.tar.gz --referer https://www.pgroup.com/products/community.htm?utm_source=hpccm\&utm_medium=wgt\&utm_campaign=CE\&nvid=nv-int-14-39155 -P /var/tmp https://www.pgroup.com/support/downloader.php?file=pgi-community-linux-openpower && \
-    mkdir -p /var/tmp/pgi && tar -x -f /var/tmp/pgi-community-linux-openpower-latest.tar.gz -C /var/tmp/pgi -z && \
-    cd /var/tmp/pgi && PGI_ACCEPT_EULA=accept PGI_INSTALL_DIR=/opt/pgi PGI_INSTALL_MPI=false PGI_INSTALL_NVIDIA=true PGI_MPI_GPU_SUPPORT=false PGI_SILENT=true ./install && \
-    echo "variable LIBRARY_PATH is environment(LIBRARY_PATH);" >> /opt/pgi/linuxpower/19.10/bin/siterc && \
-    echo "variable library_path is default(\$if(\$LIBRARY_PATH,\$foreach(ll,\$replace(\$LIBRARY_PATH,":",), -L\$ll)));" >> /opt/pgi/linuxpower/19.10/bin/siterc && \
-    echo "append LDLIBARGS=\$library_path;" >> /opt/pgi/linuxpower/19.10/bin/siterc && \
-    ln -sf /usr/lib64/libnuma.so.1 /opt/pgi/linuxpower/19.10/lib/libnuma.so && \
-    ln -sf /usr/lib64/libnuma.so.1 /opt/pgi/linuxpower/19.10/lib/libnuma.so.1 && \
-    rm -rf /var/tmp/pgi-community-linux-openpower-latest.tar.gz /var/tmp/pgi
-ENV LD_LIBRARY_PATH=/opt/pgi/linuxpower/19.10/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/pgi/linuxpower/19.10/bin:$PATH''')
-
-    @x86_64
-    @ubuntu
-    @docker
     def test_runtime_ubuntu(self):
         """Runtime"""
-        p = pgi()
+        p = pgi(tarball='pgilinux-2019-1910-x86_64.tar.gz')
         r = p.runtime()
         self.assertEqual(r,
 r'''# PGI compiler
@@ -376,7 +171,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH''')
     @docker
     def test_runtime_centos(self):
         """Runtime"""
-        p = pgi()
+        p = pgi(tarball='pgilinux-2019-1910-x86_64.tar.gz')
         r = p.runtime()
         self.assertEqual(r,
 r'''# PGI compiler
@@ -393,7 +188,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/lib:$LD_LIBRARY_PATH''')
     @docker
     def test_runtime_mpi_centos(self):
         """Runtime"""
-        p = pgi(mpi=True)
+        p = pgi(mpi=True, tarball='pgilinux-2019-1910-x86_64.tar.gz')
         r = p.runtime()
         self.assertEqual(r,
 r'''# PGI compiler
@@ -410,7 +205,7 @@ ENV LD_LIBRARY_PATH=/opt/pgi/linux86-64/19.10/mpi/openmpi-3.1.3/lib:/opt/pgi/lin
 
     def test_toolchain(self):
         """Toolchain"""
-        p = pgi()
+        p = pgi(tarball='foo')
         tc = p.toolchain
         self.assertEqual(tc.CC, 'pgcc')
         self.assertEqual(tc.CXX, 'pgc++')


### PR DESCRIPTION
## Pull Request Description

The PGI compiler is no longer available for download, so remove that option from the building block.  I.e., the user must supply a PGI tarball.

Also direct people to use the NVIDIA HPC SDK instead.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
