### PR TITLE
Default to not building MPI unless MPI and/or SHMEM support is requested

### DIFF
--- a/hpccm/building_blocks/nvshmem.py
+++ b/hpccm/building_blocks/nvshmem.py
@@ -186,6 +186,9 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
         e['NVSHMEM_PREFIX'] = self.__prefix
 
+        # Default to 0 unless MPI/SHMEM is requested
+        e['NVSHMEM_MPI_SUPPORT'] = 0
+
         if self.__cuda:
             e['CUDA_HOME'] = self.__cuda
 


### PR DESCRIPTION
If you attempt to build NVSHMEM without MPI support, it will not work since NVSHMEM must explicitly be passed in NVSHMEM_MPI_SUPPORT=0 in the environment.  This change makes that the default, as the documentation already says.

## Author Checklist
* [ X] Updated documentation (`pydocmd generate`) if any docstrings have been modified
   Documentation already specified this was the default
* [X ] Passes all unit tests
