### PR TITLE
Bump NVSHMEM to 2.2.1 and set LD_LIBRARY_PATH

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3227,6 +3227,11 @@ The default is empty.
 should be installed.  If True, adds `automake` to the list of OS
 packages.  The default is False.
 
+- __ldconfig__: Boolean flag to specify whether the NVSHMEM library
+directory should be added dynamic linker cache.  If False, then
+`LD_LIBRARY_PATH` is modified to include the NVSHMEM library
+directory. The default value is False.
+
 - __make_variables__: Dictionary of environment variables and values to
 set when building NVSHMEM.  The default is an empty dictionary.
 
@@ -3247,7 +3252,7 @@ context. The default value is empty. Either this parameter or
 default is empty, i.e., do not build NVSHMEM with SHMEM support.
 
 - __version__: The version of NVSHMEM source to download.  The default
-value is `2.1.2`.
+value is `2.2.1`.
 
 __Examples__
 

--- a/hpccm/building_blocks/nvshmem.py
+++ b/hpccm/building_blocks/nvshmem.py
@@ -26,6 +26,7 @@ import posixpath
 
 import hpccm.templates.downloader
 import hpccm.templates.envvars
+import hpccm.templates.ldconfig
 import hpccm.templates.rm
 import hpccm.templates.tar
 
@@ -38,7 +39,8 @@ from hpccm.primitives.environment import environment
 from hpccm.primitives.shell import shell
 
 class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
-              hpccm.templates.rm, hpccm.templates.tar):
+              hpccm.templates.ldconfig, hpccm.templates.rm,
+              hpccm.templates.tar):
     """The `nvshmem` building block builds and installs the
     [NVSHMEM](https://developer.nvidia.com/nvshmem) component.
 
@@ -62,6 +64,11 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
     should be installed.  If True, adds `automake` to the list of OS
     packages.  The default is False.
 
+    ldconfig: Boolean flag to specify whether the NVSHMEM library
+    directory should be added dynamic linker cache.  If False, then
+    `LD_LIBRARY_PATH` is modified to include the NVSHMEM library
+    directory. The default value is False.
+
     make_variables: Dictionary of environment variables and values to
     set when building NVSHMEM.  The default is an empty dictionary.
 
@@ -82,7 +89,7 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
     default is empty, i.e., do not build NVSHMEM with SHMEM support.
 
     version: The version of NVSHMEM source to download.  The default
-    value is `2.1.2`.
+    value is `2.2.1`.
 
     # Examples
 
@@ -108,7 +115,7 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__release = kwargs.pop('release', '0')
         self.__shmem = kwargs.pop('shmem', None)
         self.__src_directory = kwargs.pop('src_directory', None)
-        self.__version = kwargs.pop('version', '2.1.2')
+        self.__version = kwargs.pop('version', '2.2.1')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         # Set the download specific parameters
@@ -124,6 +131,8 @@ class nvshmem(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
             posixpath.join(self.__prefix, 'lib'))
         self.environment_variables['PATH'] = '{}:$PATH'.format(
             posixpath.join(self.__prefix, 'bin'))
+        if not self.ldconfig:
+            self.environment_variables['LD_LIBRARY_PATH'] = '{}:$LD_LIBRARY_PATH'.format(posixpath.join(self.__prefix, 'lib'))
 
         # Add packages
         if self.__hydra:

--- a/test/test_nvshmem.py
+++ b/test/test_nvshmem.py
@@ -37,18 +37,19 @@ class Test_nvshmem(unittest.TestCase):
         """nvshmem defaults"""
         n = nvshmem()
         self.assertEqual(str(n),
-r'''# NVSHMEM 2.1.2
+r'''# NVSHMEM 2.2.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/compute/redist/nvshmem/2.1.2/source/nvshmem_src_2.1.2-0.txz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem_src_2.1.2-0.txz -C /var/tmp -J && \
-    cd /var/tmp/nvshmem_src_2.1.2-0 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/compute/redist/nvshmem/2.2.1/source/nvshmem_src_2.2.1-0.txz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem_src_2.2.1-0.txz -C /var/tmp -J && \
+    cd /var/tmp/nvshmem_src_2.2.1-0 && \
     CUDA_HOME=/usr/local/cuda NVSHMEM_MPI_SUPPORT=0 NVSHMEM_PREFIX=/usr/local/nvshmem make -j$(nproc) install && \
-    rm -rf /var/tmp/nvshmem_src_2.1.2-0 /var/tmp/nvshmem_src_2.1.2-0.txz
+    rm -rf /var/tmp/nvshmem_src_2.2.1-0 /var/tmp/nvshmem_src_2.2.1-0.txz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -68,6 +69,7 @@ COPY nvshmem_0.4.1-0+cuda10_x86_64.txz /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.tx
 RUN mkdir -p /usr/local/nvshmem && tar -x -f /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.txz -C /usr/local/nvshmem -J --strip-components=1 && \
     rm -rf /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.txz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -86,6 +88,7 @@ COPY nvshmem_0.4.1-0+cuda10_x86_64.txz /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.tx
 RUN mkdir -p /usr/local/nvshmem && tar -x -f /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.txz -C /usr/local/nvshmem -J --strip-components=1 && \
     rm -rf /var/tmp/nvshmem_0.4.1-0+cuda10_x86_64.txz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -107,6 +110,7 @@ RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem_src_2.1.2-0.txz -C /var/tmp 
     CUDA_HOME=/usr/local/cuda NVSHMEM_MPI_SUPPORT=0 NVSHMEM_PREFIX=/usr/local/nvshmem make -j$(nproc) install && \
     rm -rf /var/tmp/nvshmem_src_2.1.2-0 /var/tmp/nvshmem_src_2.1.2-0.txz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -135,6 +139,7 @@ RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvshmem_src_2.1.2-0.txz -C /var/tmp 
     ./scripts/install_hydra.sh /var/tmp /usr/local/nvshmem && \
     rm -rf /var/tmp/nvshmem_src_2.1.2-0 /var/tmp/nvshmem_src_2.1.2-0.txz
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -148,6 +153,7 @@ ENV CPATH=/usr/local/nvshmem/include:$CPATH \
 r'''# NVSHMEM
 COPY --from=0 /usr/local/nvshmem /usr/local/nvshmem
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')
 
@@ -161,5 +167,6 @@ ENV CPATH=/usr/local/nvshmem/include:$CPATH \
 r'''# NVSHMEM
 COPY --from=0 /usr/local/nvshmem /usr/local/nvshmem
 ENV CPATH=/usr/local/nvshmem/include:$CPATH \
+    LD_LIBRARY_PATH=/usr/local/nvshmem/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/nvshmem/lib:$LIBRARY_PATH \
     PATH=/usr/local/nvshmem/bin:$PATH''')


### PR DESCRIPTION
## Pull Request Description

Bump the default NVSHMEM version to 2.2.1 and automatically add the lib directory to the search path.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
