### PR TITLE
Require enum34 on Python < 3.4 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
       "Programming Language :: Python :: 3.6"
     ],
     # Make hpccm.cli.main available from the command line as `hpccm`.
-    install_requires=['enum34', 'six'],
+    install_requires=["enum34; python_version < '3.4'", 'six'],
     entry_points={
         'console_scripts': [
             'hpccm=hpccm.cli:main']})


### PR DESCRIPTION
`enum34` package is not required from Python 3.4 onwards (as it is a backport
of the built-in module) and can cause issues with other recent Python
packages, e.g. the `black`-formatter.

Requires [setuptools v36.2](https://setuptools.readthedocs.io/en/latest/history.html#v36-2-0).

## Pull Request Description

## Author Checklist
* [ ] Passes all unit tests
