### PR TITLE
Report when attempting to copy files to a temporary directory when using Singularity

### DIFF
--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -88,7 +88,7 @@ class apt_get(bb_base, hpccm.templates.sed, hpccm.templates.wget):
         self.__download = kwargs.get('download', False)
         self.__download_directory = kwargs.get(
             'download_directory',
-            posixpath.join(hpccm.config.g_wd, '/var/tmp/apt_get_download'))
+            posixpath.join(hpccm.config.g_wd, 'apt_get_download'))
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__keys = kwargs.get('keys', [])

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -100,7 +100,7 @@ class yum(bb_base):
         self.__download_args = kwargs.get('download_args', '')
         self.__download_directory = kwargs.get(
             'download_directory',
-            posixpath.join(hpccm.config.g_wd, '/var/tmp/yum_download'))
+            posixpath.join(hpccm.config.g_wd, 'yum_download'))
         self.__epel = kwargs.get('epel', False)
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)

--- a/hpccm/primitives/copy.py
+++ b/hpccm/primitives/copy.py
@@ -171,7 +171,8 @@ class copy(object):
             # issue a warning or error depending on the Singularity
             # version.
             # https://github.com/NVIDIA/hpc-container-maker/issues/345
-            if any(f['dest'].startswith(('/var/tmp', '/tmp')) for f in files):
+            if (not self.__from and
+                any(f['dest'].startswith(('/var/tmp', '/tmp')) for f in files)):
                 msg = 'Singularity 3.6 and later no longer allow a temporary directory to be used to stage files into the container image.  Modify the recipe or, in many cases, use --working-directory or hpccm.config.set_working_directory() to specify another location.'
                 if hpccm.config.g_singularity_version >= StrictVersion('3.6'):
                     raise RuntimeError(msg)

--- a/hpccm/primitives/copy.py
+++ b/hpccm/primitives/copy.py
@@ -167,6 +167,17 @@ class copy(object):
             return '\n'.join(instructions)
 
         elif hpccm.config.g_ctype == container_type.SINGULARITY:
+            # If any of the files are being staged in /tmp or /var/tmp,
+            # issue a warning or error depending on the Singularity
+            # version.
+            # https://github.com/NVIDIA/hpc-container-maker/issues/345
+            if any(f['dest'].startswith(('/var/tmp', '/tmp')) for f in files):
+                msg = 'Singularity 3.6 and later no longer allow a temporary directory to be used to stage files into the container image.  Modify the recipe or, in many cases, use --working-directory or hpccm.config.set_working_directory() to specify another location.'
+                if hpccm.config.g_singularity_version >= StrictVersion('3.6'):
+                    raise RuntimeError(msg)
+                else:
+                    logging.warning(msg)
+
             # Format:
             # %files
             #     src1 dest

--- a/hpccm/templates/downloader.py
+++ b/hpccm/templates/downloader.py
@@ -45,7 +45,7 @@ class downloader(hpccm.base_object):
         super(downloader, self).__init__(**kwargs)
 
     def download_step(self, allow_unknown_filetype=True, recursive=False,
-                      unpack=True, wd='/var/tmp'):
+                      unpack=True, wd=hpccm.config.g_wd):
         """Get source code"""
 
         if not self.repository and not self.package and not self.url:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -126,6 +126,15 @@ def singularity32(function):
 
     return wrapper
 
+def singularity37(function):
+    """Decorator to set the global singularity version"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_ctype = container_type.SINGULARITY
+        hpccm.config.g_singularity_version = StrictVersion('3.7')
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def ubuntu(function):
     """Decorator to set the Linux distribution to Ubuntu 16.04"""
     def wrapper(*args, **kwargs):

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import bash, docker, invalid_ctype, singularity, singularity26, singularity32
+from helpers import bash, docker, invalid_ctype, singularity, singularity26, singularity32, singularity37
 
 from hpccm.primitives.copy import copy
 
@@ -239,6 +239,13 @@ r'''%files
 
     @singularity
     def test_chown_singularity(self):
-        """Docker --chown syntax"""
+        """Singularity --chown syntax"""
         c = copy(_chown='alice:alice', src='foo', dest='bar')
         self.assertEqual(str(c), '%files\n    foo bar')
+
+    @singularity37
+    def test_temp_staging(self):
+        """Singularity staged files through tmp"""
+        c = copy(src='foo', dest='/var/tmp/foo')
+        with self.assertRaises(RuntimeError):
+            str(c)

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -249,3 +249,9 @@ r'''%files
         c = copy(src='foo', dest='/var/tmp/foo')
         with self.assertRaises(RuntimeError):
             str(c)
+
+    @singularity37
+    def test_from_temp_staging(self):
+        """Singularity files from previous stage in tmp"""
+        c = copy(_from='base', src='foo', dest='/var/tmp/foo')
+        self.assertEqual(str(c), '%files from base\n    foo /var/tmp/foo')


### PR DESCRIPTION
## Pull Request Description

Partially address #345.

If a recipe stages a file into a container using `/tmp` or `/var/tmp`, issue an error if the Singularity version >= 3.6, otherwise a warning.  The message describes possible mitigation steps.  

A full solution would likely mean changing the default working directory from /var/tmp to another location.  Possible candidates include /opt or /var/cache.  But that's a bigger change with potential side effects.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
