### PR TITLE
Add ability to override the default working directory

### DIFF
--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -83,9 +83,21 @@ __Arguments__
 - __ver (string)__: Singularity definition file format version.
 
 
+## set_working_directory
+```python
+set_working_directory(wd)
+```
+Set the working directory to use for staging inside the container
+
+__Arguments__
+
+
+- __wd (string)__: working directory path
+
+
 # recipe
 ```python
-recipe(recipe_file, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None)
+recipe(recipe_file, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None, working_directory=u'/var/tmp')
 ```
 Recipe builder
 
@@ -110,6 +122,9 @@ The default is '2.6'.
 
 - __userarg__: A dictionary of key / value pairs provided to the recipe
 as the `USERARG` dictionary.
+
+- __working_directory__: path to use as the working directory in the
+container specification
 
 
 # Stage

--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -86,8 +86,9 @@ class apt_get(bb_base, hpccm.templates.sed, hpccm.templates.wget):
         self.__aptitude = kwargs.get('aptitude', False)
         self.__commands = []
         self.__download = kwargs.get('download', False)
-        self.__download_directory = kwargs.get('download_directory',
-                                               '/var/tmp/apt_get_download')
+        self.__download_directory = kwargs.get(
+            'download_directory',
+            posixpath.join(hpccm.config.g_wd, '/var/tmp/apt_get_download'))
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__keys = kwargs.get('keys', [])

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -125,7 +125,7 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__prefix = kwargs.get('prefix', '/opt/arm')
         self.__tarball = kwargs.get('tarball', None)
         self.__version = kwargs.get('version', '20.3')
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.toolchain = toolchain(CC='armclang', CXX='armclang++',
                                    F77='armflang', F90='armflang',

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -113,7 +113,7 @@ class boost(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__version = kwargs.get('version', '1.74.0')
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         if self.__sourceforge:
             self.__baseurl = 'https://sourceforge.net/projects/boost/files/boost/__version__'

--- a/hpccm/building_blocks/catalyst.py
+++ b/hpccm/building_blocks/catalyst.py
@@ -128,7 +128,7 @@ class catalyst(bb_base, hpccm.templates.CMakeBuild, hpccm.templates.envvars,
         self.__url = r'https://www.paraview.org/paraview-downloads/download.php?submit=Download\&version={0}\&type=catalyst\&os=Sources\&downloadFile={1}'
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Validate edition choice
         if self.__edition not in [

--- a/hpccm/building_blocks/charm.py
+++ b/hpccm/building_blocks/charm.py
@@ -125,7 +125,7 @@ class charm(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
             self.__installdir = posixpath.join(
                 self.__prefix, 'charm-v{}'.format(self.__version))
 
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.__commands = [] # Filled in by __setup()
 

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -99,7 +99,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
         self.__version = kwargs.get('version', '3.18.3')
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Construct the series of steps to execute
         self.__setup()

--- a/hpccm/building_blocks/conda.py
+++ b/hpccm/building_blocks/conda.py
@@ -113,7 +113,7 @@ class conda(bb_base, hpccm.templates.rm, hpccm.templates.wget):
         self.__version = kwargs.get('version', '4.8.3')
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         if not self.__eula:
             logging.warning('Anaconda EULA was not accepted.  To accept, see the documentation for this building block')

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -199,7 +199,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self.__toolchain = kwargs.get('toolchain', toolchain())
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Construct the series of steps to execute
         self.__setup()

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -140,7 +140,7 @@ class generic_build(bb_base, hpccm.templates.annotate,
         self.__run_arguments = kwargs.get('_run_arguments', None)
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__unpack = kwargs.get('unpack', True)
-        self.__wd = kwargs.get('wd', '/var/tmp') # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.__commands = [] # Filled in by __setup()
 

--- a/hpccm/building_blocks/generic_cmake.py
+++ b/hpccm/building_blocks/generic_cmake.py
@@ -198,7 +198,7 @@ class generic_cmake(bb_base, hpccm.templates.CMakeBuild,
         self.__toolchain = kwargs.get('toolchain', toolchain())
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Construct the series of steps to execute
         self.__setup()

--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -159,7 +159,7 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
         self.prefix = kwargs.get('prefix', '/usr/local/gnu')
         self.__source = kwargs.get('source', False)
         self.__version = kwargs.get('version', None)
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.__commands = []       # Filled in below
         self.__compiler_debs = []  # Filled in below

--- a/hpccm/building_blocks/hpcx.py
+++ b/hpccm/building_blocks/hpcx.py
@@ -129,7 +129,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__version = kwargs.get('version', '2.7.0')
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Output toolchain
         self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -196,7 +196,7 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__runtime_version = kwargs.get('runtime_version', '2020.2-14')
         self.__tarball = kwargs.get('tarball', None)
         self.__tbb = kwargs.get('tbb', True)
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.toolchain = toolchain(CC='icc', CXX='icpc', F77='ifort',
                                    F90='ifort', FC='ifort')

--- a/hpccm/building_blocks/julia.py
+++ b/hpccm/building_blocks/julia.py
@@ -110,7 +110,7 @@ class julia(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__version = kwargs.get('version', '1.5.1')
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Set the CPU architecture specific parameters
         self.__cpu_arch()

--- a/hpccm/building_blocks/libsim.py
+++ b/hpccm/building_blocks/libsim.py
@@ -134,7 +134,8 @@ class libsim(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__url = r'http://portal.nersc.gov/project/visit/releases/{0}/{1}'
 
         self.__commands = [] # Filled in by __setup()
-        self.__wd = '/var/tmp/visit' # working directory
+        self.__wd = kwargs.get('wd', posixpath.join(
+            hpccm.config.g_wd, 'visit')) # working directory
 
         # Set the CPU architecture specific parameters
         self.__cpu_arch()

--- a/hpccm/building_blocks/mpich.py
+++ b/hpccm/building_blocks/mpich.py
@@ -150,7 +150,8 @@ class mpich(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
             configure_opts=self.__configure_opts,
             devel_environment=self.environment_variables,
             # Run test suite (must be after install)
-            postinstall=['cd /var/tmp/mpich-{}'.format(self.__version),
+            postinstall=['cd {0}/mpich-{1}'.format(hpccm.config.g_wd,
+                                                   self.__version),
                          'RUNTESTS_SHOWPROGRESS=1 make testing'] if self.__check else None,
             prefix=self.__prefix,
             runtime_environment=self.environment_variables,

--- a/hpccm/building_blocks/mvapich2_gdr.py
+++ b/hpccm/building_blocks/mvapich2_gdr.py
@@ -156,7 +156,7 @@ class mvapich2_gdr(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__pgi_version = kwargs.get('pgi_version', '19.10')
         self.__release = kwargs.get('release', '1')
         self.version = kwargs.get('version', '2.3.4')
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Output toolchain
         self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',

--- a/hpccm/building_blocks/nccl.py
+++ b/hpccm/building_blocks/nccl.py
@@ -108,7 +108,7 @@ class nccl(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__prefix = kwargs.pop('prefix', '/usr/local/nccl')
         self.__src_directory = kwargs.pop('src_directory', None)
         self.__version = kwargs.pop('version', '2.7.8-1')
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         if not self.__build:
             # Install prebuild package

--- a/hpccm/building_blocks/nsight_compute.py
+++ b/hpccm/building_blocks/nsight_compute.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 import os
 
 from distutils.version import StrictVersion
+import posixpath
 
 import hpccm.config
 
@@ -87,7 +88,8 @@ class nsight_compute(bb_base):
                                    '/usr/local/NVIDIA-Nsight-Compute')
         self.__runfile = kwargs.get('runfile', None)
         self.__version = kwargs.get('version', '2020.2.1')
-        self.__wd = '/var/tmp/nsight_compute'
+        self.__wd = kwargs.get('wd', posixpath.join(
+            hpccm.config.g_wd, 'nsight_compute')) # working directory
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/nvhpc.py
+++ b/hpccm/building_blocks/nvhpc.py
@@ -153,7 +153,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__stdpar_cudacc = kwargs.get('stdpar_cudacc', None)
         self.__url = kwargs.get('url', None)
         self.__version = kwargs.get('version', '20.11')
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
         self.__year = '' # Filled in by __version()
 
         self.toolchain = toolchain(CC='nvc', CXX='nvc++', F77='nvfortran',

--- a/hpccm/building_blocks/nvshmem.py
+++ b/hpccm/building_blocks/nvshmem.py
@@ -112,7 +112,7 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__shmem = kwargs.pop('shmem', None)
         self.__src_directory = kwargs.pop('src_directory', None)
         self.__version = kwargs.pop('version', '1.0.1-0')
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Set the download specific parameters
         self.__download()

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -94,7 +94,7 @@ class ofed(bb_base):
         self.__powertools = False # enable the CentOS PowerTools repo
         self.__prefix = kwargs.get('prefix', None)
         self.__symlink = kwargs.get('symlink', False)
-        self.__wd = '/var/tmp'
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Set the Linux distribution specific parameters
         self.__distro()

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import posixpath
+
 import hpccm.config
 
 from hpccm.building_blocks.apt_get import apt_get
@@ -132,8 +134,9 @@ class packages(bb_base):
         self.__apt_repositories = kwargs.get('apt_repositories', [])
         self.__aptitude = kwargs.get('aptitude', False)
         self.__download = kwargs.get('download', False)
-        self.__download_directory = kwargs.get('download_directory',
-                                               '/var/tmp/packages_download')
+        self.__download_directory = kwargs.get(
+            'download_directory',
+            posixpath.join(hpccm.config.g_wd, 'packages_download'))
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__epel = kwargs.get('epel', False)

--- a/hpccm/building_blocks/pgi.py
+++ b/hpccm/building_blocks/pgi.py
@@ -134,7 +134,7 @@ class pgi(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__system_libnuma = kwargs.get('system_libnuma', True)
         self.__tarball = kwargs.get('tarball', '')
         self.__version = '' # Filled in by __setup()
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.toolchain = toolchain(CC='pgcc', CXX='pgc++', F77='pgfortran',
                                    F90='pgfortran', FC='pgfortran')

--- a/hpccm/building_blocks/pip.py
+++ b/hpccm/building_blocks/pip.py
@@ -94,7 +94,7 @@ class pip(bb_base, hpccm.templates.rm):
         self.__pip = kwargs.get('pip', 'pip')
         self.__requirements = kwargs.get('requirements', None)
         self.__upgrade = kwargs.get('upgrade', False)
-        self.__wd = '/var/tmp' # working directory
+        self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.__debs = [] # Filled in below
         self.__rpms = [] # Filled in below

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -98,8 +98,9 @@ class yum(bb_base):
         self.__commands = []
         self.__download = kwargs.get('download', False)
         self.__download_args = kwargs.get('download_args', '')
-        self.__download_directory = kwargs.get('download_directory',
-                                               '/var/tmp/yum_download')
+        self.__download_directory = kwargs.get(
+            'download_directory',
+            posixpath.join(hpccm.config.g_wd, '/var/tmp/yum_download'))
         self.__epel = kwargs.get('epel', False)
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)

--- a/hpccm/cli.py
+++ b/hpccm/cli.py
@@ -58,6 +58,9 @@ def main(): # pragma: no cover
     parser.add_argument('--userarg', action=KeyValue, metavar='key=value',
                         nargs='+', help='specify user parameters')
     parser.add_argument('--version', action='version', version=__version__)
+    parser.add_argument('--working-directory', '--wd', type=str,
+                        default='/var/tmp',
+                        help='set container working directory')
     args = parser.parse_args()
 
     # configure logger
@@ -68,7 +71,8 @@ def main(): # pragma: no cover
                           raise_exceptions=args.print_exceptions,
                           single_stage=args.single_stage,
                           singularity_version=args.singularity_version,
-                          userarg=args.userarg)
+                          userarg=args.userarg,
+                          working_directory=args.working_directory)
     print(recipe)
 
 if __name__ == "__main__": # pragma: no cover

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -41,6 +41,7 @@ g_ctype = container_type.DOCKER      # Container type
 g_linux_distro = linux_distro.UBUNTU # Linux distribution
 g_linux_version = StrictVersion('16.04') # Linux distribution version
 g_singularity_version = StrictVersion('2.6') # Singularity version
+g_wd = '/var/tmp' # Working directory
 
 def get_cpu_architecture():
   """Return the architecture string for the currently configured CPU
@@ -187,3 +188,14 @@ def set_singularity_version(ver):
   """
   this = sys.modules[__name__]
   this.g_singularity_version = StrictVersion(ver)
+
+def set_working_directory(wd):
+  """Set the working directory to use for staging inside the container
+
+  # Arguments
+
+  wd (string): working directory path
+
+  """
+  this = sys.modules[__name__]
+  this.g_wd = wd

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -88,7 +88,8 @@ def include(recipe_file, _globals=None, _locals=None, prepend_path=True,
             exit(1)
 
 def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
-           single_stage=False, singularity_version='2.6', userarg=None):
+           single_stage=False, singularity_version='2.6', userarg=None,
+           working_directory='/var/tmp'):
     """Recipe builder
 
     # Arguments
@@ -112,6 +113,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
     userarg: A dictionary of key / value pairs provided to the recipe
     as the `USERARG` dictionary.
 
+    working_directory: path to use as the working directory in the
+    container specification
+
     """
 
     # Make user arguments available
@@ -129,6 +133,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
 
     # Set the global Singularity version
     hpccm.config.g_singularity_version = StrictVersion(singularity_version)
+
+    # Set the global working directory
+    hpccm.config.g_wd = working_directory
 
     # Any included recipes that are specified using relative paths will
     # need to prepend the path to the main recipe in order to be found.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -199,3 +199,14 @@ class Test_config(unittest.TestCase):
     def test_get_format_singularity(self):
         """Get container format"""
         self.assertEqual(hpccm.config.get_format(), 'singularity')
+
+    def test_set_working_directory(self):
+        """Set working directory"""
+        # save default value in order to switch back later
+        default_wd = hpccm.config.g_wd
+
+        hpccm.config.set_working_directory('/a/b')
+        self.assertEqual(hpccm.config.g_wd, '/a/b')
+
+        # reset to the default working directory
+        hpccm.config.set_working_directory(default_wd)


### PR DESCRIPTION
## Pull Request Description

Address https://github.com/NVIDIA/hpc-container-maker/issues/328.

- Moves the definition of the working directory from a per building block basis to a single global variable.
- Adds a command line option to modify the working directory: `hpccm --working-directory /other/path`.
- Adds a routine to modify the working directory `hpccm.config.set_working_directory('/other/path')`.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
