### PR TITLE
Add CPU microarchitecture optimization support

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install six
+        pip install six archspec
 
     - name: Build container
       run: |

--- a/.github/workflows/python2.yml
+++ b/.github/workflows/python2.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade "pip < 21.0"
-        pip install six enum34
+        pip install six archspec enum34
 
     - name: Run unit tests
       run: bash ./runtests.sh

--- a/.github/workflows/python3.yml
+++ b/.github/workflows/python3.yml
@@ -25,7 +25,7 @@ jobs:
         else
           python -m pip install --upgrade pip
         fi
-        pip install six
+        pip install six archspec
       shell: bash
 
     - name: Run unit tests

--- a/.github/workflows/singularity_build.yml
+++ b/.github/workflows/singularity_build.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install six
+        pip install six archspec
 
     - name: Install Singularity
       run: |

--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -123,6 +123,18 @@ __Arguments__
 - __wd (string)__: working directory path
 
 
+## test_cpu_feature_flag
+```python
+test_cpu_feature_flag(flag)
+```
+Return True or False depending on whether the CPU supports the
+given feature flag
+
+__Arguments__
+
+
+- __flag__: A CPU feature flag, e.g., `avx`.
+
 # recipe
 ```python
 recipe(recipe_file, cpu_target=None, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None, working_directory=u'/var/tmp')

--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -8,6 +8,22 @@ Return the architecture string for the currently configured CPU
 architecture, e.g., `aarch64`, `ppc64le`, or `x86_64`.
 
 
+## get_cpu_optimization_flags
+```python
+get_cpu_optimization_flags(compiler, version='9999')
+```
+Return the CPU optimization flags for the target and compiler
+combination.
+
+__Arguments__
+
+
+- __compiler__: A compiler family string recognized by archspec.
+
+- __version__: The version of the compiler.  The default version is
+`9999`, i.e., assume the compiler supports the latest optimization
+flags.
+
 ## get_format
 ```python
 get_format()
@@ -47,6 +63,18 @@ __Arguments__
 - __arch (string)__: Value values are `aarch64`, `ppc64le`, and `x86_64`.
 `arm` and `arm64v8` are aliases for `aarch64`, `power` is an alias
 for `ppc64le`, and `amd64` and `x86` are aliases for `x86_64`.
+
+## set_cpu_target
+```python
+set_cpu_target(target)
+```
+Set the CPU optimization target
+
+__Arguments__
+
+
+- __target (string)__: A CPU microarchitecture string recognized by
+archspec.
 
 ## set_linux_distro
 ```python
@@ -97,7 +125,7 @@ __Arguments__
 
 # recipe
 ```python
