### PR TITLE
Bump default NVHPC version to 21.11

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3157,7 +3157,7 @@ wildcards are supported.  The default is an empty list.
 
 - __version__: The version of the HPC SDK to use.  Note when `package`
 is set the version is determined automatically from the package
-file name.  The default value is `21.9`.
+file name.  The default value is `21.11`.
 
 __Examples__
 

--- a/hpccm/building_blocks/nvhpc.py
+++ b/hpccm/building_blocks/nvhpc.py
@@ -102,7 +102,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     version: The version of the HPC SDK to use.  Note when `package`
     is set the version is determined automatically from the package
-    file name.  The default value is `21.9`.
+    file name.  The default value is `21.11`.
 
     # Examples
 
@@ -153,14 +153,16 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__redist = kwargs.get('redist', [])
         self.__stdpar_cudacc = kwargs.get('stdpar_cudacc', None)
         self.__url = kwargs.get('url', None)
-        self.__version = kwargs.get('version', '21.9')
+        self.__version = kwargs.get('version', '21.11')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
         self.__year = '' # Filled in by __version()
 
         self.toolchain = toolchain(CC='nvc', CXX='nvc++', F77='nvfortran',
                                    F90='nvfortran', FC='nvfortran')
 
-        if StrictVersion(self.__version) >= StrictVersion('21.7'):
+        if StrictVersion(self.__version) >= StrictVersion('21.11'):
+            self.__cuda_version_default = '11.5'
+        elif StrictVersion(self.__version) >= StrictVersion('21.7'):
             self.__cuda_version_default = '11.4'
         elif StrictVersion(self.__version) >= StrictVersion('21.5'):
             self.__cuda_version_default = '11.3'
@@ -290,7 +292,9 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
                 posixpath.join(self.__basepath, 'comm_libs', 'mpi', 'bin'))
         elif self.__hpcx:
             # Set environment for HPC-X
-            if StrictVersion(self.__version) >= StrictVersion('21.9'):
+            if StrictVersion(self.__version) >= StrictVersion('21.11'):
+                hpcx_version = '2.10.beta'
+            elif StrictVersion(self.__version) >= StrictVersion('21.9'):
                 hpcx_version = '2.9.0'
             elif StrictVersion(self.__version) >= StrictVersion('21.7'):
                 hpcx_version = '2.8.1'

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -38,7 +38,7 @@ class Test_nvhpc(unittest.TestCase):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 21.9
+r'''# NVIDIA HPC SDK version 21.11
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bc \
@@ -51,13 +51,13 @@ RUN apt-get update -y && \
         openssh-client \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -66,7 +66,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nvshmem/lib:
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertEqual(str(n),
-r'''# NVIDIA HPC SDK version 21.9
+r'''# NVIDIA HPC SDK version 21.11
 RUN yum install -y \
         bc \
         gcc \
@@ -78,13 +78,13 @@ RUN yum install -y \
         wget \
         which && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_219_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/bin:$PATH''')
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/21.11/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
+    rm -rf /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2021_2111_Linux_x86_64_cuda_multi.tar.gz
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -219,10 +219,10 @@ RUN apt-get update -y && \
         libnuma1 \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/mpi/bin:$PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -242,11 +242,11 @@ RUN yum install -y \
         numactl-libs \
         openssh-clients && \
     rm -rf /var/cache/yum/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/11.0/nccl/lib/libnccl.so
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/math_libs/11.0/lib64/libcufft.so.10
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/21.9/math_libs/11.0/lib64/libcublas.so.11
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.9/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/REDIST/comm_libs/11.0/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/11.0/nccl/lib/libnccl.so
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/REDIST/math_libs/11.0/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/11.0/lib64/libcufft.so.10
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/REDIST/math_libs/11.0/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/11.0/lib64/libcublas.so.11
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/comm_libs/11.0/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/21.11/math_libs/11.0/lib64:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""


### PR DESCRIPTION
## Pull Request Description

Bump default NVHPC version to 21.11

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
