### PR TITLE
Workaround for pip 21 and later no longer supporting Python 2

### DIFF
--- a/hpccm/building_blocks/pip.py
+++ b/hpccm/building_blocks/pip.py
@@ -144,7 +144,12 @@ class pip(bb_base, hpccm.templates.rm):
             cmds = []
 
             if self.__upgrade:
-                cmds.append('{0} install --upgrade pip'.format(self.__pip))
+                # pip version 21 and later no longer support Python 2
+                if self.__pip.startswith('pip3'):
+                    cmds.append('{0} install --upgrade pip'.format(self.__pip))
+                else:
+                    cmds.append('{0} install --upgrade "pip < 21.0"'.format(
+                        self.__pip))
 
             if self.__requirements:
                 self += copy(src=self.__requirements,

--- a/test/test_pip.py
+++ b/test/test_pip.py
@@ -164,5 +164,5 @@ RUN apt-get update -y && \
         python-setuptools \
         python-wheel && \
     rm -rf /var/lib/apt/lists/*
-RUN pip --no-cache-dir install --upgrade pip && \
+RUN pip --no-cache-dir install --upgrade "pip < 21.0" && \
     pip --no-cache-dir install hpccm''')


### PR DESCRIPTION
## Pull Request Description

Workaround for pip 21 and later no longer supporting Python 2

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
