### PR TITLE
Update default slurm_pmi2 version

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -4339,7 +4339,7 @@ non-default compilers or other toolchain options are needed.  The
 default value is empty.
 
 - __version__: The version of SLURM source to download.  The default
-value is `20.02.5`.
+value is `20.11.7`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -4356,7 +4356,7 @@ __Examples__
 
 
 ```python
-slurm_pmi2(prefix='/opt/pmi', version='19.05.4')
+slurm_pmi2(prefix='/opt/pmi', version='20.02.7')
 ```
 
 

--- a/hpccm/building_blocks/slurm_pmi2.py
+++ b/hpccm/building_blocks/slurm_pmi2.py
@@ -76,7 +76,7 @@ class slurm_pmi2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     default value is empty.
 
     version: The version of SLURM source to download.  The default
-    value is `20.02.5`.
+    value is `20.11.7`.
 
     with_PACKAGE[=ARG]: Flags to control optional packages when
     configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -92,7 +92,7 @@ class slurm_pmi2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     # Examples
 
     ```python
-    slurm_pmi2(prefix='/opt/pmi', version='19.05.4')
+    slurm_pmi2(prefix='/opt/pmi', version='20.02.7')
     ```
 
     """
@@ -107,7 +107,7 @@ class slurm_pmi2(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
         self.__ospackages = kwargs.pop('ospackages', ['bzip2', 'file', 'make',
                                                       'perl', 'tar', 'wget'])
         self.__prefix = kwargs.pop('prefix', '/usr/local/slurm-pmi2')
-        self.__version = kwargs.pop('version', '20.02.5')
+        self.__version = kwargs.pop('version', '20.11.7')
 
         # Setup the environment variables
         self.environment_variables['CPATH'] = '{}:$CPATH'.format(

--- a/recipes/osu_benchmarks/common.py
+++ b/recipes/osu_benchmarks/common.py
@@ -41,7 +41,7 @@ Stage0 += shell(commands=[
     'ln -s /usr/local/ucx-mlnx-legacy/{1}/* /usr/local/ofed/{0}/usr/{1}'.format(version, directory) for version in mlnx_versions for directory in ['bin', 'lib']])
 
 # PMI2 support
-Stage0 += slurm_pmi2(prefix="/usr/local/pmi", version='20.11.4')
+Stage0 += slurm_pmi2(prefix="/usr/local/pmi", version='20.11.7')
 
 # OpenMPI
 Stage0 += openmpi(cuda=True, infiniband=False, ldconfig=True, ucx=True,

--- a/test/test_slurm_pmi2.py
+++ b/test/test_slurm_pmi2.py
@@ -38,7 +38,7 @@ class Test_slurm_pmi2(unittest.TestCase):
         """Default slurm_pmi2 building block"""
         p = slurm_pmi2()
         self.assertEqual(str(p),
-r'''# SLURM PMI2 version 20.02.5
+r'''# SLURM PMI2 version 20.11.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -48,21 +48,21 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.5.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.5.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/slurm-20.02.5 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
-    cd /var/tmp/slurm-20.02.5 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.11.7.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.11.7.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-20.11.7 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    cd /var/tmp/slurm-20.11.7 && \
     make -C contribs/pmi2 install && \
-    rm -rf /var/tmp/slurm-20.02.5 /var/tmp/slurm-20.02.5.tar.bz2''')
+    rm -rf /var/tmp/slurm-20.11.7 /var/tmp/slurm-20.11.7.tar.bz2''')
 
     @x86_64
     @ubuntu
     @docker
     def test_ldconfig(self):
         """ldconfig option"""
-        p = slurm_pmi2(ldconfig=True, version='19.05.4')
+        p = slurm_pmi2(ldconfig=True, version='20.02.7')
         self.assertEqual(str(p),
-r'''# SLURM PMI2 version 19.05.4
+r'''# SLURM PMI2 version 20.02.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -72,13 +72,13 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-19.05.4.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-19.05.4.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/slurm-19.05.4 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
-    cd /var/tmp/slurm-19.05.4 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.02.7.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.02.7.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/slurm-20.02.7 &&   ./configure --prefix=/usr/local/slurm-pmi2 && \
+    cd /var/tmp/slurm-20.02.7 && \
     make -C contribs/pmi2 install && \
     echo "/usr/local/slurm-pmi2/lib" >> /etc/ld.so.conf.d/hpccm.conf && ldconfig && \
-    rm -rf /var/tmp/slurm-19.05.4 /var/tmp/slurm-19.05.4.tar.bz2''')
+    rm -rf /var/tmp/slurm-20.02.7 /var/tmp/slurm-20.02.7.tar.bz2''')
 
     @x86_64
     @ubuntu


### PR DESCRIPTION
## Pull Request Description

Bump default SLURM version.  Previous SLURM downloads have been removed due a CVE.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
