### PR TITLE
add the docker specific arg primitive. 

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -199,6 +199,27 @@ __Examples__
 environment(variables={'PATH': '/usr/local/bin:$PATH'})
 ```
 
+# arg
+```python
+arg(self, **kwargs)
+```
+
+The `arg` primitive sets the corresponding environment variables.
+These variables could have a default value or not. For the former
+case the value should be especified on the command line used to
+build the image. This primitive is specific to the Docker container.
+For the Singularity and bash container this primitive return only a
+empry string.
+
+- __variables__: A dictionary of key / value pairs.  The default is an
+empty dictionary.
+
+__Examples__
+
+```python
+arg(variables={'HTTP_PROXY':'proxy.example.com', 'NO_PROXY':'example.com'})
+```
+
 # label
 ```python
 label(self, **kwargs)

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -204,12 +204,12 @@ environment(variables={'PATH': '/usr/local/bin:$PATH'})
 arg(self, **kwargs)
 ```
 
-The `arg` primitive sets the corresponding environment variables.
-These variables could have a default value or not. For the former
-case the value should be especified on the command line used to
-build the image. This primitive is specific to the Docker container.
-For the Singularity and bash container this primitive return only a
-empry string.
+The `arg` primitive sets the corresponding environment
+variables during the build time of a docker container.
+Singularity and "bash" containers does not have a strict version of the
+ARG keyword found on Dockerfiles but is possible to simulate
+the behavior of this keyword as a build time parameter for the
+Singularity and bash containers using environment variables.
 
 - __variables__: A dictionary of key / value pairs.  The default is an
 empty dictionary.
@@ -218,6 +218,17 @@ __Examples__
 
 ```python
 arg(variables={'HTTP_PROXY':'proxy.example.com', 'NO_PROXY':'example.com'})
+```
+
+```bash
+    SINGULARITYENV_HTTP_PROXY="proxy.example.com" \
+    SINGULARITYENV_NO_PROXY="example.com \
+    singularity build image.sif recipe.def"
+```
+
+```bash
+    HTTP_PROXY="proxy.example.com" \
+    NO_PROXY="example.com \
 ```
 
 # label

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -229,6 +229,7 @@ arg(variables={'HTTP_PROXY':'proxy.example.com', 'NO_PROXY':'example.com'})
 ```bash
     HTTP_PROXY="proxy.example.com" \
     NO_PROXY="example.com \
+    recipe.sh
 ```
 
 # label

--- a/hpccm/primitives/__init__.py
+++ b/hpccm/primitives/__init__.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 
 __all__ = ['baseimage', 'blob', 'comment', 'copy', 'environment', 'label',
-           'raw', 'runscript', 'shell', 'user', 'workdir']
+           'raw', 'runscript', 'shell', 'user', 'workdir', 'arg']
 
 from hpccm.primitives.baseimage import baseimage
 from hpccm.primitives.blob import blob
@@ -28,3 +28,4 @@ from hpccm.primitives.runscript import runscript
 from hpccm.primitives.shell import shell
 from hpccm.primitives.user import user
 from hpccm.primitives.workdir import workdir
+from hpccm.primitives.arg import arg

--- a/hpccm/primitives/__init__.py
+++ b/hpccm/primitives/__init__.py
@@ -14,8 +14,8 @@
 
 from __future__ import absolute_import
 
-__all__ = ['baseimage', 'blob', 'comment', 'copy', 'environment', 'label',
-           'raw', 'runscript', 'shell', 'user', 'workdir', 'arg']
+__all__ = ['arg', 'baseimage', 'blob', 'comment', 'copy', 'environment', 'label',
+           'raw', 'runscript', 'shell', 'user', 'workdir']
 
 from hpccm.primitives.baseimage import baseimage
 from hpccm.primitives.blob import blob

--- a/hpccm/primitives/arg.py
+++ b/hpccm/primitives/arg.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods
+
+"""Environment primitive"""
+
+from __future__ import absolute_import
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+
+import hpccm.config
+
+from hpccm.common import container_type
+
+class arg(object):
+    """The `arg` primitive sets the corresponding environment
+    variables during the build time of a docker container. 
+    This primitive is docker specific and is ignored for singularity
+
+    # Parameters
+
+    variables: A dictionary of key / value pairs.  The default is an
+    empty dictionary.
+
+    # Examples
+
+    ```python
+    arg(variables={'HTTP_PROXY': 'proxy.example.com', 'NO_PROXY':'example.com'})
+    ```
+    """
+
+    def __init__(self, **kwargs):
+        """Initialize primitive"""
+        self.__variables = kwargs.get('variables', {})
+
+    def __str__(self):
+        """String representation of the primitive"""
+        if self.__variables:
+
+            if hpccm.config.g_ctype == container_type.SINGULARITY or \
+               hpccm.config.g_ctype == container_type.BASH:
+                return ""
+            elif hpccm.config.g_ctype == container_type.DOCKER:
+                string = ""
+                num_vars = len(self.__variables)
+                for count, (key, val) in enumerate(sorted(self.__variables.items())):
+                    eol = "" if count == num_vars - 1 else "\n"
+                    if val == "":
+                        string += 'ARG {0}'.format(key) + eol
+                    else:
+                        string += 'ARG {0}={1}'.format(key, val) + eol
+                return string
+            else:
+                raise RuntimeError('Unknown container type')
+        else:
+            return ''

--- a/test/test_arg.py
+++ b/test/test_arg.py
@@ -60,31 +60,25 @@ class Test_arg(unittest.TestCase):
     def test_single_singularity(self):
         """Single arg variable specified"""
         e = arg(variables={'A': 'B'})
