### PR TITLE
Add runtime parameter to generic building blocks

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -905,6 +905,10 @@ specified.
 
 - ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
 
+- __runtime__: The list of files / directories to copy into the runtime
+stage.  The default is an empty list, i.e., copy the entire
+prefix.
+
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
 stage.  The default is an empty dictionary.
@@ -1029,6 +1033,10 @@ specified.
 
 - ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
 
+- __runtime__: The list of files / directories to copy into the runtime
+stage.  The default is an empty list, i.e., copy the entire
+prefix.
+
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
 stage.  The default is an empty dictionary.
@@ -1150,6 +1158,10 @@ this parameter or the `package` or `url` parameters must be
 specified.
 
 - ___run_arguments__: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
+
+- __runtime__: The list of files / directories to copy into the runtime
+stage.  The default is an empty list, i.e., copy the entire
+prefix.
 
 - __runtime_environment__: Dictionary of environment variables and
 values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -135,6 +135,10 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
 
     _run_arguments: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
 
+    runtime: The list of files / directories to copy into the runtime
+    stage.  The default is an empty list, i.e., copy the entire
+    prefix.
+
     runtime_environment: Dictionary of environment variables and
     values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
     stage.  The default is an empty dictionary.
@@ -195,6 +199,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self.__preconfigure = kwargs.get('preconfigure', [])
         self.__recursive = kwargs.get('recursive', False)
         self.__run_arguments = kwargs.get('_run_arguments', None)
+        self.__runtime = kwargs.get('runtime', [])
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__toolchain = kwargs.get('toolchain', toolchain())
 
@@ -328,7 +333,22 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
                     self.rt += comment(self.url, reformat=False)
                 elif self.repository:
                     self.rt += comment(self.repository, reformat=False)
-            self.rt += copy(_from=_from, src=self.prefix, dest=self.prefix)
+
+            if self.__runtime:
+                for src in self.__runtime:
+                    if '*' in posixpath.basename(src):
+                        # When using COPY with more than one source file,
+                        # the destination must be a directory and end with
+                        # a /
+                        dest = posixpath.dirname(src) + '/'
+                    else:
+                        dest = src
+
+                    self.rt += copy(_from=_from, src=src, dest=dest)
+            else:
+                # Copy the entire prefix
+                self.rt += copy(_from=_from, src=self.prefix, dest=self.prefix)
+
             if self.ldconfig:
                 self.rt += shell(commands=[self.ldcache_step(
                     directory=posixpath.join(self.prefix, self.__libdir))])

