### PR TITLE
use xpmem github repository instead of gitlab

### DIFF
--- a/hpccm/building_blocks/xpmem.py
+++ b/hpccm/building_blocks/xpmem.py
@@ -33,7 +33,7 @@ from hpccm.primitives.comment import comment
 
 class xpmem(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     """The `xpmem` building block builds and installs the user space
-    library from the [XPMEM](https://gitlab.com/hjelmn/xpmem)
+    library from the [XPMEM](https://github.com/hjelmn/xpmem)
     component.
 
     # Parameters
@@ -111,7 +111,7 @@ class xpmem(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
                                                       'libtool', 'make'])
         self.__prefix = kwargs.pop('prefix', '/usr/local/xpmem')
         self.__repository = kwargs.pop('repository',
-                                       'https://gitlab.com/hjelmn/xpmem.git')
+                                       'https://github.com/hjelmn/xpmem.git')
 
         # Setup the environment variables
         self.environment_variables['CPATH'] = '{}:$CPATH'.format(

--- a/test/test_xpmem.py
+++ b/test/test_xpmem.py
@@ -48,7 +48,7 @@ RUN apt-get update -y && \
         libtool \
         make && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://gitlab.com/hjelmn/xpmem.git xpmem && cd - && \
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://github.com/hjelmn/xpmem.git xpmem && cd - && \
     cd /var/tmp/xpmem && \
     autoreconf --install && \
     cd /var/tmp/xpmem &&   ./configure --prefix=/usr/local/xpmem --disable-kernel-module && \
@@ -75,7 +75,7 @@ RUN yum install -y \
         libtool \
         make && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://gitlab.com/hjelmn/xpmem.git xpmem && cd - && \
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://github.com/hjelmn/xpmem.git xpmem && cd - && \
     cd /var/tmp/xpmem && \
     autoreconf --install && \
     cd /var/tmp/xpmem &&   ./configure --prefix=/usr/local/xpmem --disable-kernel-module && \
@@ -103,7 +103,7 @@ RUN apt-get update -y && \
         libtool \
         make && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://gitlab.com/hjelmn/xpmem.git xpmem && cd - && \
+RUN mkdir -p /var/tmp && cd /var/tmp && git clone --depth=1 --branch master https://github.com/hjelmn/xpmem.git xpmem && cd - && \
     cd /var/tmp/xpmem && \
     autoreconf --install && \
     cd /var/tmp/xpmem &&   ./configure --prefix=/usr/local/xpmem --disable-kernel-module && \


### PR DESCRIPTION
## Pull Request Description

HPCCM should use xpmem github repository instead of gitlab.
Indeed gitlab repository has not updated for [3 years](https://gitlab.com/hjelmn/xpmem/-/commits/master/) while github one is still [under development](https://github.com/hjelmn/xpmem/commits/master) including recent contributions from ucx devs.
Even Spack is using xpmem from github: https://github.com/spack/spack/blob/develop/var/spack/repos/builtin/packages/xpmem/package.py#L17


## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
