### PR TITLE
Update Nsight Systems and Nsight Compute building blocks

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3062,13 +3062,13 @@ local build context. The default value is empty.
 
 - __version__: the version of Nsight Compute to install.  Note when
 `runfile` is set this parameter is ignored.  The default value is
-`2022.1.1`.
+`2022.4.0`.
 
 __Examples__
 
 
 ```python
-nsight_compute(version='2020.2.1')
+nsight_compute(version='2020.4.0')
 ```
 
 ```python
@@ -3091,13 +3091,13 @@ __Parameters__
 package should be installed.  The default is True.
 
 - __version__: The version of Nsight Systems to install.  The default
-value is `2022.2.1`.
+value is `2022.5.1`.
 
 __Examples__
 
 
 ```python
-nsight_systems(version='2020.2.1')
+nsight_systems(version='2020.5.1')
 ```
 
 

--- a/hpccm/building_blocks/apt_get.py
+++ b/hpccm/building_blocks/apt_get.py
@@ -129,6 +129,8 @@ class apt_get(bb_base, hpccm.templates.sed, hpccm.templates.wget):
                 else:
                     self.__commands.extend([
                         'mkdir -p /usr/share/keyrings',
+                        'rm -f /usr/share/keyrings/{}.gpg'.format(
+                            os.path.splitext(os.path.basename(key))[0]),
                         'wget -qO - {0} | gpg --dearmor -o /usr/share/keyrings/{1}.gpg'.format(
                             key, os.path.splitext(os.path.basename(key))[0])])
 

--- a/hpccm/building_blocks/nsight_compute.py
+++ b/hpccm/building_blocks/nsight_compute.py
@@ -63,12 +63,12 @@ class nsight_compute(bb_base, hpccm.templates.envvars):
 
     version: the version of Nsight Compute to install.  Note when
     `runfile` is set this parameter is ignored.  The default value is
-    `2022.1.1`.
+    `2022.4.0`.
 
     # Examples
 
     ```python
-    nsight_compute(version='2020.2.1')
+    nsight_compute(version='2020.4.0')
     ```
 
     ```python
@@ -89,7 +89,7 @@ class nsight_compute(bb_base, hpccm.templates.envvars):
         self.__prefix = kwargs.get('prefix',
                                    '/usr/local/NVIDIA-Nsight-Compute')
         self.__runfile = kwargs.get('runfile', None)
-        self.__version = kwargs.get('version', '2022.1.1')
+        self.__version = kwargs.get('version', '2022.4.0')
         self.__wd = kwargs.get('wd', posixpath.join(
             hpccm.config.g_wd, 'nsight_compute')) # working directory
 
@@ -149,7 +149,9 @@ class nsight_compute(bb_base, hpccm.templates.envvars):
                     self.__ospackages = ['apt-transport-https',
                                          'ca-certificates', 'gnupg', 'wget']
 
-            if hpccm.config.g_linux_version >= StrictVersion('20.04'):
+            if hpccm.config.g_linux_version >= StrictVersion('22.04'):
+                self.__distro_label = 'ubuntu2204'
+            elif hpccm.config.g_linux_version >= StrictVersion('20.04'):
                 self.__distro_label = 'ubuntu2004'
             elif hpccm.config.g_linux_version >= StrictVersion('18.0'):
                 self.__distro_label = 'ubuntu1804'
@@ -179,12 +181,13 @@ class nsight_compute(bb_base, hpccm.templates.envvars):
 
         self += packages(
             apt_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
-            apt_repositories=['deb https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
+            apt_repositories=['deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
             # https://github.com/NVIDIA/hpc-container-maker/issues/367
             force_add_repo=True,
             ospackages=['nsight-compute-{}'.format(self.__version)],
             yum_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
-            yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)])
+            yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)],
+            _apt_key=False)
 
         # The distro packages do not link nsight-compute binaries to /usr/local/bin
         self.environment_variables['PATH'] = '/opt/nvidia/nsight-compute/{}:$PATH'.format(self.__version)

