### PR TITLE
Add support for Docker COPY --chmod

### DIFF
--- a/docs/primitives.md
+++ b/docs/primitives.md
@@ -118,6 +118,9 @@ __Parameters__
 identifier.  This also causes the Singularity block to named
 `%appfiles` rather than `%files` (Singularity specific).
 
+- ___chmod__: Set the permissions of the file(s) in the container image
+(Docker specific).
+
 - ___chown__: Set the ownership of the file(s) in the container image
 (Docker specific).
 

--- a/hpccm/primitives/copy.py
+++ b/hpccm/primitives/copy.py
@@ -39,6 +39,9 @@ class copy(object):
     identifier.  This also causes the Singularity block to named
     `%appfiles` rather than `%files` (Singularity specific).
 
+    _chmod: Set the permissions of the file(s) in the container image
+    (Docker specific).
+
     _chown: Set the ownership of the file(s) in the container image
     (Docker specific).
 
@@ -88,6 +91,7 @@ class copy(object):
         #super(copy, self).__init__()
 
         self._app = kwargs.get('_app', '')  # Singularity specific
+        self.__chmod = kwargs.get('_chmod', '')  # Docker specific
         self.__chown = kwargs.get('_chown', '')  # Docker specific
         self.__dest = kwargs.get('dest', '')
         self.__files = kwargs.get('files', {})
@@ -137,6 +141,9 @@ class copy(object):
             # COPY src2 dest2
             # COPY src3 dest3
             base_inst = 'COPY '
+
+            if self.__chmod:
+                base_inst = base_inst + '--chmod={} '.format(self.__chmod)
 
             if self.__chown:
                 base_inst = base_inst + '--chown={} '.format(self.__chown)

--- a/test/test_copy.py
+++ b/test/test_copy.py
@@ -232,6 +232,18 @@ r'''%files
     foo bar''')
 
     @docker
+    def test_chmod_docker(self):
+        """Docker --chmod syntax"""
+        c = copy(_chmod='0755', src='foo', dest='bar')
+        self.assertEqual(str(c), 'COPY --chmod=0755 foo bar')
+
+    @singularity
+    def test_chmod_singularity(self):
+        """Singularity --chmod syntax"""
+        c = copy(_chmod='0755', src='foo', dest='bar')
+        self.assertEqual(str(c), '%files\n    foo bar')
+
+    @docker
     def test_chown_docker(self):
         """Docker --chown syntax"""
         c = copy(_chown='alice:alice', src='foo', dest='bar')


### PR DESCRIPTION
## Pull Request Description

Add support for Docker COPY --chmod, e.g., `COPY --chmod=0755 foo bar`.

Implements #449 

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
