### PR TITLE
Remove workaround for gdrcopy 2.1 release tag special case

### DIFF
--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-from distutils.version import StrictVersion
 import posixpath
 
 import hpccm.templates.envvars
@@ -88,11 +87,6 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
             self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(
                 posixpath.join(self.__prefix, 'lib64'))
 
-        if StrictVersion(self.__version) >= StrictVersion('2.1'):
-            url='{0}/{1}.tar.gz'.format(self.__baseurl, self.__version)
-        else:
-            url='{0}/v{1}.tar.gz'.format(self.__baseurl, self.__version)
-
         # Setup build configuration
         self.__bb = generic_build(
             annotations={'version': self.__version},
@@ -106,7 +100,7 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
             libdir='lib64',
             prefix=self.__prefix,
             runtime_environment=self.environment_variables,
-            url=url,
+            url='{0}/v{1}.tar.gz'.format(self.__baseurl, self.__version),
             **kwargs)
 
         # Container instructions

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -43,12 +43,12 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/2.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.1.tar.gz -C /var/tmp -z && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.1.tar.gz -C /var/tmp -z && \
     cd /var/tmp/gdrcopy-2.1 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
     make PREFIX=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/2.1.tar.gz
+    rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/v2.1.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')
@@ -64,12 +64,12 @@ RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/2.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/2.1.tar.gz -C /var/tmp -z && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.1.tar.gz -C /var/tmp -z && \
     cd /var/tmp/gdrcopy-2.1 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
     make PREFIX=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/2.1.tar.gz
+    rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/v2.1.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')


### PR DESCRIPTION
## Pull Request Description

The 2.1 tag of gdrcopy was misnamed, so a special workaround was necessary.  The tag has been renamed to be consistent with the others, so the workaround is no longer necessary.  See https://github.com/NVIDIA/gdrcopy/issues/154.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
