### PR TITLE
Add support for signed deb repositories using the new signed-by method rather than apt-key

### DIFF
--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -83,6 +83,7 @@ class apt_get(bb_base, hpccm.templates.sed, hpccm.templates.wget):
 
         super(apt_get, self).__init__()
 
+        self.__apt_key = kwargs.get('_apt_key', True)
         self.__aptitude = kwargs.get('aptitude', False)
         self.__commands = []
         self.__download = kwargs.get('download', False)
@@ -122,8 +123,14 @@ class apt_get(bb_base, hpccm.templates.sed, hpccm.templates.wget):
 
         if self.__keys:
             for key in self.__keys:
-                self.__commands.append(
-                    'wget -qO - {} | apt-key add -'.format(key))
+                if self.__apt_key:
+                    self.__commands.append(
+                        'wget -qO - {} | apt-key add -'.format(key))
+                else:
+                    self.__commands.extend([
+                        'mkdir -p /usr/share/keyrings',
+                        'wget -qO - {0} | gpg --dearmor -o /usr/share/keyrings/{1}.gpg'.format(
+                            key, os.path.splitext(os.path.basename(key))[0])])
 
         if self.__ppas:
             # Need to install apt-add-repository

--- a/hpccm/building_blocks/packages.py
+++ b/hpccm/building_blocks/packages.py
@@ -134,6 +134,7 @@ class packages(bb_base):
         super(packages, self).__init__()
 
         self.__apt = kwargs.get('apt', [])
+        self.__apt_key = kwargs.get('_apt_key', True)
         self.__apt_keys = kwargs.get('apt_keys', [])
         self.__apt_ppas = kwargs.get('apt_ppas', [])
         self.__apt_repositories = kwargs.get('apt_repositories', [])
@@ -166,7 +167,8 @@ class packages(bb_base):
             else:
                 ospackages = self.__ospackages
 
-            self += apt_get(aptitude=self.__aptitude,
+            self += apt_get(_apt_key=self.__apt_key,
+                            aptitude=self.__aptitude,
                             download=self.__download,
                             download_directory=self.__download_directory,
                             extra_opts=self.__extra_opts,

--- a/test/test_apt_get.py
+++ b/test/test_apt_get.py
@@ -61,6 +61,23 @@ r'''RUN wget -qO - https://www.example.com/key.pub | apt-key add - && \
 
     @ubuntu
     @docker
+    def test_add_repo_signed_by(self):
+        """Add repo and key, using the signed-by method rather than apt-key"""
+        a = apt_get(_apt_key=False,
+                    keys=['https://www.example.com/key.pub'],
+                    ospackages=['example'],
+                    repositories=['deb [signed-by=/usr/share/keyrings/key.gpg] http://www.example.com all main'])
+        self.assertEqual(str(a),
+r'''RUN mkdir -p /usr/share/keyrings && \
+    wget -qO - https://www.example.com/key.pub | gpg --dearmor -o /usr/share/keyrings/key.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/key.gpg] http://www.example.com all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        example && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    @ubuntu
+    @docker
     def test_download(self):
         """Download parameter"""
         a = apt_get(download=True, download_directory='/tmp/download',


### PR DESCRIPTION
For now, this is enabled by an undocumented option.

In the future, it is expected to become the default behavior.

## Pull Request Description

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