--- a/hpccm/building_blocks/nsight_systems.py
+++ b/hpccm/building_blocks/nsight_systems.py
@@ -41,12 +41,12 @@ class nsight_systems(bb_base):
     package should be installed.  The default is True.
 
     version: The version of Nsight Systems to install.  The default
-    value is `2022.2.1`.
+    value is `2022.5.1`.
 
     # Examples
 
     ```python
-    nsight_systems(version='2020.2.1')
+    nsight_systems(version='2020.5.1')
     ```
 
     """
@@ -60,7 +60,7 @@ class nsight_systems(bb_base):
         self.__cli = kwargs.get('cli', True)
         self.__distro_label = ''     # Filled in by __distro
         self.__ospackages = kwargs.get('ospackages', [])
-        self.__version = kwargs.get('version', '2022.2.1')
+        self.__version = kwargs.get('version', '2022.5.1')
 
         # Set the CPU architecture specific parameters
         self.__cpu_arch()
@@ -86,12 +86,13 @@ class nsight_systems(bb_base):
 
         self += packages(
             apt_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
-            apt_repositories=['deb https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
+            apt_repositories=['deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/{0}/{1}/ /'.format(self.__distro_label, self.__arch_label)],
             # https://github.com/NVIDIA/hpc-container-maker/issues/367
             force_add_repo=True,
             ospackages=[package],
             yum_keys=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}/nvidia.pub'.format(self.__distro_label, self.__arch_label)],
-            yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)])
+            yum_repositories=['https://developer.download.nvidia.com/devtools/repos/{0}/{1}'.format(self.__distro_label, self.__arch_label)],
+            _apt_key=False)
 
     def __cpu_arch(self):
         """Based on the CPU architecture, set values accordingly.  A user
@@ -121,7 +122,9 @@ class nsight_systems(bb_base):
                 self.__ospackages = ['apt-transport-https', 'ca-certificates',
                                      'gnupg', 'wget']
 
-            if hpccm.config.g_linux_version >= StrictVersion('20.04'):
+            if hpccm.config.g_linux_version >= StrictVersion('22.04'):
+                self.__distro_label = 'ubuntu2204'
+            elif hpccm.config.g_linux_version >= StrictVersion('20.04'):
                 self.__distro_label = 'ubuntu2004'
             elif hpccm.config.g_linux_version >= StrictVersion('18.0'):
                 self.__distro_label = 'ubuntu1804'

--- a/test/test_apt_get.py
+++ b/test/test_apt_get.py
@@ -69,6 +69,7 @@ r'''RUN wget -qO - https://www.example.com/key.pub | apt-key add - && \
                     repositories=['deb [signed-by=/usr/share/keyrings/key.gpg] http://www.example.com all main'])
         self.assertEqual(str(a),
 r'''RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/key.gpg && \
     wget -qO - https://www.example.com/key.pub | gpg --dearmor -o /usr/share/keyrings/key.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/key.gpg] http://www.example.com all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \

