### PR TITLE
Disable deployment of Nsight Compute section files.

### DIFF
--- a/hpccm/building_blocks/nsight_compute.py
+++ b/hpccm/building_blocks/nsight_compute.py
@@ -26,14 +26,16 @@ from distutils.version import StrictVersion
 import posixpath
 
 import hpccm.config
+import hpccm.templates.envvars
 
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
 from hpccm.building_blocks.generic_build import generic_build
 from hpccm.common import cpu_arch, linux_distro
 from hpccm.primitives.comment import comment
+from hpccm.primitives.environment import environment
 
-class nsight_compute(bb_base):
+class nsight_compute(bb_base, hpccm.templates.envvars):
     """The `nsight_compute` building block downloads and installs the
     [NVIDIA Nsight Compute
     profiler]](https://developer.nvidia.com/nsight-compute).
@@ -93,6 +95,12 @@ class nsight_compute(bb_base):
 
         # Set the Linux distribution specific parameters
         self.__distro()
+
+        # Disables deployment of section files to prevent warning
+        # when there is no home or home is read-only:
+        self.environment_variables[
+            'NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT'
+        ] = '1'
 
         if self.__runfile:
             # Runfile based installation
@@ -178,6 +186,8 @@ class nsight_compute(bb_base):
             yum_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
             yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)])
 
+        self += environment(variables=self.environment_step())
+
     def __instructions_runfile(self):
         """Fill in container instructions"""
 
@@ -219,3 +229,4 @@ class nsight_compute(bb_base):
         self += comment('NVIDIA Nsight Compute {}'.format(pkg), reformat=False)
         self += packages(ospackages=self.__ospackages)
         self += self.__bb
+        self += environment(variables=self.environment_variables)

--- a/test/test_nsight_compute.py
+++ b/test/test_nsight_compute.py
@@ -51,7 +51,8 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/a
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/lib/apt/lists/*''')
+    rm -rf /var/lib/apt/lists/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @x86_64
     @centos8
@@ -66,7 +67,8 @@ RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel8/x86_
     (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/cache/yum/*''')
+    rm -rf /var/cache/yum/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @x86_64
     @ubuntu
@@ -88,7 +90,8 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/a
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/lib/apt/lists/*''')
+    rm -rf /var/lib/apt/lists/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @ppc64le
     @ubuntu18
@@ -110,7 +113,8 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/p
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/lib/apt/lists/*''')
+    rm -rf /var/lib/apt/lists/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @ppc64le
     @centos
@@ -125,7 +129,8 @@ RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/ppc6
     (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/ppc64le || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/cache/yum/*''')
+    rm -rf /var/cache/yum/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @aarch64
     @centos
@@ -140,7 +145,8 @@ RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel7/arm6
     (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel7/arm64 || true) && \
     yum install -y \
         nsight-compute-2020.2.1 && \
-    rm -rf /var/cache/yum/*''')
+    rm -rf /var/cache/yum/*
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @x86_64
     @ubuntu
@@ -164,7 +170,8 @@ RUN cd /var/tmp/nsight_compute && \
     ln -sf /usr/local/NVIDIA-Nsight-Compute/sections /tmp/var/ && \
     chmod -R a+w /tmp/var && \
     rm -rf /var/tmp/nsight_compute /var/tmp/nsight_compute/nsight_compute-linux-x86_64-2020.2.0.18_28964561.run
-ENV PATH=/usr/local/NVIDIA-Nsight-Compute:$PATH''')
+ENV PATH=/usr/local/NVIDIA-Nsight-Compute:$PATH
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')
 
     @x86_64
     @ubuntu
@@ -187,4 +194,5 @@ RUN mkdir -p /var/tmp/nsight_compute && wget -q -nc --no-check-certificate -P /v
     ln -sf /usr/local/NVIDIA-Nsight-Compute/sections /tmp/var/ && \
     chmod -R a+w /tmp/var && \
     rm -rf /var/tmp/nsight_compute /var/tmp/nsight_compute/nsight_compute-linux-x86_64-2020.2.0.18_28964561.run
-ENV PATH=/usr/local/NVIDIA-Nsight-Compute:$PATH''')
+ENV PATH=/usr/local/NVIDIA-Nsight-Compute:$PATH
+ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1''')


### PR DESCRIPTION
Nsight Compute attempts to deploy section files to the user's home
directory and warns when this fails. This warning is not really actionable
for a container that cannot rely on a home directory existing, or being
writtable.

## Pull Request Description

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
