### PR TITLE
Install the NVIDIA HPC SDK from package repositories

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -549,7 +549,7 @@ use the available pre-compiled package.  For all other processors,
 the default is True.
 
 - __version__: The version of CMake to download.  The default value is
-`3.18.3`.
+`3.22.2`.
 
 __Examples__
 
@@ -3097,8 +3097,10 @@ nvhpc(self, **kwargs)
 ```
 The `nvhpc` building block downloads and installs the [NVIDIA HPC
 SDK](https://developer.nvidia.com/hpc-sdk).  By default, the
-NVIDIA HPC SDK is downloaded, although a local tar package may
-used instead by specifying the `package` parameter.
+NVIDIA HPC SDK is installed from a package repository.
+Alternatively the tar package can be downloaded by specifying the
+`tarball` parameter, or a local tar package may used instead by
+specifying the `package` parameter.
 
 You must agree to the [NVIDIA HPC SDK End-User License Agreement](https://docs.nvidia.com/hpc-sdk/eula) to use this
 building block.
@@ -3112,15 +3114,16 @@ __Parameters__
 
 - __cuda__: The default CUDA version to configure.  The default is an
 empty value, i.e., use the latest version supported by the NVIDIA
-HPC SDK.
+HPC SDK.  This value is ignored if installing from the package
+repository.
 
 - __cuda_multi__: Boolean flag to specify whether the NVIDIA HPC SDK
 support for multiple CUDA versions should be installed.  The
 default value is `True`.
 
 - __environment__: Boolean flag to specify whether the environment
-(`LD_LIBRARY_PATH`, `MANPATH`, and `PATH`) should be modified to
-include the NVIDIA HPC SDK. The default is True.
+(`CPATH`, `LD_LIBRARY_PATH`, `MANPATH`, and `PATH`) should be
+modified to include the NVIDIA HPC SDK. The default is True.
 
 - __eula__: By setting this value to `True`, you agree to the [NVIDIA HPC SDK End-User License Agreement](https://docs.nvidia.com/hpc-sdk/eula).
 The default value is `False`.
@@ -3128,30 +3131,36 @@ The default value is `False`.
 - __extended_environment__: Boolean flag to specify whether an extended
 set of environment variables should be defined.  If True, the
 following environment variables `CC`, `CPP`, `CXX`, `F77`, `F90`,
-and `FC`.  If False, then only `LD_LIBRARY_PATH`, `MANPATH`, and
-`PATH` will be extended to include the NVIDIA HPC SDK.  The
-default value is `False`.
+and `FC`.  If False, then only `CPATH`, `LD_LIBRARY_PATH`,
+`MANPATH`, and `PATH` will be extended to include the NVIDIA HPC
+SDK.  The default value is `False`.
 
 - __mpi__: Boolean flag to specify whether MPI should be included in the
 environment.  The default value is `True`.
 
 - __ospackages__: List of OS packages to install prior to installing the
-NVIDIA HPC SDK.  For Ubuntu, the default values are `bc`,
-`debianutils`, `gcc`, `g++`, `gfortran`, `libatomic`, `libnuma1`,
-`openssh-client`, and `wget`.  For RHEL-based Linux distributions,
-the default values are `bc`, `gcc`, `gcc-c++`, `gcc-gfortran`,
-`libatomic`, `numactl-libs`, `openssh-clients`, `wget`, and
-`which`.
+NVIDIA HPC SDK.  The default value is `ca-certificates`.  If not
+installing from the package repository, then for Ubuntu, the
+default values are `bc`, `debianutils`, `gcc`, `g++`, `gfortran`,
+`libatomic`, `libnuma1`, `openssh-client`, and `wget`, and for
+RHEL-based Linux distributions, the default values are `bc`,
+`gcc`, `gcc-c++`, `gcc-gfortran`, `libatomic`, `numactl-libs`,
+`openssh-clients`, `wget`, and `which`.
 
 - __package__: Path to the NVIDIA HPC SDK tar package file relative to
 the local build context.  The default value is empty.
 
 - __prefix__: The top level install prefix.  The default value is
-`/opt/nvidia/hpc_sdk`.
+`/opt/nvidia/hpc_sdk`.  This value is ignored when installing from
+the package repository.
 
 - __redist__: The list of redistributable files to copy into the runtime
 stage.  The paths are relative to the `REDIST` directory and
 wildcards are supported.  The default is an empty list.
+
+- __tarball__: Boolean flag to specify whether the NVIDIA HPC SDK should
+be installed by downloading the tar package file.  If False,
+install from the package repository.  The default is False.
 
 - __url__: The location of the package that should be installed.  The default value is `https://developer.download.nvidia.com/hpc-sdk/nvhpc_X_Y_Z_cuda_multi.tar.gz`, where `X, `Y`, and `Z` are the year, version, and architecture whose values are automatically determined.
 
