### PR TITLE
Update example recipes to remove Stage.baseimage() usage

### DIFF
--- a/recipes/easybuild.py
+++ b/recipes/easybuild.py
@@ -15,7 +15,7 @@ import os
 
 Stage0 += comment(__doc__, reformat=False)
 
-Stage0.baseimage('centos:8')
+Stage0 += baseimage(image='centos:8')
 
 Stage0 += shell(commands=['yum update -y centos-release',
                           'rm -rf /var/cache/yum/*'])

--- a/recipes/examples/basic.py
+++ b/recipes/examples/basic.py
@@ -6,7 +6,7 @@ $ hpccm.py --recipe recipes/examples/basic.py --format docker
 """
 
 # Choose a base image
-Stage0.baseimage('ubuntu:16.04')
+Stage0 += baseimage(image='ubuntu:16.04')
 
 # Install GNU compilers (upstream)
 Stage0 += apt_get(ospackages=['gcc', 'g++', 'gfortran'])

--- a/recipes/examples/multistage.py
+++ b/recipes/examples/multistage.py
@@ -9,27 +9,23 @@ $ hpccm.py --recipe recipes/examples/multistage.py
 ######
 
 # Devel stage base image
-Stage0.name = 'devel'
-Stage0.baseimage('nvcr.io/nvidia/cuda:9.0-devel-ubuntu16.04')
+Stage0 += baseimage(image='nvcr.io/nvidia/cuda:9.0-devel-ubuntu16.04',
+                    _as='devel')
 
 # Install compilers (upstream)
-g = gnu()
-Stage0 += g
+Stage0 += gnu()
 
 # Build FFTW using all default options
-f = fftw()
-Stage0 += f
+Stage0 += fftw()
 
 ######
 # Runtime stage
 ######
 
 # Runtime stage base image
-Stage1.baseimage('nvcr.io/nvidia/cuda:9.0-runtime-ubuntu16.04')
+Stage1 += baseimage(image='nvcr.io/nvidia/cuda:9.0-runtime-ubuntu16.04')
 
-# Compiler runtime (upstream)
-Stage1 += g.runtime()
-
-# Copy the FFTW build from the devel stage and setup the runtime environment.
+# Copy the compiler runtime and FFTW from the devel stage and setup the
+# runtime environment.
 # The _from option is not necessary, but increases clarity.
-Stage1 += f.runtime(_from=Stage0.name)
+Stage1 += Stage0.runtime(_from='devel')

--- a/recipes/examples/userargs.py
+++ b/recipes/examples/userargs.py
@@ -13,10 +13,8 @@ $ hpccm.py --recipe recipes/examples/userargs.py --userarg cuda=9.0 ompi=2.1.2
 cuda_version = USERARG.get('cuda', '9.1')
 image = 'nvcr.io/nvidia/cuda:{}-devel-ubuntu16.04'.format(cuda_version)
 
-Stage0.baseimage(image)
+Stage0 += baseimage(image=image)
 
 # Set the OpenMPI version based on the specified version (default to 3.0.0)
 ompi_version = USERARG.get('ompi', '3.0.0')
-ompi = openmpi(infiniband=False, version=ompi_version)
-
-Stage0 += ompi
+Stage0 += openmpi(infiniband=False, version=ompi_version)


### PR DESCRIPTION
## Pull Request Description

Remove `StageX.baseimage()` usage from the examples in favor of `StageX += baseimage()`.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
