### PR TITLE
Add args parameter to pip building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3701,6 +3701,9 @@ __Parameters__
 
 - __alternatives__: Boolean flag to specify whether to configure alternatives for `python` and `pip`.  RHEL-based 8.x distributions do not setup `python` by [default](https://developers.redhat.com/blog/2019/05/07/what-no-python-in-red-hat-enterprise-linux-8/).  The default is False.
 
+- __args__: List of arguments to pass to pip.  The default is
+`--no-cache-dir`.
+
 - __ospackages__: List of OS packages to install prior to installing
 PyPi packages.  For Ubuntu, the default values are `python-pip`,
 `python-setuptools`, and `python-wheel` for Python 2.x and

--- a/hpccm/building_blocks/pip.py
+++ b/hpccm/building_blocks/pip.py
@@ -41,6 +41,9 @@ class pip(bb_base, hpccm.templates.rm):
 
     alternatives: Boolean flag to specify whether to configure alternatives for `python` and `pip`.  RHEL-based 8.x distributions do not setup `python` by [default](https://developers.redhat.com/blog/2019/05/07/what-no-python-in-red-hat-enterprise-linux-8/).  The default is False.
 
+    args: List of arguments to pass to pip.  The default is
+    `--no-cache-dir`.
+
     ospackages: List of OS packages to install prior to installing
     PyPi packages.  For Ubuntu, the default values are `python-pip`,
     `python-setuptools`, and `python-wheel` for Python 2.x and
@@ -83,6 +86,7 @@ class pip(bb_base, hpccm.templates.rm):
         super(pip, self).__init__(**kwargs)
 
         self.__alternatives = kwargs.get('alternatives', False)
+        self.__args = kwargs.get('args', ['--no-cache-dir'])
         self.__epel = False
         self.__ospackages = kwargs.get('ospackages', None)
         self.__packages = kwargs.get('packages', [])
@@ -128,6 +132,10 @@ class pip(bb_base, hpccm.templates.rm):
                 'alternatives --install /usr/bin/pip pip /usr/bin/pip2 30'])
 
         if self.__pip:
+            if self.__args:
+                self.__pip = '{0} {1}'.format(self.__pip,
+                                              ' '.join(self.__args))
+
             cmds = []
 
             if self.__upgrade:

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -44,7 +44,7 @@ RUN apt-get update -y && \
         python-setuptools \
         python-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install hpccm''')
+RUN pip --no-cache-dir install hpccm''')
 
     @centos
     @docker
@@ -57,7 +57,7 @@ RUN yum install -y epel-release && \
     yum install -y \
         python2-pip && \
     rm -rf /var/cache/yum/*
-RUN pip install hpccm''')
+RUN pip --no-cache-dir install hpccm''')
 
     @centos8
     @docker
@@ -71,7 +71,7 @@ RUN yum install -y \
     rm -rf /var/cache/yum/*
 RUN alternatives --set python /usr/bin/python2 && \
     alternatives --install /usr/bin/pip pip /usr/bin/pip2 30
-RUN pip install hpccm''')
+RUN pip --no-cache-dir install hpccm''')
 
     @ubuntu
     @docker
@@ -86,13 +86,25 @@ RUN apt-get update -y && \
         python3-setuptools \
         python3-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip3 install hpccm''')
+RUN pip3 --no-cache-dir install hpccm''')
 
     @centos
     @docker
     def test_pip3_centos(self):
         """pip3 w/ pip building block"""
         p = pip(packages=['hpccm'], pip='pip3')
+        self.assertEqual(str(p),
+r'''# pip
+RUN yum install -y \
+        python3-pip && \
+    rm -rf /var/cache/yum/*
+RUN pip3 --no-cache-dir install hpccm''')
+
+    @centos
+    @docker
+    def test_no_args(self):
+        """empty args option"""
+        p = pip(args=[], packages=['hpccm'], pip='pip3')
         self.assertEqual(str(p),
 r'''# pip
 RUN yum install -y \
@@ -107,7 +119,7 @@ RUN pip3 install hpccm''')
         p = pip(ospackages=[], packages=['hpccm'])
         self.assertEqual(str(p),
 r'''# pip
-RUN pip install hpccm''')
+RUN pip --no-cache-dir install hpccm''')
 
     @ubuntu
     @docker
@@ -120,7 +132,7 @@ RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         foo && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install hpccm''')
+RUN pip --no-cache-dir install hpccm''')
 
     @ubuntu
     @docker
@@ -136,7 +148,7 @@ RUN apt-get update -y && \
         python-wheel && \
     rm -rf /var/lib/apt/lists/*
 COPY foo/requirements.txt /var/tmp/requirements.txt
-RUN pip install -r /var/tmp/requirements.txt && \
+RUN pip --no-cache-dir install -r /var/tmp/requirements.txt && \
     rm -rf /var/tmp/requirements.txt''')
 
     @ubuntu
@@ -152,5 +164,5 @@ RUN apt-get update -y && \
         python-setuptools \
         python-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip install --upgrade pip && \
-    pip install hpccm''')
+RUN pip --no-cache-dir install --upgrade pip && \
+    pip --no-cache-dir install hpccm''')


### PR DESCRIPTION
## Pull Request Description

Add `args` parameter to the pip building block.  Use `--no-cache-dir` by default to reduce the image size.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
