### PR TITLE
Bump ARM Allinea studio version to 22.0 

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -150,7 +150,8 @@ Studio. The default is True.
 The default value is `False`.
 
 - __microarchitectures__: List of microarchitectures to install.
-Available values are `generic`, `generic-sve` for all versions,
+From 22.0 version, only `generic` is available.
+Available values are `generic`, `generic-sve` for version 21.1,
 and `neoverse-n1`, `thunderx2t99` are valid for versions <= 20.3.
 Irrespective of this setting, the generic implementation will
 always be installed.
@@ -170,7 +171,7 @@ defined, the tarball in the local build context will be used
 rather than downloading the tarball from the web.
 
 - __version__: The version of Arm Allinea Studio to install.  The
-default value is `21.1`.  Due to differences in the packaging
+default value is `22.0`.  Due to differences in the packaging
 scheme, versions prior to 20.2 are not supported.
 
 __Examples__

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -181,9 +181,12 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
                 self.__url_string = "ACfL"
 
             self.__installer_template = 'arm-compiler-for-linux_{{}}_{0}.sh'.format(self.__directory_string)
-
+            if  hpccm.config.g_linux_version >= StrictVersion('22.04'):
+                python2_package = "python2"
+            else:
+                python2_package = "python"
             if not self.__ospackages:
