### PR TITLE
Bump HPC SDK default to version 21.2

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3136,10 +3136,10 @@ default value is `False`.
 environment.  The default value is `True`.
 
 - __ospackages__: List of OS packages to install prior to installing the
-NVIDIA HPC SDK.  For Ubuntu, the default values are `debianutils`,
-`gcc`, `g++`, `gfortran`, `libatomic`, `libnuma1`,
+NVIDIA HPC SDK.  For Ubuntu, the default values are `bc`,
+`debianutils`, `gcc`, `g++`, `gfortran`, `libatomic`, `libnuma1`,
 `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
-the default values are `gcc`, `gcc-c++`, `gcc-gfortran`,
+the default values are `bc`, `gcc`, `gcc-c++`, `gcc-gfortran`,
 `libatomic`, `numactl-libs`, `openssh-clients`, `wget`, and
 `which`.
 
@@ -3157,7 +3157,7 @@ wildcards are supported.  The default is an empty list.
 
 - __version__: The version of the HPC SDK to use.  Note when `package`
 is set the version is determined automatically from the package
-file name.  The default value is `20.11`.
+file name.  The default value is `21.2`.
 
 __Examples__
 

--- a/hpccm/building_blocks/nvhpc.py
+++ b/hpccm/building_blocks/nvhpc.py
@@ -81,10 +81,10 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
     environment.  The default value is `True`.
 
     ospackages: List of OS packages to install prior to installing the
-    NVIDIA HPC SDK.  For Ubuntu, the default values are `debianutils`,
-    `gcc`, `g++`, `gfortran`, `libatomic`, `libnuma1`,
+    NVIDIA HPC SDK.  For Ubuntu, the default values are `bc`,
+    `debianutils`, `gcc`, `g++`, `gfortran`, `libatomic`, `libnuma1`,
     `openssh-client`, and `wget`.  For RHEL-based Linux distributions,
-    the default values are `gcc`, `gcc-c++`, `gcc-gfortran`,
+    the default values are `bc`, `gcc`, `gcc-c++`, `gcc-gfortran`,
     `libatomic`, `numactl-libs`, `openssh-clients`, `wget`, and
     `which`.
 
@@ -102,7 +102,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     version: The version of the HPC SDK to use.  Note when `package`
     is set the version is determined automatically from the package
-    file name.  The default value is `20.11`.
+    file name.  The default value is `21.2`.
 
     # Examples
 
@@ -152,14 +152,16 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__redist = kwargs.get('redist', [])
         self.__stdpar_cudacc = kwargs.get('stdpar_cudacc', None)
         self.__url = kwargs.get('url', None)
-        self.__version = kwargs.get('version', '20.11')
+        self.__version = kwargs.get('version', '21.2')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
         self.__year = '' # Filled in by __version()
 
         self.toolchain = toolchain(CC='nvc', CXX='nvc++', F77='nvfortran',
                                    F90='nvfortran', FC='nvfortran')
 
-        if StrictVersion(self.__version) >= StrictVersion('20.11'):
+        if StrictVersion(self.__version) >= StrictVersion('21.2'):
+            self.__cuda_version_default = '11.2'
+        elif StrictVersion(self.__version) >= StrictVersion('20.11'):
             self.__cuda_version_default = '11.1'
         else:
             self.__cuda_version_default = '11.0'
@@ -218,14 +220,14 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__ospackages:
-                self.__ospackages = ['debianutils', 'gcc', 'g++', 'gfortran',
-                                     'libatomic1', 'libnuma1',
+                self.__ospackages = ['bc', 'debianutils', 'gcc', 'g++',
+                                     'gfortran', 'libatomic1', 'libnuma1',
                                      'openssh-client', 'wget']
             self.__runtime_ospackages = ['libatomic1', 'libnuma1',
                                          'openssh-client']
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__ospackages:
-                self.__ospackages = ['gcc', 'gcc-c++', 'gcc-gfortran',
+                self.__ospackages = ['bc', 'gcc', 'gcc-c++', 'gcc-gfortran',
                                      'libatomic', 'openssh-clients',
                                      'numactl-libs', 'wget', 'which']
             self.__runtime_ospackages = ['libatomic', 'numactl-libs',

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -38,7 +38,7 @@ class Test_nvhpc(unittest.TestCase):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 20.11
+r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         debianutils \
@@ -50,13 +50,13 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -65,7 +65,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nvshmem/lib
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 20.11
+r'''# NVIDIA HPC SDK version 21.2
 RUN yum install -y \
         gcc \
         gcc-c++ \
@@ -76,13 +76,13 @@ RUN yum install -y \
         wget \
         which && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2020_2011_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -151,7 +151,7 @@ ENV CC=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc \
         """Default HPC SDK building block on aarch64"""
         n = nvhpc(cuda_multi=False, eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 20.11
+r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         debianutils \
@@ -163,13 +163,13 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/20.11/nvhpc_2020_2011_Linux_aarch64_cuda_11.1.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_2011_Linux_aarch64_cuda_11.1.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2020_2011_Linux_aarch64_cuda_11.1 && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2020_2011_Linux_aarch64_cuda_11.1 /var/tmp/nvhpc_2020_2011_Linux_aarch64_cuda_11.1.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/20.11/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_aarch64_cuda_11.2.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2 && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2 /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/bin:$PATH''')
 
     @ppc64le
     @ubuntu
@@ -213,10 +213,10 @@ RUN apt-get update -y && \
         libnuma1 \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/mpi/bin:$PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -236,11 +236,11 @@ RUN yum install -y \
         numactl-libs \
         openssh-clients && \
     rm -rf /var/cache/yum/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/11.0/nccl/lib/libnccl.so
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/math_libs/11.0/lib64/libcufft.so.10
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/20.11/math_libs/11.0/lib64/libcublas.so.11
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.11/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/11.0/nccl/lib/libnccl.so
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64/libcufft.so.10
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64/libcublas.so.11
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -41,6 +41,7 @@ class Test_nvhpc(unittest.TestCase):
 r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bc \
         debianutils \
         g++ \
         gcc \
@@ -67,6 +68,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:
         self.assertEqual(str(n),
 r'''# NVIDIA HPC SDK version 21.2
 RUN yum install -y \
+        bc \
         gcc \
         gcc-c++ \
         gcc-gfortran \
@@ -95,6 +97,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:
 r'''# NVIDIA HPC SDK version 20.7
 COPY nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
 RUN yum install -y \
+        bc \
         gcc \
         gcc-c++ \
         gcc-gfortran \
@@ -122,6 +125,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/lib:
 r'''# NVIDIA HPC SDK version 20.7
 COPY nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
 RUN yum install -y \
+        bc \
         gcc \
         gcc-c++ \
         gcc-gfortran \
@@ -154,6 +158,7 @@ ENV CC=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc \
 r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bc \
         debianutils \
         g++ \
         gcc \
@@ -181,6 +186,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/lib
 r'''# NVIDIA HPC SDK version 20.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bc \
         debianutils \
         g++ \
         gcc \


### PR DESCRIPTION
## Pull Request Description

Bump HPC SDK default to version 21.2

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
