### PR TITLE
Add support for Ubuntu 22.04, and bump default HPC-X version

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1470,6 +1470,10 @@ component.
 __Parameters__
 
 
+- __buildlabel__: The build label assigned by Mellanox to the tarball.
+This value is ignored for HPC-X version 2.10 and earlier.  The
+default value is `cuda11-gdrcopy2-nccl2.11`.
+
 - __environment__: Boolean flag to specify whether the environment
 should be modified to include HPC-X. This option is only
 recognized if `hpcxinit` is False. The default is True.
@@ -1500,28 +1504,33 @@ library directories. This value is ignored if `hpcxinit` is
 
 - __mlnx_ofed__: The version of Mellanox OFED that should be matched.
 This value is ignored if Inbox OFED is selected.  The default
-value is `5.2-2.2.0.0`.
+value is `5` for HPC-X version 2.11 and later, and `5.2-2.2.0.0`
+for earlier HPC-X versions.
 
 - __multi_thread__: Boolean flag to specify whether the multi-threaded
 version of Mellanox HPC-X should be used.  The default is `False`.
 
 - __oslabel__: The Linux distribution label assigned by Mellanox to the
 tarball.  For Ubuntu, the default value is `ubuntu16.04` for
-Ubuntu 16.04, `ubuntu18.04` for Ubuntu 18.04, and `ubuntu20.04`
-for Ubuntu 20.04.  For RHEL-based Linux distributions, the default
-value is `redhat7.6` for version 7 and `redhat8.0` for version 8.
+Ubuntu 16.04, `ubuntu18.04` for Ubuntu 18.04, `ubuntu20.04` for
+Ubuntu 20.04, and `ubuntu22.04` for Ubuntu 22.04.  For HPC-X
+version 2.11 and later and RHEL-based Linux distributions, the
+default value is `redhat7` for version 7 and `redhat8` for version
+8.  For HPC-X version 2.10 and earlier and RHEL-based Linux
+distributions, the default value is `redhat7.6` for version 7 and
+`redhat8.0` for version 8.
 
 - __ospackages__: List of OS packages to install prior to installing
 Mellanox HPC-X.  For Ubuntu, the default values are `bzip2`,
-`openssh-client`, `tar`, and `wget`.  For RHEL-based distributions
-the default values are `bzip2`, `openssh-clients`, `tar`, and
-`wget`.
+`libnuma1`, `openssh-client`, `tar`, and `wget`.  For RHEL-based
+distributions the default values are `bzip2`, `numactl-libs`,
+`openssh-clients`, `tar`, and `wget`.
 
 - __prefix__: The top level installation location.  The default value is
 `/usr/local/hpcx`.
 
 - __version__: The version of Mellanox HPC-X to install.  The default
-value is `2.8.1`.
+value is `2.11`.
 
 __Examples__
 

--- a/docs/misc_api.md
+++ b/docs/misc_api.md
@@ -90,9 +90,9 @@ __Arguments__
 
 
 - __distro (string)__: Valid values are `centos7`, `centos8`, `rhel7`,
-`rhel8`, `rockylinux8`, `ubuntu16`, `ubuntu18`, and `ubuntu20`.
-`ubuntu` is an alias for `ubuntu16`, `centos` is an alias for
-`centos7`, and `rhel` is an alias for `rhel7`.
+`rhel8`, `rockylinux8`, `ubuntu16`, `ubuntu18`, `ubuntu20`, and
+`ubuntu22`.  `ubuntu` is an alias for `ubuntu16`, `centos` is an
+alias for `centos7`, and `rhel` is an alias for `rhel7`.
 
 
 ## set_singularity_version

--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -23,10 +23,10 @@ is `docker` (Singularity specific).
 - ___distro__: The underlying Linux distribution of the base image.
 Valid values are `centos`, `centos7`, `centos8`, `redhat`, `rhel`,
 `rhel7`, `rhel8`, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
-and `ubuntu20`.  By default, the primitive attempts to figure out
-the Linux distribution by inspecting the image identifier, and
-falls back to `ubuntu` if unable to determine the Linux
-distribution automatically.
+`ubuntu20`, and `ubuntu22`.  By default, the primitive attempts to
+figure out the Linux distribution by inspecting the image
+identifier, and falls back to `ubuntu` if unable to determine the
+Linux distribution automatically.
 
 - ___docker_env__: Boolean specifying whether to load the Docker base
  image environment, i.e., source

--- a/hpccm/building_blocks/llvm.py
+++ b/hpccm/building_blocks/llvm.py
@@ -343,7 +343,14 @@ class llvm(bb_base, hpccm.templates.envvars):
         codename = 'xenial'
         codename_ver = 'xenial'
 