-                self.__ospackages = ['libc6-dev', 'lmod', 'python', 'tar',
+                self.__ospackages = ['libc6-dev', 'lmod', python2_package, 'tar',
                                      'tcl', 'wget']
 
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -88,7 +88,7 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     rather than downloading the tarball from the web.
 
     version: The version of Arm Allinea Studio to install.  The
-    default value is `21.1`.  Due to differences in the packaging
+    default value is `22.0`.  Due to differences in the packaging
     scheme, versions prior to 20.2 are not supported.
 
     # Examples
@@ -123,7 +123,7 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
         self.__package_string = '' # Filled in by __distro()
         self.__prefix = kwargs.get('prefix', '/opt/arm')
         self.__tarball = kwargs.get('tarball', None)
-        self.__version = kwargs.get('version', '21.1')
+        self.__version = kwargs.get('version', '22.0')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
         self.toolchain = toolchain(CC='armclang', CXX='armclang++',
@@ -316,6 +316,9 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
                             '21.1': {
                                 'generic': 'AArch64',
                                 'generic-sve': 'AArch64-SVE'
+                                },
+                            '22.0': {
+                                'generic': 'AArch64'
                                 }
                             }
         for microarch in self.__microarchitectures:
@@ -329,7 +332,6 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
             self.rt += copy(_from=_from,
                             src=[posixpath.join(armpl_arm_redist_path, lib)
                                  for lib in ['libamath.so',
-                                             'libamath_dummy.so',
                                              'libastring.so']],
                             dest=posixpath.join(armpl_arm_redist_path, ''))
             armpl_gcc_redist_path = posixpath.join(
@@ -342,7 +344,6 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
             self.rt += copy(_from=_from,
                             src=[posixpath.join(armpl_gcc_redist_path, lib)
                                  for lib in ['libamath.so',
-                                             'libamath_dummy.so',
                                              'libastring.so']],
                             dest=posixpath.join(armpl_gcc_redist_path, ''))
 

--- a/hpccm/building_blocks/arm_allinea_studio.py
+++ b/hpccm/building_blocks/arm_allinea_studio.py
@@ -68,7 +68,8 @@ class arm_allinea_studio(bb_base, hpccm.templates.envvars, hpccm.templates.rm,
     The default value is `False`.
 
     microarchitectures: List of microarchitectures to install.
-    Available values are `generic`, `generic-sve` for all versions,
+    From 22.0 version, only `generic` is available.
+    Available values are `generic`, `generic-sve` for version 21.1,
     and `neoverse-n1`, `thunderx2t99` are valid for versions <= 20.3.
     Irrespective of this setting, the generic implementation will
     always be installed.

--- a/test/test_arm_allinea_studio.py
+++ b/test/test_arm_allinea_studio.py
@@ -38,7 +38,7 @@ class Test_arm_allinea_studio(unittest.TestCase):
         """Default arm_allinea_studio building block"""
         a = arm_allinea_studio(eula=True)
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 21.1
+r'''# Arm Allinea Studio version 22.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6-dev \
@@ -48,10 +48,10 @@ RUN apt-get update -y && \
         tcl \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/21-1/ACfL/arm-compiler-for-linux_21.1_Ubuntu-20.04_aarch64.tar && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-20.04_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-20.04 && ./arm-compiler-for-linux_21.1_Ubuntu-20.04.sh --install-to /opt/arm --accept && \
-    rm -rf /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-20.04_aarch64.tar /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-20.04
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/22-0/ACfL/arm-compiler-for-linux_22.0_Ubuntu-20.04_aarch64.tar && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-20.04_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-20.04 && ./arm-compiler-for-linux_22.0_Ubuntu-20.04.sh --install-to /opt/arm --accept && \
+    rm -rf /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-20.04_aarch64.tar /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-20.04
 ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
@@ -61,7 +61,7 @@ ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
         """Default arm_allinea_studio building block"""
         a = arm_allinea_studio(eula=True)
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 21.1
+r'''# Arm Allinea Studio version 22.0
 RUN yum install -y epel-release && \
     yum install -y \
         Lmod \
@@ -69,10 +69,10 @@ RUN yum install -y epel-release && \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/21-1/ACfL/arm-compiler-for-linux_21.1_RHEL-7_aarch64.tar && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_21.1_RHEL-7_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/arm-compiler-for-linux_21.1_RHEL-7 && ./arm-compiler-for-linux_21.1_RHEL-7.sh --install-to /opt/arm --accept && \
-    rm -rf /var/tmp/arm-compiler-for-linux_21.1_RHEL-7_aarch64.tar /var/tmp/arm-compiler-for-linux_21.1_RHEL-7
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://developer.arm.com/-/media/Files/downloads/hpc/arm-allinea-studio/22-0/ACfL/arm-compiler-for-linux_22.0_RHEL-7_aarch64.tar && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_22.0_RHEL-7_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/arm-compiler-for-linux_22.0_RHEL-7 && ./arm-compiler-for-linux_22.0_RHEL-7.sh --install-to /opt/arm --accept && \
+    rm -rf /var/tmp/arm-compiler-for-linux_22.0_RHEL-7_aarch64.tar /var/tmp/arm-compiler-for-linux_22.0_RHEL-7
 ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
@@ -112,9 +112,9 @@ ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
     def test_tarball(self):
         """tarball"""
         a = arm_allinea_studio(eula=True,
-                               tarball='arm-compiler-for-linux_21.1_Ubuntu-18.04_aarch64.tar')
+                               tarball='arm-compiler-for-linux_22.0_Ubuntu-18.04_aarch64.tar')
         self.assertEqual(str(a),
-r'''# Arm Allinea Studio version 21.1
+r'''# Arm Allinea Studio version 22.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         libc6-dev \
@@ -124,10 +124,10 @@ RUN apt-get update -y && \
         tcl \
         wget && \
     rm -rf /var/lib/apt/lists/*
-COPY arm-compiler-for-linux_21.1_Ubuntu-18.04_aarch64.tar /var/tmp
-RUN mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-18.04_aarch64.tar -C /var/tmp && \
-    cd /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-18.04 && ./arm-compiler-for-linux_21.1_Ubuntu-18.04.sh --install-to /opt/arm --accept && \
-    rm -rf /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-18.04_aarch64.tar /var/tmp/arm-compiler-for-linux_21.1_Ubuntu-18.04
+COPY arm-compiler-for-linux_22.0_Ubuntu-18.04_aarch64.tar /var/tmp
+RUN mkdir -p /var/tmp && tar -x -f /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-18.04_aarch64.tar -C /var/tmp && \
+    cd /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-18.04 && ./arm-compiler-for-linux_22.0_Ubuntu-18.04.sh --install-to /opt/arm --accept && \
+    rm -rf /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-18.04_aarch64.tar /var/tmp/arm-compiler-for-linux_22.0_Ubuntu-18.04
 ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
 
     @aarch64
@@ -139,21 +139,19 @@ ENV MODULEPATH=/opt/arm/modulefiles:$MODULEPATH''')
         r = a.runtime()
         self.assertEqual(r,
 r'''# Arm Allinea Studio
-COPY --from=0 /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/libgomp.so \
-    /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/libiomp5.so \
-    /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/libomp.so \
-    /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflang.so \
-    /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflangrti.so \
-    /opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib/
-COPY --from=0 /opt/arm/armpl-21.1.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/libamath.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/libamath_dummy.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/libastring.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/
-COPY --from=0 /opt/arm/armpl-21.1.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/libamath.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/libamath_dummy.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/libastring.so \
-    /opt/arm/armpl-21.1.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/
-ENV LD_LIBRARY_PATH=/opt/arm/arm-linux-compiler-21.1_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/armpl-21.1.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib:/opt/arm/armpl-21.1.0_AArch64_RHEL-7_gcc_aarch64-linux/lib:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libgomp.so \
+    /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libiomp5.so \
+    /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libomp.so \
+    /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflang.so \
+    /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/libflangrti.so \
+    /opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib/
+COPY --from=0 /opt/arm/armpl-22.0.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/libamath.so \
+    /opt/arm/armpl-22.0.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/libastring.so \
+    /opt/arm/armpl-22.0.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib/
+COPY --from=0 /opt/arm/armpl-22.0.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/libamath.so \
+    /opt/arm/armpl-22.0.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/libastring.so \
+    /opt/arm/armpl-22.0.0_AArch64_RHEL-7_gcc_aarch64-linux/lib/
+ENV LD_LIBRARY_PATH=/opt/arm/arm-linux-compiler-22.0_Generic-AArch64_RHEL-7_aarch64-linux/lib:/opt/arm/armpl-22.0.0_AArch64_RHEL-7_arm-linux-compiler_aarch64-linux/lib:/opt/arm/armpl-22.0.0_AArch64_RHEL-7_gcc_aarch64-linux/lib:$LD_LIBRARY_PATH''')
 
     def test_toolchain(self):
         """Toolchain"""


### PR DESCRIPTION
## Pull Request Description
ARM stopped providing multiple flavours of the libraries, unifying them under the 'generic' name
Also add support for ubuntu >= 22.04, as package python does no longer exist
doc was updated manually

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
