### PR TITLE
Update cmake download urls

### DIFF
--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -84,7 +84,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
 
         super(cmake, self).__init__(**kwargs)
 
-        self.__baseurl = kwargs.get('baseurl', 'https://cmake.org/files')
+        self.__baseurl = kwargs.get('baseurl', 'https://github.com/Kitware/CMake/releases/download')
         self.__bootstrap_opts = kwargs.get('bootstrap_opts', [])
 
         # By setting this value to True, you agree to the CMake
@@ -129,15 +129,6 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     def __binary(self):
         """Install the pre-compiled binary"""
 
-        # The download URL has the format contains vMAJOR.MINOR in the
-        # path and the runfile contains MAJOR.MINOR.REVISION, so pull
-        # apart the full version to get the MAJOR and MINOR
-        # components.
-        match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)', self.__version)
-        major = int(match.groupdict()['major'])
-        minor = int(match.groupdict()['minor'])
-        major_minor = '{0}.{1}'.format(major, minor)
-
         runfile = 'cmake-{}-Linux-x86_64.sh'.format(self.__version)
         if LooseVersion(self.__version) < LooseVersion('3.1'):
             runfile = 'cmake-{}-Linux-i386.sh'.format(self.__version)
@@ -150,7 +141,7 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
             else: # pragma: no cover
                 raise RuntimeError('Unknown Linux distribution')
 
-        url = '{0}/v{1}/{2}'.format(self.__baseurl, major_minor, runfile)
+        url = '{0}/v{1}/{2}'.format(self.__baseurl, self.__version, runfile)
 
         # Download source from web
         self.__commands.append(self.download_step(url=url, directory=self.__wd))
@@ -175,15 +166,8 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     def __build(self):
         """Build from source"""
 
-        # The download URL has the format contains vMAJOR.MINOR in the
-        # path and the tarball contains MAJOR.MINOR.REVISION, so pull
-        # apart the full version to get the MAJOR and MINOR
-        # components.
-        match = re.match(r'(?P<major>\d+)\.(?P<minor>\d+)', self.__version)
-        major_minor = '{0}.{1}'.format(match.groupdict()['major'],
-                                       match.groupdict()['minor'])
         tarball = 'cmake-{}.tar.gz'.format(self.__version)
-        url = '{0}/v{1}/{2}'.format(self.__baseurl, major_minor, tarball)
+        url = '{0}/v{1}/{2}'.format(self.__baseurl, self.__version, tarball)
 
         # Include SSL packages
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:

--- a/hpccm/building_blocks/cmake.py
+++ b/hpccm/building_blocks/cmake.py
@@ -129,7 +129,11 @@ class cmake(bb_base, hpccm.templates.rm, hpccm.templates.tar,
     def __binary(self):
         """Install the pre-compiled binary"""
 
-        runfile = 'cmake-{}-Linux-x86_64.sh'.format(self.__version)
+        runfile = 'cmake-{}-linux-x86_64.sh'
+        if LooseVersion(self.__version) < LooseVersion('3.20'):
+            runfile = 'cmake-{}-Linux-x86_64.sh'
+
+        runfile = runfile.format(self.__version)
         if LooseVersion(self.__version) < LooseVersion('3.1'):
             runfile = 'cmake-{}-Linux-i386.sh'.format(self.__version)
             # CMake releases of versions < 3.1 are only include 32-bit

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -44,7 +44,7 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.18/cmake-3.18.3-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.18.3-Linux-x86_64.sh --prefix=/usr/local && \
     rm -rf /var/tmp/cmake-3.18.3-Linux-x86_64.sh
@@ -62,7 +62,7 @@ RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.18/cmake-3.18.3-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.18.3/cmake-3.18.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.18.3-Linux-x86_64.sh --prefix=/usr/local && \
     rm -rf /var/tmp/cmake-3.18.3-Linux-x86_64.sh
@@ -81,7 +81,7 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.16/cmake-3.16.3-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.16.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.16.3-Linux-x86_64.sh
@@ -100,7 +100,7 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.10/cmake-3.10.3-Linux-x86_64.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.10.3/cmake-3.10.3-Linux-x86_64.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.10.3-Linux-x86_64.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.10.3-Linux-x86_64.sh
@@ -120,7 +120,7 @@ RUN apt-get update -y && \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.0.0/cmake-3.0.0-Linux-i386.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.0.0-Linux-i386.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.0.0-Linux-i386.sh
@@ -139,7 +139,7 @@ RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.0/cmake-3.0.0-Linux-i386.sh && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.0.0/cmake-3.0.0-Linux-i386.sh && \
     mkdir -p /usr/local && \
     /bin/sh /var/tmp/cmake-3.0.0-Linux-i386.sh --prefix=/usr/local --skip-license && \
     rm -rf /var/tmp/cmake-3.0.0-Linux-i386.sh
@@ -158,7 +158,7 @@ RUN yum install -y \
         openssl-devel \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/cmake-3.14.5.tar.gz -C /var/tmp -z && \
     cd /var/tmp/cmake-3.14.5 && ./bootstrap --prefix=/usr/local --parallel=$(nproc) && \
     make -j$(nproc) && \
@@ -179,7 +179,7 @@ RUN yum install -y \
         openssl-devel \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.14.5/cmake-3.14.5.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/cmake-3.14.5.tar.gz -C /var/tmp -z && \
     cd /var/tmp/cmake-3.14.5 && ./bootstrap --prefix=/usr/local --parallel=$(nproc) && \
     make -j$(nproc) && \

--- a/test/test_cmake.py
+++ b/test/test_cmake.py
@@ -68,6 +68,26 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     rm -rf /var/tmp/cmake-3.18.3-Linux-x86_64.sh
 ENV PATH=/usr/local/bin:$PATH''')
 
+
+    @x86_64
+    @ubuntu
+    @docker
+    def test_eula(self):
+        """3.20 binary naming"""
+        c = cmake(version='3.20.0')
+        self.assertEqual(str(c),
+r'''# CMake version 3.20.0
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.sh && \
+    mkdir -p /usr/local && \
+    /bin/sh /var/tmp/cmake-3.20.0-linux-x86_64.sh --prefix=/usr/local && \
+    rm -rf /var/tmp/cmake-3.20.0-linux-x86_64.sh
+ENV PATH=/usr/local/bin:$PATH''')
+
     @x86_64
     @ubuntu
     @docker


### PR DESCRIPTION
## Pull Request Description

This brings in two changes to how hpccm cmake support.

- Downloads of CMake now leverage the github release urls, which are what `cmake.org/download` points to as they provide better performance and uptime
- Handles the new CMake 3.20 linux binary names

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
