### PR TITLE
Print the exception traceback even without --print-exceptions

### DIFF
--- a/hpccm/recipe.py
+++ b/hpccm/recipe.py
@@ -25,6 +25,7 @@ from distutils.version import StrictVersion
 import logging
 import os
 import sys
+import traceback
 
 import hpccm
 
@@ -84,7 +85,7 @@ def include(recipe_file, _globals=None, _locals=None, prepend_path=True,
         if raise_exceptions:
             raise_from(e, e)
         else:
-            logging.error(e)
+            traceback.print_exc()
             exit(1)
 
 def recipe(recipe_file, cpu_target=None, ctype=container_type.DOCKER,


### PR DESCRIPTION
## Pull Request Description

Improve the output messages for erroneous recipes to help determine the issue.

Prior to this change:
```
$ hpccm --recipe my_recipes/pos.py 
ERROR: __init__() takes 1 positional argument but 2 were given
```

With this change:
```
$ hpccm --recipe my_recipes/pos.py 
Traceback (most recent call last):
  File "/home/smcmillan/git/hpc-container-maker/hpccm/recipe.py", line 83, in include
    exec(compile(f.read(), recipe_file, 'exec'), _globals, _locals)
  File "my_recipes/pos.py", line 1, in <module>
    Stage0 += baseimage('foo')
TypeError: __init__() takes 1 positional argument but 2 were given
```

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
