### PR TITLE
Fix tiny typo in primitives.md

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -22,7 +22,7 @@ is `docker` (Singularity specific).
 
 - ___distro__: The underlying Linux distribution of the base image.
 Valid values are `centos`, `centos7`, `centos8`, `redhat`, `rhel`,
-`rhel7`, `rhel8, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
+`rhel7`, `rhel8`, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
 and `ubuntu20`.  By default, the primitive attempts to figure out
 the Linux distribution by inspecting the image identifier, and
 falls back to `ubuntu` if unable to determine the Linux

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -50,7 +50,7 @@ class baseimage(object):
 
     _distro: The underlying Linux distribution of the base image.
     Valid values are `centos`, `centos7`, `centos8`, `redhat`, `rhel`,
-    `rhel7`, `rhel8, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
+    `rhel7`, `rhel8`, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
     and `ubuntu20`.  By default, the primitive attempts to figure out
     the Linux distribution by inspecting the image identifier, and
     falls back to `ubuntu` if unable to determine the Linux


### PR DESCRIPTION
## Pull Request Description
One missing "`" in markdown of baseimage `_distro` argument.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