-        self.assertEqual(str(e), '')
+        self.assertEqual(str(e), '%post\n    A=${A:-"B"}')
+
+    @singularity
+    def test_single_singularity_nodefault(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': ''})
+        self.assertEqual(str(e), '%post\n    A=${A:-""}')
 
     @bash
     def test_single_bash(self):
         """Single arg variable specified"""
         e = arg(variables={'A': 'B'})
-        self.assertEqual(str(e), '')
-
-    @docker
-    def test_single_export_docker(self):
-        """Single arg variable specified"""
-        e = arg(variables={'A': 'B'})
-        self.assertEqual(str(e), 'ARG A=B')
-
-    @singularity
-    def test_single_export_singularity(self):
-        """Single arg variable specified"""
-        e = arg(variables={'A': 'B'})
-        self.assertEqual(str(e),'')
+        self.assertEqual(str(e), 'A=${A:-"B"}')
 
     @bash
-    def test_single_export_bash(self):
+    def test_single_bash_nodefault(self):
         """Single arg variable specified"""
-        e = arg(variables={'A': 'B'})
-        self.assertEqual(str(e), '')
+        e = arg(variables={'A': ''})
+        self.assertEqual(str(e), 'A=${A:-""}')
 
     @docker
     def test_multiple_docker(self):
@@ -107,13 +101,37 @@ ARG TWO''')
     @singularity
     def test_multiple_singularity(self):
         """Multiple arg variables specified"""
-        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3},
-                        _export=False)
-        self.assertEqual(str(e),'')
+        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3})
+        self.assertEqual(str(e),
+'''%post
+    ONE=${ONE:-"1"}
+    THREE=${THREE:-"3"}
+    TWO=${TWO:-"2"}''')
+
+    @singularity
+    def test_multiple_singularity_nodefault(self):
+        """Multiple arg variables specified"""
+        e = arg(variables={'ONE':"", 'TWO':"", 'THREE':""})
+        self.assertEqual(str(e),
+'''%post
+    ONE=${ONE:-""}
+    THREE=${THREE:-""}
+    TWO=${TWO:-""}''')
 
     @bash
     def test_multiple_bash(self):
         """Multiple arg variables specified"""
-        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3},
-                        _export=False)
-        self.assertEqual(str(e),'')
+        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3})
+        self.assertEqual(str(e),
+'''ONE=${ONE:-"1"}
+THREE=${THREE:-"3"}
+TWO=${TWO:-"2"}''')
+
+    @bash
+    def test_multiple_bash_nodefault(self):
+        """Multiple arg variables specified"""
+        e = arg(variables={'ONE': "", 'TWO': "", 'THREE': ""})
+        self.assertEqual(str(e),
+'''ONE=${ONE:-""}
+THREE=${THREE:-""}
+TWO=${TWO:-""}''')

--- a/test/test_arg.py
+++ b/test/test_arg.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=invalid-name, too-few-public-methods, bad-continuation
+
+"""Test cases for the arg module"""
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import logging # pylint: disable=unused-import
+import unittest
+
+from helpers import bash, docker, invalid_ctype, singularity
+
+from hpccm.primitives.arg import arg
+
+class Test_arg(unittest.TestCase):
+    def setUp(self):
+        """Disable logging output messages"""
+        logging.disable(logging.ERROR)
+
+    @docker
+    def test_empty(self):
+        """No arg specified"""
+        e = arg()
+        self.assertEqual(str(e), '')
+
+    @invalid_ctype
+    def test_invalid_ctype(self):
+        """Invalid container type specified"""
+        e = arg(variables={'A': 'B'})
+        with self.assertRaises(RuntimeError):
+            str(e)
+
+    @docker
+    def test_single_docker(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e), 'ARG A=B')
+
+    @docker
+    def test_single_docker_nodefault(self):
+        """Single arg variable specified (no default value)"""
+        e = arg(variables={'A': ''})
+        self.assertEqual(str(e), 'ARG A')
+
+    @singularity
+    def test_single_singularity(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e), '')
+
+    @bash
+    def test_single_bash(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e), '')
+
+    @docker
+    def test_single_export_docker(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e), 'ARG A=B')
+
+    @singularity
+    def test_single_export_singularity(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e),'')
+
+    @bash
+    def test_single_export_bash(self):
+        """Single arg variable specified"""
+        e = arg(variables={'A': 'B'})
+        self.assertEqual(str(e), '')
+
+    @docker
+    def test_multiple_docker(self):
+        """Multiple arg variables specified"""
+        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3})
+        self.assertEqual(str(e),
+'''ARG ONE=1
+ARG THREE=3
+ARG TWO=2''')
+
+    @docker
+    def test_multiple_docker_nodefault(self):
+        """Multiple arg variables specified (no default value)"""
+        e = arg(variables={'ONE': '', 'TWO': '', 'THREE': ''})
+        self.assertEqual(str(e),
+'''ARG ONE
+ARG THREE
+ARG TWO''')
+
+    @singularity
+    def test_multiple_singularity(self):
+        """Multiple arg variables specified"""
+        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3},
+                        _export=False)
+        self.assertEqual(str(e),'')
+
+    @bash
+    def test_multiple_bash(self):
+        """Multiple arg variables specified"""
+        e = arg(variables={'ONE': 1, 'TWO': 2, 'THREE': 3},
+                        _export=False)
+        self.assertEqual(str(e),'')


### PR DESCRIPTION
… string for the shell and singularity container types

## Pull Request Description
Add the the arg primitive that is docker specific. This primitive return a empty string for the bash and singularity container types.
Environment variables for these containers are already treated  by the environment primitive.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