--- a/test/test_nsight_compute.py
+++ b/test/test_nsight_compute.py
@@ -38,7 +38,7 @@ class Test_nsight_compute(unittest.TestCase):
         """Default nsight_compute building block"""
         n = nsight_compute()
         self.assertEqual(str(n),
-r'''# NVIDIA Nsight Compute 2022.1.1
+r'''# NVIDIA Nsight Compute 2022.4.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -46,14 +46,16 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-compute-2022.1.1 && \
+        nsight-compute-2022.4.0 && \
     rm -rf /var/lib/apt/lists/*
 ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
-    PATH=/opt/nvidia/nsight-compute/2022.1.1:$PATH''')
+    PATH=/opt/nvidia/nsight-compute/2022.4.0:$PATH''')
 
     @x86_64
     @centos8
@@ -62,15 +64,15 @@ ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
         """Default nsight_compute building block"""
         n = nsight_compute()
         self.assertEqual(str(n),
-r'''# NVIDIA Nsight Compute 2022.1.1
+r'''# NVIDIA Nsight Compute 2022.4.0
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64/nvidia.pub && \
     yum install -y dnf-utils && \
     (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 || true) && \
     yum install -y \
-        nsight-compute-2022.1.1 && \
+        nsight-compute-2022.4.0 && \
     rm -rf /var/cache/yum/*
 ENV NV_COMPUTE_PROFILER_DISABLE_STOCK_FILE_DEPLOYMENT=1 \
-    PATH=/opt/nvidia/nsight-compute/2022.1.1:$PATH''')
+    PATH=/opt/nvidia/nsight-compute/2022.4.0:$PATH''')
 
     @x86_64
     @ubuntu
@@ -87,8 +89,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-compute-2020.2.1 && \
@@ -111,8 +115,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-compute-2020.2.1 && \

--- a/test/test_nsight_systems.py
+++ b/test/test_nsight_systems.py
@@ -38,7 +38,7 @@ class Test_nsight_systems(unittest.TestCase):
         """Default nsight_systems building block"""
         n = nsight_systems()
         self.assertEqual(str(n),
-r'''# NVIDIA Nsight Systems 2022.2.1
+r'''# NVIDIA Nsight Systems 2022.5.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         apt-transport-https \
@@ -46,11 +46,13 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nsight-systems-cli-2022.2.1 && \
+        nsight-systems-cli-2022.5.1 && \
     rm -rf /var/lib/apt/lists/*''')
 
     @x86_64
@@ -60,12 +62,12 @@ RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/a
         """Default nsight_systems building block"""
         n = nsight_systems()
         self.assertEqual(str(n),
-r'''# NVIDIA Nsight Systems 2022.2.1
+r'''# NVIDIA Nsight Systems 2022.5.1
 RUN rpm --import https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64/nvidia.pub && \
     yum install -y dnf-utils && \
     (yum-config-manager --add-repo https://developer.download.nvidia.com/devtools/repos/rhel8/x86_64 || true) && \
     yum install -y \
-        nsight-systems-cli-2022.2.1 && \
+        nsight-systems-cli-2022.5.1 && \
     rm -rf /var/cache/yum/*''')
 
     @x86_64
@@ -83,8 +85,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-systems-cli-2020.1.1 && \
@@ -105,8 +109,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1604/amd64/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-systems-2020.1.1 && \
@@ -127,8 +133,10 @@ RUN apt-get update -y && \
         gnupg \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/nvidia.pub | apt-key add - && \
-    echo "deb https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/ /" >> /etc/apt/sources.list.d/hpccm.list && \
+RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/nvidia.gpg && \
+    wget -qO - https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/nvidia.pub | gpg --dearmor -o /usr/share/keyrings/nvidia.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/nvidia.gpg] https://developer.download.nvidia.com/devtools/repos/ubuntu1804/ppc64el/ /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         nsight-systems-cli-2020.1.1 && \

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -47,6 +47,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN mkdir -p /usr/share/keyrings && \
+    rm -f /usr/share/keyrings/DEB-GPG-KEY-NVIDIA-HPC-SDK.gpg && \
     wget -qO - https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | gpg --dearmor -o /usr/share/keyrings/DEB-GPG-KEY-NVIDIA-HPC-SDK.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/DEB-GPG-KEY-NVIDIA-HPC-SDK.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \


### PR DESCRIPTION
## Pull Request Description

Update Nsight Systems and Nsight Compute building blocks

- Bump the default versions to the latest
- Add support for the Ubuntu 22.04 repository
- Switch Nsight apt repository setup to use the "signed-by" key approach
- Fix a "signed-by" issue in the apt_get building block where `gpg` will not output a file if it already exists.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
