### PR TITLE
Add toolchain support to the gdrcopy building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -777,6 +777,10 @@ default values are `make` and `wget`.
 - __prefix__: The top level install location.  The default value is
 `/usr/local/gdrcopy`.
 
+- __toolchain__: The toolchain object.  This should be used if
+non-default compilers or other toolchain options are needed.  The
+default is empty.
+
 - __version__: The version of gdrcopy source to download.  The default
 value is `2.1`.
 

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -25,6 +25,7 @@ import unittest
 from helpers import centos, docker, ubuntu
 
 from hpccm.building_blocks.gdrcopy import gdrcopy
+from hpccm.toolchain import toolchain
 
 class Test_gdrcopy(unittest.TestCase):
     def setUp(self):
@@ -94,6 +95,29 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     echo "/usr/local/gdrcopy/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
     rm -rf /var/tmp/gdrcopy-1.3 /var/tmp/v1.3.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
+    LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')
+
+    @ubuntu
+    @docker
+    def test_toolchain(self):
+        """Toolchain"""
+        tc = toolchain(CC='gcc', CFLAGS='-O2')
+        g = gdrcopy(toolchain=tc, version='2.1')
+        self.assertEqual(str(g),
+r'''# GDRCOPY version 2.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.1.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.1.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.1 && \
+    mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib64 && \
+    make CC=gcc COMMONCFLAGS=-O2 PREFIX=/usr/local/gdrcopy lib lib_install && \
+    rm -rf /var/tmp/gdrcopy-2.1 /var/tmp/v2.1.tar.gz
+ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib64:$LIBRARY_PATH''')
 
     @ubuntu


### PR DESCRIPTION
## Pull Request Description

gdrcopy does not use autotools or CMake, so the build options from the toolchain have to be handled manually.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