-        if (hpccm.config.g_linux_version >= StrictVersion('20.0') and
+        if (hpccm.config.g_linux_version >= StrictVersion('22.0') and
+            hpccm.config.g_linux_version < StrictVersion('23.0')):
+            codename = 'jammy'
+            if self.__version == self.__trunk_version:
+                codename_ver = 'jammy'
+            else:
+                codename_ver = 'jammy-{}'.format(self.__version)
+        elif (hpccm.config.g_linux_version >= StrictVersion('20.0') and
             hpccm.config.g_linux_version < StrictVersion('21.0')):
             codename = 'focal'
             if self.__version == self.__trunk_version:

--- a/hpccm/building_blocks/mlnx_ofed.py
+++ b/hpccm/building_blocks/mlnx_ofed.py
@@ -168,7 +168,9 @@ class mlnx_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
                                  'libnuma1']
 
             if not self.__oslabel:
-                if hpccm.config.g_linux_version >= StrictVersion('20.0'):
+                if hpccm.config.g_linux_version >= StrictVersion('22.0'):
+                    self.__oslabel = 'ubuntu22.04'
+                elif hpccm.config.g_linux_version >= StrictVersion('20.0'):
                     self.__oslabel = 'ubuntu20.04'
                 elif hpccm.config.g_linux_version >= StrictVersion('18.0'):
                     self.__oslabel = 'ubuntu18.04'

--- a/hpccm/building_blocks/ofed.py
+++ b/hpccm/building_blocks/ofed.py
@@ -113,7 +113,9 @@ class ofed(bb_base):
             if hpccm.config.g_linux_version >= StrictVersion('18.0'):
                 # Give priority to packages from the Ubuntu repositories over
                 # vendor repositories
-                if hpccm.config.g_linux_version >= StrictVersion('20.0'):
+                if hpccm.config.g_linux_version >= StrictVersion('22.0'):
+                    self.__extra_opts = ['-t jammy']
+                elif hpccm.config.g_linux_version >= StrictVersion('20.0'):
                     self.__extra_opts = ['-t focal']
                 else:
                     self.__extra_opts = ['-t bionic']

--- a/hpccm/config.py
+++ b/hpccm/config.py
@@ -174,9 +174,9 @@ def set_linux_distro(distro):
   # Arguments
 
   distro (string): Valid values are `centos7`, `centos8`, `rhel7`,
