### PR TITLE
Add export_build_environment option

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -869,6 +869,10 @@ Underscores in the parameter name are converted to dashes.
 should be modified (see `devel_environment` and
 `runtime_environment`).  The default is True.
 
+- __export_build_environment__: Boolean flag to specify whether the
+build environment should be exported, or merely set on the
+configure command line.  The default is False.
+
 - __install__: Boolean flag to specify whether the `make install` step
 should be performed.  The default is True.
 

--- a/hpccm/building_blocks/generic_autotools.py
+++ b/hpccm/building_blocks/generic_autotools.py
@@ -98,6 +98,10 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
     should be modified (see `devel_environment` and
     `runtime_environment`).  The default is True.
 
+    export_build_environment: Boolean flag to specify whether the
+    build environment should be exported, or merely set on the
+    configure command line.  The default is False.
+
     install: Boolean flag to specify whether the `make install` step
     should be performed.  The default is True.
 
@@ -191,6 +195,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self.configure_opts = kwargs.get('configure_opts', [])
         self.__directory = kwargs.get('directory', None)
         self.environment_variables = kwargs.get('devel_environment', {})
+        self.__export_build_environment = kwargs.get('export_build_environment', False)
         self.__install = kwargs.get('install', True)
         self.__libdir = kwargs.get('libdir', 'lib')
         self.__make = kwargs.get('make', True)
@@ -266,6 +271,7 @@ class generic_autotools(bb_base, hpccm.templates.ConfigureMake,
         self.__commands.append(self.configure_step(
             build_directory=self.__build_directory,
             directory=self.src_directory, environment=build_environment,
+            export_environment=self.__export_build_environment,
             toolchain=self.__toolchain))
 
         # Post configure setup

--- a/hpccm/templates/ConfigureMake.py
+++ b/hpccm/templates/ConfigureMake.py
@@ -72,7 +72,8 @@ class ConfigureMake(hpccm.base_object):
         return 'make -j{} check'.format(parallel)
 
     def configure_step(self, build_directory=None, directory=None,
-                       environment=[], opts=[], toolchain=None):
+                       environment=[], export_environment=False, opts=[],
+                       toolchain=None):
         """Generate configure command line string"""
 
         change_directory = ''
@@ -138,7 +139,10 @@ class ConfigureMake(hpccm.base_object):
                 e.append('LIBS={}'.format(shlex_quote(
                     toolchain.LIBS)))
 
-        configure_env = ' '.join(e)
+        if export_environment:
+            configure_env = 'export {} &&'.format(' '.join(e))
+        else:
+            configure_env = ' '.join(e)
 
         # Build set of configuration command line options
         optlist = []

--- a/test/test_ConfigureMake.py
+++ b/test/test_ConfigureMake.py
@@ -121,3 +121,17 @@ class Test_ConfigureMake(unittest.TestCase):
                            without_bar=True, prefix=None)
         configure = cm.configure_step()
         self.assertEqual(configure, './configure --disable-long-option --enable-foo --with-foo --with-foo2=/usr --without-bar')
+
+    def test_export_environment(self):
+        """export_environment"""
+        cm = ConfigureMake()
+
+        tc = toolchain(CC='mpicc', CXX='mpicxx', FC='mpifc')
+        env = ['OMPI_CC=mycc', 'OMPI_CXX=mycxx', 'OMPI_FC=myfc']
+
+        configure = cm.configure_step(environment=env, toolchain=tc)
+        self.assertEqual(configure, 'OMPI_CC=mycc OMPI_CXX=mycxx OMPI_FC=myfc CC=mpicc CXX=mpicxx FC=mpifc ./configure --prefix=/usr/local')
+
+        ex_configure = cm.configure_step(environment=env,
+                                         export_environment=True, toolchain=tc)
+        self.assertEqual(ex_configure, 'export OMPI_CC=mycc OMPI_CXX=mycxx OMPI_FC=myfc CC=mpicc CXX=mpicxx FC=mpifc && ./configure --prefix=/usr/local')


### PR DESCRIPTION
## Pull Request Description

Add `export_build_environment` option to generic_autotools building block

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
