### PR TITLE
Update recipes for CentOS 8 EOL

### DIFF
--- a/recipes/easybuild.py
+++ b/recipes/easybuild.py
@@ -15,9 +15,9 @@ import os
 
 Stage0 += comment(__doc__, reformat=False)
 
-Stage0 += baseimage(image='centos:8')
+Stage0 += baseimage(image='rockylinux:8')
 
-Stage0 += shell(commands=['yum update -y centos-release',
+Stage0 += shell(commands=['yum update -y rocky-release',
                           'rm -rf /var/cache/yum/*'])
 
 # Base dependencies

--- a/recipes/hpcbase-nvhpc-mvapich2.py
+++ b/recipes/hpcbase-nvhpc-mvapich2.py
@@ -19,11 +19,11 @@ if USERARG.get('nvhpc_eula_accept', False):
 else:
   raise RuntimeError('NVIDIA HPC SDK EULA not accepted. To accept, use "--userarg nvhpc_eula_accept=yes"\nSee NVIDIA HPC SDK EULA at https://docs.nvidia.com/hpc-sdk/eula')
 
-# Choose between either Ubuntu 18.04 (default) or CentOS 8
-# Add '--userarg centos=true' to the command line to select CentOS
+# Choose between either Ubuntu 18.04 (default) or RockyLinux 8
+# Add '--userarg rockylinux=true' to the command line to select RockyLinux
 image = 'ubuntu:18.04'
-if USERARG.get('centos', False):
-  image = 'centos:8'
+if USERARG.get('rockylinux', False):
+  image = 'rockylinux:8'
 
 ######
 # Devel stage

--- a/recipes/hpcbase-nvhpc-openmpi.py
+++ b/recipes/hpcbase-nvhpc-openmpi.py
@@ -19,11 +19,11 @@ if USERARG.get('nvhpc_eula_accept', False):
 else:
   raise RuntimeError('NVIDIA HPC SDK EULA not accepted. To accept, use "--userarg nvhpc_eula_accept=yes"\nSee NVIDIA HPC SDK EULA at https://docs.nvidia.com/hpc-sdk/eula')
 
-# Choose between either Ubuntu 18.04 (default) or CentOS 8
-# Add '--userarg centos=true' to the command line to select CentOS
+# Choose between either Ubuntu 18.04 (default) or RockyLinux 8
+# Add '--userarg rockylinux=true' to the command line to select RockyLinux
 image = 'ubuntu:18.04'
-if USERARG.get('centos', False):
-  image = 'centos:8'
+if USERARG.get('rockylinux', False):
+  image = 'rockylinux:8'
 
 ######
 # Devel stage


### PR DESCRIPTION
## Pull Request Description

Update recipes using CentOS 8 to use Rocky Linux 8 since CentOS 8 is EOL.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
