### PR TITLE
Update python2 package name for Ubuntu 22.04

### DIFF
--- a/hpccm/building_blocks/python.py
+++ b/hpccm/building_blocks/python.py
@@ -21,8 +21,13 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from __future__ import print_function
 
+from distutils.version import StrictVersion
+
+import hpccm.config
+
 from hpccm.building_blocks.base import bb_base
 from hpccm.building_blocks.packages import packages
+from hpccm.common import linux_distro
 from hpccm.primitives.comment import comment
 from hpccm.primitives.shell import shell
 
@@ -69,11 +74,19 @@ class python(bb_base):
         self.__rpms = [] # Filled in below
 
         if self.__python2:
-            self.__debs.append('python')
+            if (hpccm.config.g_linux_distro == linux_distro.UBUNTU and
+                hpccm.config.g_linux_version >= StrictVersion('22.0')):
+                self.__debs.append('python2')
+            else:
+                self.__debs.append('python')
             self.__rpms.append('python2')
 
             if self.__devel:
-                self.__debs.append('python-dev')
+                if (hpccm.config.g_linux_distro == linux_distro.UBUNTU and
+                    hpccm.config.g_linux_version >= StrictVersion('22.0')):
+                    self.__debs.append('python2-dev')
+                else:
+                    self.__debs.append('python-dev')
                 self.__rpms.append('python2-devel')
 
         if self.__python3:

--- a/test/test_python.py
+++ b/test/test_python.py
@@ -22,7 +22,7 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import centos, centos8, docker, ubuntu
+from helpers import centos, centos8, docker, ubuntu, ubuntu22
 
 from hpccm.building_blocks.python import python
 
@@ -41,6 +41,19 @@ r'''# Python
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python \
+        python3 && \
+    rm -rf /var/lib/apt/lists/*''')
+
+    @ubuntu22
+    @docker
+    def test_defaults_ubuntu22(self):
+        """Default python building block"""
+        p = python()
+        self.assertEqual(str(p),
+r'''# Python
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        python2 \
         python3 && \
     rm -rf /var/lib/apt/lists/*''')
 


### PR DESCRIPTION
## Pull Request Description

The python 2 package name changed from python to python2 in Ubuntu 22.

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