--- a/hpccm/building_blocks/generic_build.py
+++ b/hpccm/building_blocks/generic_build.py
@@ -104,6 +104,10 @@ class generic_build(bb_base, hpccm.templates.annotate,
 
     _run_arguments: Specify additional [Dockerfile RUN arguments](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md) (Docker specific).
 
+    runtime: The list of files / directories to copy into the runtime
+    stage.  The default is an empty list, i.e., copy the entire
+    prefix.
+
     runtime_environment: Dictionary of environment variables and
     values, e.g., `LD_LIBRARY_PATH` and `PATH`, to set in the runtime
     stage.  The default is an empty dictionary.
@@ -138,6 +142,7 @@ class generic_build(bb_base, hpccm.templates.annotate,
         self.__prefix = kwargs.get('prefix', None)
         self.__recursive = kwargs.get('recursive', False)
         self.__run_arguments = kwargs.get('_run_arguments', None)
+        self.__runtime = kwargs.get('runtime', [])
         self.runtime_environment_variables = kwargs.get('runtime_environment', {})
         self.__unpack = kwargs.get('unpack', True)
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
@@ -238,7 +243,23 @@ class generic_build(bb_base, hpccm.templates.annotate,
                     self.rt += comment(self.url, reformat=False)
                 elif self.repository:
                     self.rt += comment(self.repository, reformat=False)
-            self.rt += copy(_from=_from, src=self.__prefix, dest=self.__prefix)
+
+            if self.__runtime:
+                for src in self.__runtime:
+                    if '*' in posixpath.basename(src):
+                        # When using COPY with more than one source file,
+                        # the destination must be a directory and end with
+                        # a /
+                        dest = posixpath.dirname(src) + '/'
+                    else:
+                        dest = src
+
+                    self.rt += copy(_from=_from, src=src, dest=dest)
+            else:
+                # Copy the entire prefix
+                self.rt += copy(_from=_from, src=self.__prefix,
+                                dest=self.__prefix)
+
             if self.ldconfig:
                 self.rt += shell(commands=[self.ldcache_step(
                     directory=posixpath.join(self.__prefix, self.__libdir))])

--- a/test/test_generic_autotools.py
+++ b/test/test_generic_autotools.py
@@ -215,6 +215,21 @@ COPY --from=0 /usr/local/tcl /usr/local/tcl''')
 
     @ubuntu
     @docker
+    def test_runtime_manual(self):
+        """Runtime"""
+        g = generic_autotools(
+            directory='tcl8.6.9/unix',
+            prefix='/usr/local/tcl',
+            runtime=['/usr/local/tcl/bin/tclsh*', '/usr/local/tcl/lib'],
+            url='https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://prdownloads.sourceforge.net/tcl/tcl8.6.9-src.tar.gz
+COPY --from=0 /usr/local/tcl/bin/tclsh* /usr/local/tcl/bin/
+COPY --from=0 /usr/local/tcl/lib /usr/local/tcl/lib''')
+
+    @ubuntu
+    @docker
     def test_runtime_annotate(self):
         """Runtime"""
         g = generic_autotools(

--- a/test/test_generic_build.py
+++ b/test/test_generic_build.py
@@ -167,12 +167,13 @@ LABEL hpccm.openblas.branch=v0.3.6 \
 
     @ubuntu
     @docker
-    def test_runtime(self):
+    def test_runtime_manual(self):
         """Runtime"""
         g = generic_build(build=['make ARCH=sm_70'],
                           install=['cp stream /usr/local/cuda-stream/bin/cuda-stream'],
                           prefix='/usr/local/cuda-stream/bin',
-                          repository='https://github.com/bcumming/cuda-stream')
+                          repository='https://github.com/bcumming/cuda-stream',
+                          runtime=['/usr/local/cuda-stream/bin'])
         r = g.runtime()
         self.assertEqual(r,
 r'''# https://github.com/bcumming/cuda-stream

--- a/test/test_generic_build.py
+++ b/test/test_generic_build.py
@@ -167,6 +167,19 @@ LABEL hpccm.openblas.branch=v0.3.6 \
 
     @ubuntu
     @docker
+    def test_runtime(self):
+        """Runtime"""
+        g = generic_build(build=['make ARCH=sm_70'],
+                          install=['cp stream /usr/local/cuda-stream/bin/cuda-stream'],
+                          prefix='/usr/local/cuda-stream/bin',
+                          repository='https://github.com/bcumming/cuda-stream')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://github.com/bcumming/cuda-stream
+COPY --from=0 /usr/local/cuda-stream/bin /usr/local/cuda-stream/bin''')
+
+    @ubuntu
+    @docker
     def test_runtime_manual(self):
         """Runtime"""
         g = generic_build(build=['make ARCH=sm_70'],

--- a/test/test_generic_cmake.py
+++ b/test/test_generic_cmake.py
@@ -257,6 +257,29 @@ COPY --from=0 /usr/local/gromacs /usr/local/gromacs''')
 
     @ubuntu
     @docker
+    def test_runtime_manual(self):
+        """Runtime"""
+        g = generic_cmake(
+            cmake_opts=['-D CMAKE_BUILD_TYPE=Release',
+                        '-D CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda',
+                        '-D GMX_BUILD_OWN_FFTW=ON',
+                        '-D GMX_GPU=ON',
+                        '-D GMX_MPI=OFF',
+                        '-D GMX_OPENMP=ON',
+                        '-D GMX_PREFER_STATIC_LIBS=ON',
+                        '-D MPIEXEC_PREFLAGS=--allow-run-as-root'],
+            directory='gromacs-2018.2',
+            prefix='/usr/local/gromacs',
+            runtime=['/usr/local/gromacs/bin/*', '/usr/local/gromacs/share'],
+            url='https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz')
+        r = g.runtime()
+        self.assertEqual(r,
+r'''# https://github.com/gromacs/gromacs/archive/v2018.2.tar.gz
+COPY --from=0 /usr/local/gromacs/bin/* /usr/local/gromacs/bin/
+COPY --from=0 /usr/local/gromacs/share /usr/local/gromacs/share''')
+
+    @ubuntu
+    @docker
     def test_runtime_annotate(self):
         """Runtime"""
         g = generic_cmake(


### PR DESCRIPTION
## Pull Request Description

This PR adds the ability to customize the files that get copied into the runtime stage when using one of the generic building blocks.  The default remains the entire prefix.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
