### PR TITLE
Update boost to use jfrog download site and bump default version

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -245,7 +245,7 @@ repository.  For versions of Boost older than 1.63.0, the
 SourceForge repository should be used.  The default is False.
 
 - __version__: The version of Boost source to download.  The default
-value is `1.74.0`.
+value is `1.76.0`.
 
 __Examples__
 

--- a/hpccm/building_blocks/boost.py
+++ b/hpccm/building_blocks/boost.py
@@ -82,7 +82,7 @@ class boost(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     SourceForge repository should be used.  The default is False.
 
     version: The version of Boost source to download.  The default
-    value is `1.74.0`.
+    value is `1.76.0`.
 
     # Examples
 
@@ -103,14 +103,14 @@ class boost(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         self.__b2_opts = kwargs.get('b2_opts', [])
         self.__baseurl = kwargs.get('baseurl',
-                                    'https://dl.bintray.com/boostorg/release/__version__/source')
+                                    'https://boostorg.jfrog.io/artifactory/main/release/__version__/source')
         self.__bootstrap_opts = kwargs.get('bootstrap_opts', [])
         self.__ospackages = kwargs.get('ospackages', [])
         self.__parallel = kwargs.get('parallel', '$(nproc)')
         self.__prefix = kwargs.get('prefix', '/usr/local/boost')
         self.__python = kwargs.get('python', False)
         self.__sourceforge = kwargs.get('sourceforge', False)
-        self.__version = kwargs.get('version', '1.74.0')
+        self.__version = kwargs.get('version', '1.76.0')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory

--- a/test/test_boost.py
+++ b/test/test_boost.py
@@ -37,7 +37,7 @@ class Test_boost(unittest.TestCase):
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.74.0
+r'''# Boost version 1.76.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,11 +46,11 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_74_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_74_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_76_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_76_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_74_0.tar.bz2 /var/tmp/boost_1_74_0
+    rm -rf /var/tmp/boost_1_76_0.tar.bz2 /var/tmp/boost_1_76_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @centos
@@ -59,7 +59,7 @@ ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
         """Default boost building block"""
         b = boost()
         self.assertEqual(str(b),
-r'''# Boost version 1.74.0
+r'''# Boost version 1.76.0
 RUN yum install -y \
         bzip2 \
         bzip2-devel \
@@ -68,11 +68,11 @@ RUN yum install -y \
         which \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.74.0/source/boost_1_74_0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_74_0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/boost_1_74_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2 && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_76_0.tar.bz2 -C /var/tmp -j && \
+    cd /var/tmp/boost_1_76_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
-    rm -rf /var/tmp/boost_1_74_0.tar.bz2 /var/tmp/boost_1_74_0
+    rm -rf /var/tmp/boost_1_76_0.tar.bz2 /var/tmp/boost_1_76_0
 ENV LD_LIBRARY_PATH=/usr/local/boost/lib:$LD_LIBRARY_PATH''')
 
     @ubuntu
@@ -90,7 +90,7 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
     cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost  && \
     ./b2 -j$(nproc) -q install && \
@@ -134,7 +134,7 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.68.0/source/boost_1_68_0.tar.bz2 && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_68_0.tar.bz2 -C /var/tmp -j && \
     cd /var/tmp/boost_1_68_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 -j$(nproc) -q install && \
@@ -156,7 +156,7 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
     cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost --with-libraries=atomic,chrono && \
     ./b2 -j$(nproc) -q install && \
@@ -177,7 +177,7 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.bz2 && \
     mkdir -p /var/tmp && tar -x -f /var/tmp/boost_1_72_0.tar.bz2 -C /var/tmp -j && \
     cd /var/tmp/boost_1_72_0 && ./bootstrap.sh --prefix=/usr/local/boost --without-libraries=python && \
     ./b2 cxxflags="-std=c++14" -j$(nproc) -q install && \


### PR DESCRIPTION
## Pull Request Description

Fix #377 

Update Boost to use the new jfrog download site and bump the default version to the latest.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