-recipe(recipe_file, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None, working_directory=u'/var/tmp')
+recipe(recipe_file, cpu_target=None, ctype=<container_type.DOCKER: 1>, raise_exceptions=False, single_stage=False, singularity_version=u'2.6', userarg=None, working_directory=u'/var/tmp')
 ```
 Recipe builder
 
@@ -105,6 +133,8 @@ __Arguments__
 
 
 - __recipe_file__: path to a recipe file (required).
+
+- __cpu_target__: A CPU microarchitecture string recognized by archspec.
 
 - __ctype__: Enum representing the container specification format.  The
 default is `container_type.DOCKER`.

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -130,6 +130,8 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.toolchain = toolchain(CC='armclang', CXX='armclang++',
                                    F77='armflang', F90='armflang',
                                    FC='armflang')
+        self.toolchain.CFLAGS = hpccm.config.get_cpu_optimization_flags('clang')
+        self.toolchain.CXXFLAGS = hpccm.config.get_cpu_optimization_flags('clang')
 
         if hpccm.config.g_cpu_arch != cpu_arch.AARCH64: # pragma: no cover
             logging.warning('Using arm_allinea_studio on a non-aarch64 processor')

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -176,6 +176,15 @@ class fftw(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
             if not self.__configure_opts:
                 self.__configure_opts = ['--enable-shared', '--enable-openmp',
                                          '--enable-threads', '--enable-sse2']
+
+                if hpccm.config.test_cpu_feature_flag('avx'):
+                    self.__configure_opts.append('--enable-avx')
+
+                if hpccm.config.test_cpu_feature_flag('avx'):
+                    self.__configure_opts.append('--enable-avx2')
+
+                if hpccm.config.test_cpu_feature_flag('avx512'):
+                    self.__configure_opts.append('--enable-avx512')
         else:
             if not self.__configure_opts:
                 self.__configure_opts = ['--enable-shared', '--enable-openmp',

--- a/hpccm/building_blocks/fftw.py
+++ b/hpccm/building_blocks/fftw.py
@@ -180,7 +180,7 @@ class fftw(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
                 if hpccm.config.test_cpu_feature_flag('avx'):
                     self.__configure_opts.append('--enable-avx')
 
-                if hpccm.config.test_cpu_feature_flag('avx'):
+                if hpccm.config.test_cpu_feature_flag('avx2'):
                     self.__configure_opts.append('--enable-avx2')
 
                 if hpccm.config.test_cpu_feature_flag('avx512'):

--- a/hpccm/building_blocks/gnu.py
+++ b/hpccm/building_blocks/gnu.py
@@ -188,14 +188,18 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
 
         if self.__cc:
             self.toolchain.CC = posixpath.join(directory, 'gcc')
+            self.toolchain.CFLAGS = hpccm.config.get_cpu_optimization_flags('gcc', self.__version)
 
         if self.__cxx:
             self.toolchain.CXX = posixpath.join(directory, 'g++')
+            self.toolchain.CXXFLAGS = hpccm.config.get_cpu_optimization_flags('gcc', self.__version)
 
         if self.__fortran:
             self.toolchain.FC = posixpath.join(directory, 'gfortran')
             self.toolchain.F77 = posixpath.join(directory, 'gfortran')
             self.toolchain.F90 = posixpath.join(directory, 'gfortran')
+            self.toolchain.FFLAGS = hpccm.config.get_cpu_optimization_flags('gcc', self.__version)
+            self.toolchain.FCFLAGS = hpccm.config.get_cpu_optimization_flags('gcc', self.__version)
 
         if "LD_LIBRARY_PATH" in self.environment_variables:
             self.toolchain.LD_LIBRARY_PATH = self.environment_variables["LD_LIBRARY_PATH"]
@@ -411,11 +415,13 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
             self.__compiler_debs.append('gcc')
             self.__compiler_rpms.append('gcc')
             self.toolchain.CC = 'gcc'
+            self.toolchain.CFLAGS = hpccm.config.get_cpu_optimization_flags('gcc')
 
         if self.__cxx:
             self.__compiler_debs.append('g++')
             self.__compiler_rpms.append('gcc-c++')
             self.toolchain.CXX = 'g++'
+            self.toolchain.CXXFLAGS = hpccm.config.get_cpu_optimization_flags('gcc')
 
         if self.__fortran:
             self.__compiler_debs.append('gfortran')
@@ -425,6 +431,8 @@ class gnu(bb_base, hpccm.templates.ConfigureMake, hpccm.templates.envvars,
             self.toolchain.F77 = 'gfortran'
             self.toolchain.F90 = 'gfortran'
             self.toolchain.FC = 'gfortran'
+            self.toolchain.FFLAGS = hpccm.config.get_cpu_optimization_flags('gcc')
+            self.toolchain.FCFLAGS = hpccm.config.get_cpu_optimization_flags('gcc')
 
         # Install an alternate version, i.e., not the default for
         # the Linux distribution

--- a/hpccm/building_blocks/intel_psxe.py
+++ b/hpccm/building_blocks/intel_psxe.py
@@ -200,6 +200,10 @@ class intel_psxe(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
 
         self.toolchain = toolchain(CC='icc', CXX='icpc', F77='ifort',
                                    F90='ifort', FC='ifort')
+        self.toolchain.CFLAGS = hpccm.config.get_cpu_optimization_flags('intel')
+        self.toolchain.CXXFLAGS = hpccm.config.get_cpu_optimization_flags('intel')
+        self.toolchain.FFLAGS = hpccm.config.get_cpu_optimization_flags('intel')
+        self.toolchain.FCFLAGS = hpccm.config.get_cpu_optimization_flags('intel')
 
         self.__bashrc = ''   # Filled in by __distro()
         self.__commands = [] # Filled in by __setup()

--- a/hpccm/building_blocks/llvm.py
+++ b/hpccm/building_blocks/llvm.py
@@ -112,7 +112,9 @@ class llvm(bb_base, hpccm.templates.envvars):
         # Output toolchain
         self.toolchain = toolchain()
         self.toolchain.CC = 'clang'
+        self.toolchain.CFLAGS = hpccm.config.get_cpu_optimization_flags('clang')
         self.toolchain.CXX = 'clang++'
+        self.toolchain.CXXFLAGS = hpccm.config.get_cpu_optimization_flags('clang')
 
         # Set the packages to install based on the Linux distribution
         # and CPU architecture

--- a/hpccm/cli.py
+++ b/hpccm/cli.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+import archspec.cpu
 import argparse
 import logging
 
@@ -42,17 +43,20 @@ class KeyValue(argparse.Action): # pylint: disable=too-few-public-methods
 
 def main(): # pragma: no cover
     parser = argparse.ArgumentParser(description='HPC Container Maker')
+    parser.add_argument('--cpu-target', type=str, default=None,
+                        choices=[a for a in sorted(archspec.cpu.TARGETS)],
+                        help='cpu microarchitecture optimization target')
     parser.add_argument('--format', type=str, default='docker',
                         choices=[i.name.lower() for i in hpccm.container_type],
                         help='select output format')
     parser.add_argument('--print-exceptions', action='store_true',
                         default=False,
                         help='print exceptions (stack traces)')
+    parser.add_argument('--recipe', required=True,
+                        help='generate a container spec for the RECIPE file')
     parser.add_argument('--single-stage', action='store_true', default=False,
                         help='only process the first stage of a multi-stage ' +
                         'recipe')
-    parser.add_argument('--recipe', required=True,
-                        help='generate a container spec for the RECIPE file')
     parser.add_argument('--singularity-version', type=str, default='2.6',
                         help='set Singularity definition file format version')
     parser.add_argument('--userarg', action=KeyValue, metavar='key=value',
@@ -67,6 +71,7 @@ def main(): # pragma: no cover
     logging.basicConfig(format='%(levelname)s: %(message)s')
 
     recipe = hpccm.recipe(args.recipe,
+                          cpu_target=args.cpu_target,
                           ctype=hpccm.container_type[args.format.upper()],
                           raise_exceptions=args.print_exceptions,
                           single_stage=args.single_stage,

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -238,3 +238,25 @@ def set_working_directory(wd):
   """
   this = sys.modules[__name__]
   this.g_wd = wd
+
+def test_cpu_feature_flag(flag):
+  """Return True or False depending on whether the CPU supports the
+  given feature flag
+
+  # Arguments
+
+  flag: A CPU feature flag, e.g., `avx`.
+  """
+  this = sys.modules[__name__]
+
+  if this.g_cpu_target not in archspec.cpu.TARGETS:
+    logging.warning('unrecognized CPU target "{}"'.format(this.g_cpu_target))
+    return False
+
+  if this.g_cpu_target:
+    try:
+      return flag in archspec.cpu.TARGETS[this.g_cpu_target]
+    except Exception as e:
+      logging.warning('get_cpu_optimization_flags: {}'.format(e))
+
+  return False

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -78,15 +78,17 @@ def get_cpu_optimization_flags(compiler, version='9999'):
   """
   this = sys.modules[__name__]
 
+  if not this.g_cpu_target:
+    return None
+
   if this.g_cpu_target not in archspec.cpu.TARGETS:
     logging.warning('unrecognized CPU target "{}"'.format(this.g_cpu_target))
     return None
 
-  if this.g_cpu_target:
-    try:
-      return archspec.cpu.TARGETS[this.g_cpu_target].optimization_flags(compiler, version)
-    except Exception as e:
-      logging.warning('get_cpu_optimization_flags: {}'.format(e))
+  try:
+    return archspec.cpu.TARGETS[this.g_cpu_target].optimization_flags(compiler, version)
+  except Exception as e:
+    logging.warning('get_cpu_optimization_flags: {}'.format(e))
 
   return None
 

--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -87,14 +87,17 @@ def include(recipe_file, _globals=None, _locals=None, prepend_path=True,
             logging.error(e)
             exit(1)
 
-def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
-           single_stage=False, singularity_version='2.6', userarg=None,
+def recipe(recipe_file, cpu_target=None, ctype=container_type.DOCKER,
+           raise_exceptions=False, single_stage=False,
+           singularity_version='2.6', userarg=None,
            working_directory='/var/tmp'):
     """Recipe builder
 
     # Arguments
 
     recipe_file: path to a recipe file (required).
+
+    cpu_target: A CPU microarchitecture string recognized by archspec.
 
     ctype: Enum representing the container specification format.  The
     default is `container_type.DOCKER`.
@@ -127,6 +130,9 @@ def recipe(recipe_file, ctype=container_type.DOCKER, raise_exceptions=False,
     stages = [Stage(), Stage()]
     Stage0 = stages[0] # alias # pylint: disable=unused-variable
     Stage1 = stages[1] # alias # pylint: disable=unused-variable
+
+    # Set the CPU target
+    hpccm.config.set_cpu_target(cpu_target)
 
     # Set the global container type
     hpccm.config.g_ctype = ctype

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
       "Programming Language :: Python :: 3.6"
     ],
     # Make hpccm.cli.main available from the command line as `hpccm`.
-    install_requires=["enum34; python_version < '3.4'", 'six'],
+    install_requires=["archspec; enum34; python_version < '3.4'", 'six'],
     entry_points={
         'console_scripts': [
             'hpccm=hpccm.cli:main']})

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -42,6 +42,14 @@ def bash(function):
 
     return wrapper
 
+def broadwell(function):
+    """Decorator to set the CPU type to Broadwell"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_target = 'broadwell'
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def centos(function):
     """Decorator to set the Linux distribution to CentOS 7"""
     def wrapper(*args, **kwargs):
@@ -60,10 +68,26 @@ def centos8(function):
 
     return wrapper
 
+def cpu_target_none(function):
+    """Decorator to set the CPU type to None"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_target = None
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def docker(function):
     """Decorator to set the global container type to docker"""
     def wrapper(*args, **kwargs):
         hpccm.config.g_ctype = container_type.DOCKER
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def icelake(function):
+    """Decorator to set the CPU type to Ice Lake"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_target = 'icelake'
         return function(*args, **kwargs)
 
     return wrapper
@@ -135,6 +159,14 @@ def singularity37(function):
 
     return wrapper
 
+def thunderx2(function):
+    """Decorator to set the CPU type to ThunderX2"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_target = 'thunderx2'
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def ubuntu(function):
     """Decorator to set the Linux distribution to Ubuntu 16.04"""
     def wrapper(*args, **kwargs):
@@ -166,6 +198,14 @@ def x86_64(function):
     """Decorator to set the CPU architecture to x86_64"""
     def wrapper(*args, **kwargs):
         hpccm.config.g_cpu_arch = cpu_arch.X86_64
+        return function(*args, **kwargs)
+
+    return wrapper
+
+def zen2(function):
+    """Decorator to set the CPU type to Zen 2"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_cpu_target = 'zen2'
         return function(*args, **kwargs)
 
     return wrapper

--- a/test/test_arm_allinea_studio.py
+++ b/test/test_arm_allinea_studio.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, centos8, docker, ubuntu
+from helpers import aarch64, centos, centos8, docker, thunderx2, ubuntu
 
 from hpccm.building_blocks.arm_allinea_studio import arm_allinea_studio
 
@@ -164,3 +164,11 @@ ENV LD_LIBRARY_PATH=/opt/arm/arm-linux-compiler-20.3_Generic-AArch64_RHEL-7_aarc
         self.assertEqual(tc.FC, 'armflang')
         self.assertEqual(tc.F77, 'armflang')
         self.assertEqual(tc.F90, 'armflang')
+
+    @thunderx2
+    def test_toolchain_thunderx2(self):
+        """CPU target optimization flags"""
+        a = arm_allinea_studio(eula=True)
+        tc = a.toolchain
+        self.assertEqual(tc.CFLAGS, '-mcpu=thunderx2t99')
+        self.assertEqual(tc.CXXFLAGS, '-mcpu=thunderx2t99')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -23,7 +23,7 @@ from distutils.version import StrictVersion
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import bash, centos, docker, singularity, ubuntu
+from helpers import bash, broadwell, centos, docker, icelake, singularity, thunderx2, ubuntu, zen2
 
 import hpccm.config
 
@@ -210,3 +210,32 @@ class Test_config(unittest.TestCase):
 
         # reset to the default working directory
         hpccm.config.set_working_directory(default_wd)
+
+    def test_set_cpu_target(self):
+        """Set CPU optimization target"""
+        # save default value in order to switch back later
+        default_cpu_target = hpccm.config.g_cpu_target
+
+        hpccm.config.set_cpu_target('broadwell')
+        self.assertEqual(hpccm.config.g_cpu_target, 'broadwell')
+
+        # reset to the default cpu optimization target
+        hpccm.config.set_cpu_target(default_cpu_target)
+
+    @thunderx2
+    def test_get_cpu_optimization_flags(self):
+        """Get CPU optimization flags"""
+        flags = hpccm.config.get_cpu_optimization_flags('gcc')
+        self.assertEqual(flags, '-mcpu=thunderx2t99')
+
+    @icelake
+    def test_get_cpu_optimization_flags_old_compiler(self):
+        """Get CPU optimization flags"""
+        flags = hpccm.config.get_cpu_optimization_flags('gcc', version='4.8.5')
+        self.assertEqual(flags, None)
+
+    @zen2
+    def test_test_feature_flag(self):
+        """Test CPU feature flags"""
+        self.assertTrue(hpccm.config.test_cpu_feature_flag('avx2'))
+        self.assertFalse(hpccm.config.test_cpu_feature_flag('foo'))

--- a/test/test_fftw.py
+++ b/test/test_fftw.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, docker, ppc64le, ubuntu, x86_64
+from helpers import aarch64, centos, cpu_target_none, docker, icelake, ppc64le, ubuntu, x86_64
 
 from hpccm.building_blocks.fftw import fftw
 
@@ -31,6 +31,7 @@ class Test_fftw(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
+    @cpu_target_none
     @x86_64
     @ubuntu
     @docker
@@ -53,6 +54,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8 /var/tmp/fftw-3.3.8.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @cpu_target_none
     @x86_64
     @centos
     @docker
@@ -74,6 +76,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8 /var/tmp/fftw-3.3.8.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @cpu_target_none
     @x86_64
     @ubuntu
     @docker
@@ -96,6 +99,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.8 /var/tmp/fftw-3.3.8.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @cpu_target_none
     @x86_64
     @ubuntu
     @docker
@@ -157,6 +161,29 @@ RUN apt-get update -y && \
 RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
     cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-openmp --enable-shared --enable-threads && \
+    make -j$(nproc) && \
+    make -j$(nproc) install && \
+    rm -rf /var/tmp/fftw-3.3.8 /var/tmp/fftw-3.3.8.tar.gz
+ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
+
+    @icelake
+    @x86_64
+    @ubuntu
+    @docker
+    def test_cpu_optimization_flags(self):
+        """CPU optimization flags"""
+        f = fftw(version='3.3.8')
+        self.assertEqual(str(f),
+r'''# FFTW version 3.3.8
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        file \
+        make \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ftp.fftw.org/pub/fftw/fftw-3.3.8.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/fftw-3.3.8.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/fftw-3.3.8 &&   ./configure --prefix=/usr/local/fftw --enable-avx --enable-avx2 --enable-avx512 --enable-openmp --enable-shared --enable-sse2 --enable-threads && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
     rm -rf /var/tmp/fftw-3.3.8 /var/tmp/fftw-3.3.8.tar.gz

--- a/test/test_gnu.py
+++ b/test/test_gnu.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, centos8, docker, ubuntu, ubuntu18
+from helpers import broadwell, centos, centos8, docker, ubuntu, ubuntu18
 
 from hpccm.building_blocks.gnu import gnu
 
@@ -292,3 +292,13 @@ RUN echo "/usr/local/gnu/lib64" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig''')
         self.assertEqual(tc.F90, "/usr/local/gnu/bin/gfortran")
         if tc.LD_LIBRARY_PATH:
             self.assertTrue("/usr/local/gnu/lib64" in tc.LD_LIBRARY_PATH)
+
+    @broadwell
+    def test_toolchain_broadwell(self):
+        """CPU arch optimization flags"""
+        g = gnu()
+        tc = g.toolchain
+        self.assertEqual(tc.CFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.CXXFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.FFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.FCFLAGS, '-march=broadwell -mtune=broadwell')

--- a/test/test_intel_psxe.py
+++ b/test/test_intel_psxe.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, docker, ubuntu
+from helpers import broadwell, centos, docker, ubuntu
 
 from hpccm.building_blocks.intel_psxe import intel_psxe
 
@@ -172,3 +172,13 @@ RUN echo "source /opt/intel/psxe_runtime/linux/bin/psxevars.sh intel64" >> /etc/
         self.assertEqual(tc.FC, 'ifort')
         self.assertEqual(tc.F77, 'ifort')
         self.assertEqual(tc.F90, 'ifort')
+
+    @broadwell
+    def test_toolchain_broadwell(self):
+        """CPU arch optimization flags"""
+        psxe = intel_psxe(tarball='foo.tgz')
+        tc = psxe.toolchain
+        self.assertEqual(tc.CFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.CXXFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.FFLAGS, '-march=broadwell -mtune=broadwell')
+        self.assertEqual(tc.FCFLAGS, '-march=broadwell -mtune=broadwell')

--- a/test/test_llvm.py
+++ b/test/test_llvm.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, centos8, docker, ppc64le, ubuntu, ubuntu18, ubuntu20, x86_64
+from helpers import aarch64, centos, centos8, docker, ppc64le, ubuntu, ubuntu18, ubuntu20, x86_64, zen2
 
 from hpccm.building_blocks.llvm import llvm
 
@@ -430,3 +430,11 @@ RUN apt-get update -y && \
         tc = l.toolchain
         self.assertEqual(tc.CC, 'clang')
         self.assertEqual(tc.CXX, 'clang++')
+
+    @zen2
+    def test_toolchain_zen2(self):
+        """CPU arch optimization flags"""
+        l = llvm()
+        tc = l.toolchain
+        self.assertEqual(tc.CFLAGS, '-march=znver2 -mtune=znver2')
+        self.assertEqual(tc.CXXFLAGS, '-march=znver2 -mtune=znver2')


### PR DESCRIPTION
## Pull Request Description

Add the capability to optimize a container for a specific CPU microarchitecture.

This relies on the [archspec](https://github.com/archspec/archspec) package.  This is a new dependency.

A new command line option has been added:
```
$ hpccm --help
...
  --cpu-target {a64fx,aarch64,arm,broadwell,bulldozer,cannonlake,cascadelake,core2,excavator,graviton,graviton2,haswell,i686,icelake,ivybridge,k10,mic_knl,nehalem,nocona,pentium2,pentium3,pentium4,piledriver,power7,power8,power8le,power9,power9le,ppc,ppc64,ppc64le,ppcle,prescott,sandybridge,skylake,skylake_avx512,sparc,sparc64,steamroller,thunderx2,westmere,x86,x86_64,zen,zen2}
                        cpu microarchitecture optimization target
...
```

The equivalent API call is `hpccm.config.set_cpu_target()`.

Setting the CPU target will add the corresponding compiler options to the compiler toolchain (the compiler must be supported by archspec).  If a recipe does not use a compiler toolchain, then this option will not do anything.  

For instance:

```
Stage0 += baseimage(image='ubuntu:20.04')

compiler = gnu()
Stage0 += compiler
tc = compiler.toolchain

Stage0 += hdf5(toolchain=tc)
```

Given this recipe, adding `--cpu-target skylake` extends the toolchain flags to include `CFLAGS='-march=skylake -mtune=skylake'`, and similarly for the other compiler flag variables.

No validation is done to verify that the CPU target choice is compatible with the container base image, the current hardware, or other settings.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
