### PR TITLE
Update conda building block version handling and default value

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -598,10 +598,10 @@ Anaconda should be installed.  The default is False.
 
 - __python_subversion__: The Python version to install.  This value is
 ignored if the Conda version is less than 4.8.  The default is
-`py38` if using Python 3, and `py27` if using Python 2.
+`py310` if using Python 3, and `py27` if using Python 2.
 
 - __version__: The version of Anaconda to download.  The default value
-is `4.8.3`.
+is `23.1.0-1` if using Python 3, and `4.8.3` if using Python 2.
 
 __Examples__
 

--- a/hpccm/building_blocks/conda.py
+++ b/hpccm/building_blocks/conda.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 import logging
 import posixpath
 
@@ -66,10 +66,10 @@ class conda(bb_base, hpccm.templates.rm, hpccm.templates.wget):
 
     python_subversion: The Python version to install.  This value is
     ignored if the Conda version is less than 4.8.  The default is
-    `py38` if using Python 3, and `py27` if using Python 2.
+    `py310` if using Python 3, and `py27` if using Python 2.
 
     version: The version of Anaconda to download.  The default value
-    is `4.8.3`.
+    is `23.1.0-1` if using Python 3, and `4.8.3` if using Python 2.
 
     # Examples
 
@@ -109,8 +109,8 @@ class conda(bb_base, hpccm.templates.rm, hpccm.templates.wget):
         self.__python2 = kwargs.get('python2', False)
         self.__python_version = '2' if self.__python2 else '3'
         self.__python_subversion = kwargs.get(
-            'python_subversion', 'py27' if self.__python2 else 'py38')
-        self.__version = kwargs.get('version', '4.8.3')
+            'python_subversion', 'py27' if self.__python2 else 'py310')
+        self.__version = kwargs.get('version', '4.8.3' if self.__python2 else '23.1.0-1')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
@@ -152,7 +152,7 @@ class conda(bb_base, hpccm.templates.rm, hpccm.templates.wget):
         """Construct the series of shell commands, i.e., fill in
            self.__commands"""
 
-        if StrictVersion(self.__version) >= StrictVersion('4.8'):
+        if LooseVersion(self.__version) >= LooseVersion('4.8'):
             miniconda = 'Miniconda{0}-{1}_{2}-Linux-{3}.sh'.format(
                 self.__python_version, self.__python_subversion,
                 self.__version, self.__arch_pkg)

--- a/test/test_conda.py
+++ b/test/test_conda.py
@@ -44,15 +44,15 @@ RUN apt-get update -y && \
         ca-certificates \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-Linux-x86_64.sh && \
-    bash /var/tmp/Miniconda3-py38_4.8.3-Linux-x86_64.sh -b -p /usr/local/anaconda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh && \
+    bash /var/tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -b -p /usr/local/anaconda && \
     /usr/local/anaconda/bin/conda init && \
     ln -s /usr/local/anaconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     . /usr/local/anaconda/etc/profile.d/conda.sh && \
     conda activate base && \
     conda install -y numpy && \
     /usr/local/anaconda/bin/conda clean -afy && \
-    rm -rf /var/tmp/Miniconda3-py38_4.8.3-Linux-x86_64.sh''')
+    rm -rf /var/tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh''')
 
     @x86_64
     @centos
@@ -66,15 +66,15 @@ RUN yum install -y \
         ca-certificates \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://repo.anaconda.com/miniconda/Miniconda3-py38_4.8.3-Linux-x86_64.sh && \
-    bash /var/tmp/Miniconda3-py38_4.8.3-Linux-x86_64.sh -b -p /usr/local/anaconda && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp http://repo.anaconda.com/miniconda/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh && \
+    bash /var/tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh -b -p /usr/local/anaconda && \
     /usr/local/anaconda/bin/conda init && \
     ln -s /usr/local/anaconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
     . /usr/local/anaconda/etc/profile.d/conda.sh && \
     conda activate base && \
     conda install -y numpy && \
     /usr/local/anaconda/bin/conda clean -afy && \
-    rm -rf /var/tmp/Miniconda3-py38_4.8.3-Linux-x86_64.sh''')
+    rm -rf /var/tmp/Miniconda3-py310_23.1.0-1-Linux-x86_64.sh''')
 
     @ppc64le
     @ubuntu


### PR DESCRIPTION
## Pull Request Description

Update the conda building block to handle the new version number format (X.Y.Z-P).

Also update the default version to the current latest.

Fix #455. 

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
