### PR TITLE
Bump default NVIDIA HPC SDK version to 21.3

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3157,7 +3157,7 @@ wildcards are supported.  The default is an empty list.
 
 - __version__: The version of the HPC SDK to use.  Note when `package`
 is set the version is determined automatically from the package
-file name.  The default value is `21.2`.
+file name.  The default value is `21.3`.
 
 __Examples__
 

--- a/hpccm/building_blocks/nvhpc.py
+++ b/hpccm/building_blocks/nvhpc.py
@@ -102,7 +102,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     version: The version of the HPC SDK to use.  Note when `package`
     is set the version is determined automatically from the package
-    file name.  The default value is `21.2`.
+    file name.  The default value is `21.3`.
 
     # Examples
 
@@ -153,7 +153,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__redist = kwargs.get('redist', [])
         self.__stdpar_cudacc = kwargs.get('stdpar_cudacc', None)
         self.__url = kwargs.get('url', None)
-        self.__version = kwargs.get('version', '21.2')
+        self.__version = kwargs.get('version', '21.3')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
         self.__year = '' # Filled in by __version()
 

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -38,7 +38,7 @@ class Test_nvhpc(unittest.TestCase):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 21.2
+r'''# NVIDIA HPC SDK version 21.3
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bc \
@@ -51,13 +51,13 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -66,7 +66,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 21.2
+r'''# NVIDIA HPC SDK version 21.3
 RUN yum install -y \
         bc \
         gcc \
@@ -78,13 +78,13 @@ RUN yum install -y \
         wget \
         which && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.2/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_212_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.3/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_213_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -153,7 +153,7 @@ ENV CC=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc \
     @docker
     def test_aarch64(self):
         """Default HPC SDK building block on aarch64"""
-        n = nvhpc(cuda_multi=False, eula=True)
+        n = nvhpc(cuda_multi=False, eula=True, version='21.2')
         self.assertEqual(str(n),
 r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
@@ -219,10 +219,10 @@ RUN apt-get update -y && \
         libnuma1 \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/mpi/bin:$PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -242,11 +242,11 @@ RUN yum install -y \
         numactl-libs \
         openssh-clients && \
     rm -rf /var/cache/yum/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/11.0/nccl/lib/libnccl.so
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64/libcufft.so.10
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64/libcublas.so.11
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.2/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/11.0/nccl/lib/libnccl.so
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/math_libs/11.0/lib64/libcufft.so.10
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/21.3/math_libs/11.0/lib64/libcublas.so.11
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.3/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""


### PR DESCRIPTION
## Pull Request Description

Update for most recent nvhpc release.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