-  `rhel8`, `rockylinux8`, `ubuntu16`, `ubuntu18`, and `ubuntu20`.
-  `ubuntu` is an alias for `ubuntu16`, `centos` is an alias for
-  `centos7`, and `rhel` is an alias for `rhel7`.
+  `rhel8`, `rockylinux8`, `ubuntu16`, `ubuntu18`, `ubuntu20`, and
+  `ubuntu22`.  `ubuntu` is an alias for `ubuntu16`, `centos` is an
+  alias for `centos7`, and `rhel` is an alias for `rhel7`.
 
   """
   this = sys.modules[__name__]
@@ -213,6 +213,9 @@ def set_linux_distro(distro):
   elif distro == 'ubuntu20':
     this.g_linux_distro = linux_distro.UBUNTU
     this.g_linux_version = StrictVersion('20.04')
+  elif distro == 'ubuntu22':
+    this.g_linux_distro = linux_distro.UBUNTU
+    this.g_linux_version = StrictVersion('22.04')
   else:
     logging.warning('Unable to determine the Linux distribution, defaulting to Ubuntu')
     this.g_linux_distro = linux_distro.UBUNTU

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -51,10 +51,10 @@ class baseimage(object):
     _distro: The underlying Linux distribution of the base image.
     Valid values are `centos`, `centos7`, `centos8`, `redhat`, `rhel`,
     `rhel7`, `rhel8`, `rockylinux8`, `ubuntu`, `ubuntu16`, `ubuntu18`,
-    and `ubuntu20`.  By default, the primitive attempts to figure out
-    the Linux distribution by inspecting the image identifier, and
-    falls back to `ubuntu` if unable to determine the Linux
-    distribution automatically.
+    `ubuntu20`, and `ubuntu22`.  By default, the primitive attempts to
+    figure out the Linux distribution by inspecting the image
+    identifier, and falls back to `ubuntu` if unable to determine the
+    Linux distribution automatically.
 
     _docker_env: Boolean specifying whether to load the Docker base
      image environment, i.e., source
@@ -116,6 +116,8 @@ class baseimage(object):
             hpccm.config.set_linux_distro('ubuntu18')
         elif self.__distro == 'ubuntu20':
             hpccm.config.set_linux_distro('ubuntu20')
+        elif self.__distro == 'ubuntu22':
+            hpccm.config.set_linux_distro('ubuntu22')
         elif self.__distro == 'centos':
             hpccm.config.set_linux_distro('centos')
         elif self.__distro == 'centos7':
@@ -148,6 +150,8 @@ class baseimage(object):
             hpccm.config.set_linux_distro('ubuntu18')
         elif re.search(r'ubuntu:?20', self.image):
             hpccm.config.set_linux_distro('ubuntu20')
+        elif re.search(r'ubuntu:?22', self.image):
+            hpccm.config.set_linux_distro('ubuntu22')
         elif re.search(r'ubuntu', self.image):
             hpccm.config.set_linux_distro('ubuntu')
         else:

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -194,6 +194,15 @@ def ubuntu20(function):
 
     return wrapper
 
+def ubuntu22(function):
+    """Decorator to set the Linux distribution to Ubuntu 22.04"""
+    def wrapper(*args, **kwargs):
+        hpccm.config.g_linux_distro = linux_distro.UBUNTU
+        hpccm.config.g_linux_version = StrictVersion('22.04')
+        return function(*args, **kwargs)
+
+    return wrapper
+
 def x86_64(function):
     """Decorator to set the CPU architecture to x86_64"""
     def wrapper(*args, **kwargs):

--- a/test/test_hpcx.py
+++ b/test/test_hpcx.py
@@ -38,20 +38,21 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64''')
 
     @x86_64
     @ubuntu18
@@ -60,20 +61,21 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu18.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu18.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu18.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu18.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu18.04-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu18.04-x86_64''')
 
     @x86_64
     @ubuntu20
@@ -82,20 +84,21 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu20.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu20.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu20.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu20.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu20.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu20.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu20.04-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu20.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu20.04-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu20.04-x86_64''')
 
     @x86_64
     @centos
@@ -104,19 +107,20 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default mlnx_ofed building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN yum install -y \
         bzip2 \
+        numactl-libs \
         openssh-clients \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat7.6-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat7.6-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat7.6-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat7-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat7-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat7-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat7.6-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat7.6-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat7-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat7-x86_64''')
 
     @x86_64
     @centos8
@@ -125,19 +129,20 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default mlnx_ofed building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN yum install -y \
         bzip2 \
+        numactl-libs \
         openssh-clients \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat8.0-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat8.0-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat8.0-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat8-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat8-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat8-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat8.0-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-redhat8.0-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat8-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-redhat8-x86_64''')
 
     @x86_64
     @ubuntu
@@ -151,6 +156,7 @@ r'''# Mellanox HPC-X version 2.5.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
@@ -173,6 +179,7 @@ r'''# Mellanox HPC-X version 2.5.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
@@ -194,6 +201,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
 r'''# Mellanox HPC-X version 2.5.0
 RUN yum install -y \
         bzip2 \
+        numactl-libs \
         openssh-clients \
         tar \
         wget && \
@@ -216,6 +224,7 @@ r'''# Mellanox HPC-X version 2.5.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
@@ -259,6 +268,7 @@ ENV CPATH=/usr/local/hpcx/hcoll/include:/usr/local/hpcx/ompi/include:/usr/local/
 r'''# Mellanox HPC-X version 2.5.0
 RUN yum install -y \
         bzip2 \
+        numactl-libs \
         openssh-clients \
         tar \
         wget && \
@@ -304,17 +314,18 @@ ENV CPATH=/usr/local/hpcx/hcoll/include:/usr/local/hpcx/ompi/include:/usr/local/
         h = hpcx()
         r = h.runtime()
         self.assertEqual(r,
-r'''# Mellanox HPC-X version 2.8.1
+r'''# Mellanox HPC-X version 2.11
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
+        libnuma1 \
         openssh-client \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.8.1/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.11/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.8.1-gcc-MLNX_OFED_LINUX-5.2-2.2.0.0-ubuntu16.04-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64.tbz /var/tmp/hpcx-v2.11-gcc-MLNX_OFED_LINUX-5-cuda11-gdrcopy2-nccl2.11-ubuntu16.04-x86_64''')


### PR DESCRIPTION
## Pull Request Description

Add base support for Ubuntu 22.04, and update affected building blocks (hpcx, llvm, mlnx_ofed, ofed).

Also bump default HPC-X version to 2.11, and reflect new package naming scheme.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
