### PR TITLE
Add option to force add yum repositories and use it for Nsight

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3623,6 +3623,11 @@ packages are extracted they are deleted. This parameter is ignored
 if `download` is False. If empty, then the downloaded packages are
 not extracted. The default value is an empty string.
 
+- __force_add_repo__: Boolean flag to specify whether adding a
+repository should be considered successful no matter the actual
+result.  This parameter is only valid for yum repositories.  The
+default value is False.
+
 - __ospackages__: A list of packages to install.  The list is used for
 both Ubuntu and RHEL-based Linux distributions, therefore only
 packages with the consistent names across Linux distributions
@@ -4656,6 +4661,10 @@ i.e., the package manager is bypassed. After the downloaded
 packages are extracted they are deleted. This parameter is ignored
 if `download` is False. If empty, then the downloaded packages are
 not extracted. The default value is an empty string.
+
+- __force_add_repo__: Boolean flag to specify whether adding a
+repository should be considered successful no matter the actual
+result.  The default value is False.
 
 - __keys__: A list of GPG keys to import.  The default is an empty list.
 

--- a/hpccm/building_blocks/nsight_compute.py
+++ b/hpccm/building_blocks/nsight_compute.py
@@ -172,6 +172,8 @@ class nsight_compute(bb_base):
         self += packages(
             apt_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
             apt_repositories=['deb https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
+            # https://github.com/NVIDIA/hpc-container-maker/issues/367
+            force_add_repo=True,
             ospackages=['nsight-compute-{}'.format(self.__version)],
             yum_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
             yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)])

--- a/hpccm/building_blocks/nsight_systems.py
+++ b/hpccm/building_blocks/nsight_systems.py
@@ -87,6 +87,8 @@ class nsight_systems(bb_base):
         self += packages(
             apt_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
             apt_repositories=['deb https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
+            # https://github.com/NVIDIA/hpc-container-maker/issues/367
+            force_add_repo=True,
             ospackages=[package],
             yum_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
             yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)])

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -74,6 +74,11 @@ class packages(bb_base):
     if `download` is False. If empty, then the downloaded packages are
     not extracted. The default value is an empty string.
 
+    force_add_repo: Boolean flag to specify whether adding a
+    repository should be considered successful no matter the actual
+    result.  This parameter is only valid for yum repositories.  The
+    default value is False.
+
     ospackages: A list of packages to install.  The list is used for
     both Ubuntu and RHEL-based Linux distributions, therefore only
     packages with the consistent names across Linux distributions
@@ -140,6 +145,7 @@ class packages(bb_base):
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
         self.__epel = kwargs.get('epel', False)
+        self.__force_add_repo = kwargs.get('force_add_repo', False)
         self.__ospackages = kwargs.get('ospackages', [])
         self.__powertools = kwargs.get('powertools', False)
         self.__release_stream = kwargs.get('release_stream', False)
@@ -180,6 +186,7 @@ class packages(bb_base):
                         extra_opts=self.__extra_opts,
                         extract=self.__extract,
                         epel=self.__epel,
+                        force_add_repo=self.__force_add_repo,
                         keys=self.__yum_keys,
                         ospackages=ospackages,
                         powertools=self.__powertools,

--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -58,6 +58,10 @@ class yum(bb_base):
     if `download` is False. If empty, then the downloaded packages are
     not extracted. The default value is an empty string.
 
+    force_add_repo: Boolean flag to specify whether adding a
+    repository should be considered successful no matter the actual
+    result.  The default value is False.
+
     keys: A list of GPG keys to import.  The default is an empty list.
 
     ospackages: A list of packages to install.  The default is an
@@ -104,6 +108,7 @@ class yum(bb_base):
         self.__epel = kwargs.get('epel', False)
         self.__extra_opts = kwargs.get('extra_opts', [])
         self.__extract = kwargs.get('extract', None)
+        self.__force_add_repo = kwargs.get('force_add_repo', False)
         self.__keys = kwargs.get('keys', [])
         self.__opts = ['-y']
         self.ospackages = kwargs.get('ospackages', [])
@@ -166,8 +171,12 @@ class yum(bb_base):
                 self.__commands.append('yum install -y yum-utils')
 
             for repo in self.__repositories:
-                self.__commands.append(
-                    'yum-config-manager --add-repo {}'.format(repo))
+                if self.__force_add_repo:
+                    self.__commands.append(
+                        '(yum-config-manager --add-repo {} || true)'.format(repo))
+                else:
+                    self.__commands.append(
+                        'yum-config-manager --add-repo {}'.format(repo))
 
         if self.__epel:
             # This needs to be a discrete, preliminary step so that

--- a/test/test_nsight_compute.py
+++ b/test/test_nsight_compute.py
@@ -63,7 +63,7 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/a
 r'''# NVIDIA Nsight Compute 2020.2.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64/nvidia.pub && \
     yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
     rm -rf /var/cache/yum/*''')
@@ -122,7 +122,7 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/p
 r'''# NVIDIA Nsight Compute 2020.2.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le/nvidia.pub && \
     yum install -y yum-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
     rm -rf /var/cache/yum/*''')
@@ -137,7 +137,7 @@ RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/ppc6
 r'''# NVIDIA Nsight Compute 2020.2.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/arm64/nvidia.pub && \
     yum install -y yum-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/arm64 && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/arm64 || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
     rm -rf /var/cache/yum/*''')

--- a/test/test_nsight_systems.py
+++ b/test/test_nsight_systems.py
@@ -63,7 +63,7 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/a
 r'''# NVIDIA Nsight Systems 2021.1.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64/nvidia.pub && \
     yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 || true) && \
     yum install -y \
         nsight-systems-cli-2021.1.1 && \
     rm -rf /var/cache/yum/*''')
@@ -144,7 +144,7 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/p
 r'''# NVIDIA Nsight Systems 2020.1.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le/nvidia.pub && \
     yum install -y yum-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le || true) && \
     yum install -y \
         nsight-systems-cli-2020.1.1 && \
     rm -rf /var/cache/yum/*''')
@@ -159,7 +159,7 @@ RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/ppc6
 r'''# NVIDIA Nsight Systems 2020.2.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/arm64/nvidia.pub && \
     yum install -y yum-utils && \
-    yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/arm64 && \
+    (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/arm64 || true) && \
     yum install -y \
         nsight-systems-cli-2020.2.1 && \
     rm -rf /var/cache/yum/*''')


### PR DESCRIPTION
## Pull Request Description

Fix #367 

Adds a new `force_add_repo` parameter to the `packages` and `yum` building blocks.  When True, assume that the repository was added successfully even if it wasn't.  The default is False.  This is used by the `nsight_systems` and `nsight_compute` building blocks because they both add the same repository, which previously conflicted for the second add (see #367).

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
