### PR TITLE
Fallback to the system architecture rather than x86_64

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -10,8 +10,8 @@ __Parameters__
 - ___arch__: The underlying CPU architecture of the base image.  Valid
 values are `aarch64`, `ppc64le`, and `x86_64`.  By default, the
 primitive attemps to figure out the CPU architecture by inspecting
-the image identifier, and falls back to `x86_64` if unable to
-determine the CPU architecture automatically.
+the image identifier, and falls back to system architecture if
+unable to determine the CPU architecture automatically.
 
 - ___as__: Name for the stage.  When using Singularity multi-stage
 recipes, this value must be specified.  The default value is

--- a/hpccm/primitives/baseimage.py
+++ b/hpccm/primitives/baseimage.py
@@ -38,8 +38,8 @@ class baseimage(object):
     _arch: The underlying CPU architecture of the base image.  Valid
     values are `aarch64`, `ppc64le`, and `x86_64`.  By default, the
     primitive attemps to figure out the CPU architecture by inspecting
-    the image identifier, and falls back to `x86_64` if unable to
-    determine the CPU architecture automatically.
+    the image identifier, and falls back to system architecture if
+    unable to determine the CPU architecture automatically.
 
     _as: Name for the stage.  When using Singularity multi-stage
     recipes, this value must be specified.  The default value is
@@ -102,7 +102,10 @@ class baseimage(object):
         elif re.search(r'ppc64le', self.image):
             hpccm.config.set_cpu_architecture('ppc64le')
         else:
-            hpccm.config.set_cpu_architecture('x86_64')
+            # Unable to figure out the architecture, so use the
+            # default, which should be the architecture of the machine
+            # running HPCCM
+            pass
 
         # Set the global Linux distribution.  Use the user specified
         # value if available, otherwise try to figure it out based on

--- a/test/test_baseimage.py
+++ b/test/test_baseimage.py
@@ -233,9 +233,18 @@ From: foo.sif
     @docker
     def test_detect_nonexistent(self):
         """Base image Linux distribution detection"""
+        arch = hpccm.config.get_cpu_architecture()
+        if arch == 'aarch64':
+            gold = cpu_arch.AARCH64
+        elif arch == 'ppc64le':
+            gold = cpu_arch.PPC64LE
+        elif arch == 'x86_64':
+            gold = cpu_arch.X86_64
+
         b = baseimage(image='nonexistent')
         self.assertEqual(hpccm.config.g_linux_distro, linux_distro.UBUNTU)
         self.assertEqual(hpccm.config.g_linux_version, StrictVersion('16.04'))
+        self.assertEqual(hpccm.config.g_cpu_arch, gold)
 
     @docker
     def test_distro_ubuntu(self):
@@ -306,12 +315,6 @@ From: foo.sif
         self.assertEqual(hpccm.config.g_cpu_arch, cpu_arch.PPC64LE)
 
     @docker
-    def test_detect_nonexistent(self):
-        """Base image CPU architecture detection"""
-        b = baseimage(image='foo')
-        self.assertEqual(hpccm.config.g_cpu_arch, cpu_arch.X86_64)
-
-    @docker
     def test_arch_aarch64(self):
         """Base image CPU architecture specification"""
         b = baseimage(image='foo', _arch='aarch64')
@@ -332,5 +335,13 @@ From: foo.sif
     @docker
     def test_arch_nonexistent(self):
         """Base image CPU architecture specification"""
+        arch = hpccm.config.get_cpu_architecture()
+        if arch == 'aarch64':
+            gold = cpu_arch.AARCH64
+        elif arch == 'ppc64le':
+            gold = cpu_arch.PPC64LE
+        elif arch == 'x86_64':
+            gold = cpu_arch.X86_64
+
         b = baseimage(image='foo', _arch='nonexistent')
-        self.assertEqual(hpccm.config.g_cpu_arch, cpu_arch.X86_64)
+        self.assertEqual(hpccm.config.g_cpu_arch, gold)

--- a/test/test_recipe.py
+++ b/test/test_recipe.py
@@ -23,6 +23,8 @@ import logging # pylint: disable=unused-import
 import os
 import unittest
 
+from helpers import x86_64
+
 from hpccm.common import container_type
 from hpccm.recipe import recipe
 
@@ -85,6 +87,7 @@ From: ubuntu:16.04
         gfortran
     rm -rf /var/lib/apt/lists/*''')
 
+    @x86_64
     def test_multistage_example_singlestage(self):
         """Single_stage option"""
         path = os.path.dirname(__file__)
@@ -116,6 +119,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp ftp://ft
     rm -rf /var/tmp/fftw-3.3.10 /var/tmp/fftw-3.3.10.tar.gz
 ENV LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     def test_multistage_example_singularity26(self):
         """Multi-stage recipe with Singularity container type"""
         path = os.path.dirname(__file__)
@@ -158,6 +162,7 @@ From: nvcr.io/nvidia/cuda:9.0-devel-ubuntu16.04
 %post
     export LD_LIBRARY_PATH=/usr/local/fftw/lib:$LD_LIBRARY_PATH''')
 
+    @x86_64
     def test_multistage_example_singularity32(self):
         """Multi-stage recipe with Singularity container type"""
         path = os.path.dirname(__file__)


### PR DESCRIPTION
## Pull Request Description

Fallback to the system architecture rather than x86_64 if the base image architecture cannot be determined or was not specified.

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