@@ -3164,6 +3173,10 @@ __Examples__
 
 ```python
 nvhpc(eula=True)
+```
+
+```python
+nvhpc(eula=True, tarball=True)
 ```
 
 ```python

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -37,25 +37,19 @@ class Test_nvhpc(unittest.TestCase):
     def test_defaults_ubuntu(self):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 22.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        bc \
-        debianutils \
-        g++ \
-        gcc \
-        gfortran \
-        libatomic1 \
-        libnuma1 \
-        openssh-client \
-        wget && \
+        ca-certificates && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+RUN echo "deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        nvhpc-22-2-cuda-multi && \
+    rm -rf /var/lib/apt/lists/*
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
     MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/man:$MANPATH \
     PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/bin:$PATH''')
 
@@ -65,24 +59,18 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:
     def test_defaults_centos(self):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 22.2
 RUN yum install -y \
-        bc \
-        gcc \
-        gcc-c++ \
-        gcc-gfortran \
-        libatomic \
-        numactl-libs \
-        openssh-clients \
-        wget \
-        which && \
+        ca-certificates && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.download.nvidia.com/hpc-sdk/22.2/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
-    rm -rf /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2022_222_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+RUN yum install -y yum-utils && \
+    yum-config-manager --add-repo https://developer.download.nvidia.com/hpc-sdk/rhel/nvhpc.repo && \
+    yum install -y \
+        nvhpc-cuda-multi-22.2 && \
+    rm -rf /var/cache/yum/*
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/include:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
     MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/man:$MANPATH \
     PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/bin:$PATH''')
 
@@ -93,7 +81,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/nvshmem/lib:
         """Local package"""
         n = nvhpc(eula=True,
                   package='nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz')
-        self.assertEqual(str(n),        
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 20.7
 COPY nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
 RUN yum install -y \
@@ -110,7 +98,8 @@ RUN yum install -y \
 RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz -C /var/tmp -z && \
     cd /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
     rm -rf /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/math_libs/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/mpi/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
     MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/man:$MANPATH \
     PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/mpi/bin:$PATH''')
 
@@ -121,7 +110,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/lib:
         """Extended environment"""
         n = nvhpc(eula=True, extended_environment=True,
                   package='nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz')
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 20.7
 COPY nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
 RUN yum install -y \
@@ -139,6 +128,7 @@ RUN mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_mul
     cd /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
     rm -rf /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi /var/tmp/nvhpc_2020_207_Linux_x86_64_cuda_multi.tar.gz
 ENV CC=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc \
+    CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/math_libs/include:/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/comm_libs/mpi/include:$CPATH \
     CPP=cpp \
     CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc++ \
     F77=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvfortran \
@@ -153,8 +143,8 @@ ENV CC=/opt/nvidia/hpc_sdk/Linux_x86_64/20.7/compilers/bin/nvc \
     @docker
     def test_aarch64(self):
         """Default HPC SDK building block on aarch64"""
-        n = nvhpc(cuda_multi=False, eula=True, version='21.2')
-        self.assertEqual(str(n),
+        n = nvhpc(cuda_multi=False, eula=True, version='21.2', tarball=True)
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 21.2
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -172,7 +162,8 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2.tar.gz -C /var/tmp -z && \
     cd /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2 && NVHPC_ACCEPT_EULA=accept NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
     rm -rf /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2 /var/tmp/nvhpc_2021_212_Linux_aarch64_cuda_11.2.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/math_libs/include:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/lib:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
     MANPATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/man:$MANPATH \
     PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/profilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/compilers/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/cuda/bin:/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/mpi/bin:$PATH''')
 
@@ -181,8 +172,9 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_aarch64/21.2/comm_libs/nvshmem/lib
     @docker
     def test_ppc64le(self):
         """Default HPC SDK building block on ppc64le"""
-        n = nvhpc(eula=True, cuda_multi=False, cuda='11.0', version='20.7')
-        self.assertEqual(str(n),
+        n = nvhpc(eula=True, cuda_multi=False, cuda='11.0', version='20.7',
+                  tarball=True)
+        self.assertMultiLineEqual(str(n),
 r'''# NVIDIA HPC SDK version 20.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -200,7 +192,8 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     mkdir -p /var/tmp && tar -x -f /var/tmp/nvhpc_2020_207_Linux_ppc64le_cuda_11.0.tar.gz -C /var/tmp -z && \
     cd /var/tmp/nvhpc_2020_207_Linux_ppc64le_cuda_11.0 && NVHPC_ACCEPT_EULA=accept NVHPC_DEFAULT_CUDA=11.0 NVHPC_INSTALL_DIR=/opt/nvidia/hpc_sdk NVHPC_SILENT=true ./install && \
     rm -rf /var/tmp/nvhpc_2020_207_Linux_ppc64le_cuda_11.0 /var/tmp/nvhpc_2020_207_Linux_ppc64le_cuda_11.0.tar.gz
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/math_libs/include:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/mpi/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/cuda/lib64:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/mpi/lib:$LD_LIBRARY_PATH \
     MANPATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/compilers/man:$MANPATH \
     PATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/profilers/bin:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/compilers/bin:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/cuda/bin:/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/mpi/bin:$PATH''')
 
@@ -211,7 +204,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_ppc64le/20.7/comm_libs/nvshmem/lib
         """Runtime"""
         n = nvhpc(eula=True, redist=['compilers/lib/*'])
         r = n.runtime()
-        self.assertEqual(r,
+        self.assertMultiLineEqual(r,
 r'''# NVIDIA HPC SDK
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -235,7 +228,7 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/mpi/lib:/opt
                           'math_libs/11.0/lib64/libcufft.so.10',
                           'math_libs/11.0/lib64/libcublas.so.11'])
         r = n.runtime()
-        self.assertEqual(r,
+        self.assertMultiLineEqual(r,
 r'''# NVIDIA HPC SDK
 RUN yum install -y \
         libatomic \
@@ -250,21 +243,10 @@ ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/22.2/comm_libs/11.0/nccl/li
 
     def test_toolchain(self):
         """Toolchain"""
-        n = nvhpc(version='20.9')
+        n = nvhpc()
         tc = n.toolchain
         self.assertEqual(tc.CC, 'nvc')
         self.assertEqual(tc.CXX, 'nvc++')
         self.assertEqual(tc.FC, 'nvfortran')
         self.assertEqual(tc.F77, 'nvfortran')
         self.assertEqual(tc.F90, 'nvfortran')
-        self.assertEqual(tc.CUDA_HOME, None)
-
-        n2 = nvhpc(cuda='11.0', cuda_home=True, version='20.9')
-        tc2 = n2.toolchain
-        self.assertEqual(tc2.CC, 'nvc')
-        self.assertEqual(tc2.CXX, 'nvc++')
-        self.assertEqual(tc2.FC, 'nvfortran')
-        self.assertEqual(tc2.F77, 'nvfortran')
-        self.assertEqual(tc2.F90, 'nvfortran')
-        self.assertEqual(tc2.CUDA_HOME,
-                         '/opt/nvidia/hpc_sdk/Linux_x86_64/20.9/cuda/11.0')


### PR DESCRIPTION
## Pull Request Description

Make the default behavior to install the NVIDIA HPC SDK from the apt / yum repositories rather than using the tarball.

The previous behavior can still be selected by setting `tarball=True`.

Also makes the environment set match the environment modules (`CPATH`).

Also switches to use multi-line comparisons in the test case to make it easier to identify issues.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
