### PR TITLE
Bump default HPC-X version to 2.16

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1468,15 +1468,19 @@ Stage1 += h.runtime()
 hpcx(self, **kwargs)
 ```
 The `hpcx` building block downloads and installs the [Mellanox
-HPC-X](https://www.mellanox.com/page/products_dyn?product_family=189&mtag=hpc-x)
+HPC-X](https://developer.nvidia.com/networking/hpc-x)
 component.
 
 __Parameters__
 
 
 - __buildlabel__: The build label assigned by Mellanox to the tarball.
-This value is ignored for HPC-X version 2.10 and earlier.  The
-default value is `cuda12-gdrcopy2-nccl2.17`.
+For version 2.16 the default value is `cuda12-gdrcopy2-nccl2.18`.
+For version 2.15 the default value is `cuda12-gdrcopy2-nccl2.17`.
+For version 2.14 the default value is `cuda11-gdrcopy2-nccl2.16`.
+For versions 2.12 and 2.13 the default value is `cuda11-gdrcopy2-nccl2.12`.
+For versions 2.10 and 2.11 the default value is `cuda11-gdrcopy2-nccl2.11`.
+This value is ignored for HPC-X version 2.9 and earlier.
 
 - __environment__: Boolean flag to specify whether the environment
 should be modified to include HPC-X. This option is only
@@ -1508,19 +1512,24 @@ library directories. This value is ignored if `hpcxinit` is
 
 - __mlnx_ofed__: The version of Mellanox OFED that should be matched.
 This value is ignored if Inbox OFED is selected.  The default
-value is `5` for HPC-X version 2.11 and later, and `5.2-2.2.0.0`
+value is `5` for HPC-X version 2.10 and later, and `5.2-2.2.0.0`
 for earlier HPC-X versions.
 
 - __multi_thread__: Boolean flag to specify whether the multi-threaded
 version of Mellanox HPC-X should be used.  The default is `False`.
 
+- __ofedlabel__: The Mellanox OFED label assigned by Mellanox to the
+tarball.  For version 2.16 and later, the default value is
+`gcc-mlnx_ofed`.  For earlier versions, the default value is
+`gcc-MLNX_OFED_LINUX-5`.  This value is ignored if `inbox` is `True`.
+
 - __oslabel__: The Linux distribution label assigned by Mellanox to the
 tarball.  For Ubuntu, the default value is `ubuntu16.04` for
 Ubuntu 16.04, `ubuntu18.04` for Ubuntu 18.04, `ubuntu20.04` for
 Ubuntu 20.04, and `ubuntu22.04` for Ubuntu 22.04.  For HPC-X
-version 2.11 and later and RHEL-based Linux distributions, the
+version 2.10 and later and RHEL-based Linux distributions, the
 default value is `redhat7` for version 7 and `redhat8` for version
-8.  For HPC-X version 2.10 and earlier and RHEL-based Linux
+8.  For HPC-X version 2.9 and earlier and RHEL-based Linux
 distributions, the default value is `redhat7.6` for version 7 and
 `redhat8.0` for version 8.
 
@@ -1534,13 +1543,13 @@ distributions the default values are `bzip2`, `numactl-libs`,
 `/usr/local/hpcx`.
 
 - __version__: The version of Mellanox HPC-X to install.  The default
-value is `2.15`.
+value is `2.16`.
 
 __Examples__
 
 
 ```python
-hpcx(prefix='/usr/local/hpcx', version='2.15')
+hpcx(prefix='/usr/local/hpcx', version='2.16')
 ```
 
 

--- a/hpccm/building_blocks/hpcx.py
+++ b/hpccm/building_blocks/hpcx.py
@@ -43,14 +43,18 @@ from hpccm.toolchain import toolchain
 class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
             hpccm.templates.rm, hpccm.templates.tar, hpccm.templates.wget):
     """The `hpcx` building block downloads and installs the [Mellanox
-    HPC-X](https://www.mellanox.com/page/products_dyn?product_family=189&mtag=hpc-x)
+    HPC-X](https://developer.nvidia.com/networking/hpc-x)
     component.
 
     # Parameters
 
     buildlabel: The build label assigned by Mellanox to the tarball.
-    This value is ignored for HPC-X version 2.10 and earlier.  The
-    default value is `cuda12-gdrcopy2-nccl2.17`.
+    For version 2.16 the default value is `cuda12-gdrcopy2-nccl2.18`.
+    For version 2.15 the default value is `cuda12-gdrcopy2-nccl2.17`.
+    For version 2.14 the default value is `cuda11-gdrcopy2-nccl2.16`.
+    For versions 2.12 and 2.13 the default value is `cuda11-gdrcopy2-nccl2.12`.
+    For versions 2.10 and 2.11 the default value is `cuda11-gdrcopy2-nccl2.11`.
+    This value is ignored for HPC-X version 2.9 and earlier.
 
     environment: Boolean flag to specify whether the environment
     should be modified to include HPC-X. This option is only
@@ -82,19 +86,24 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
     mlnx_ofed: The version of Mellanox OFED that should be matched.
     This value is ignored if Inbox OFED is selected.  The default
-    value is `5` for HPC-X version 2.11 and later, and `5.2-2.2.0.0`
+    value is `5` for HPC-X version 2.10 and later, and `5.2-2.2.0.0`
     for earlier HPC-X versions.
 
     multi_thread: Boolean flag to specify whether the multi-threaded
     version of Mellanox HPC-X should be used.  The default is `False`.
 
+    ofedlabel: The Mellanox OFED label assigned by Mellanox to the
+    tarball.  For version 2.16 and later, the default value is
+    `gcc-mlnx_ofed`.  For earlier versions, the default value is
+    `gcc-MLNX_OFED_LINUX-5`.  This value is ignored if `inbox` is `True`.
+
     oslabel: The Linux distribution label assigned by Mellanox to the
     tarball.  For Ubuntu, the default value is `ubuntu16.04` for
     Ubuntu 16.04, `ubuntu18.04` for Ubuntu 18.04, `ubuntu20.04` for
     Ubuntu 20.04, and `ubuntu22.04` for Ubuntu 22.04.  For HPC-X
-    version 2.11 and later and RHEL-based Linux distributions, the
+    version 2.10 and later and RHEL-based Linux distributions, the
     default value is `redhat7` for version 7 and `redhat8` for version
-    8.  For HPC-X version 2.10 and earlier and RHEL-based Linux
+    8.  For HPC-X version 2.9 and earlier and RHEL-based Linux
     distributions, the default value is `redhat7.6` for version 7 and
     `redhat8.0` for version 8.
 
@@ -108,12 +117,12 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     `/usr/local/hpcx`.
 
     version: The version of Mellanox HPC-X to install.  The default
-    value is `2.15`.
+    value is `2.16`.
 
     # Examples
 
     ```python
-    hpcx(prefix='/usr/local/hpcx', version='2.15')
+    hpcx(prefix='/usr/local/hpcx', version='2.16')
     ```
 
     """
@@ -127,26 +136,44 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__baseurl = kwargs.get('baseurl',
                                     'https://content.mellanox.com/hpc/hpc-x')
         self.__bashrc = '' # Filled in by __distro()
-        self.__buildlabel = kwargs.get('buildlabel',
-                                       'cuda12-gdrcopy2-nccl2.17')
+        self.__buildlabel = kwargs.get('buildlabel', None)
         self.__hpcxinit = kwargs.get('hpcxinit', True)
         self.__inbox = kwargs.get('inbox', False)
         self.__mlnx_ofed = kwargs.get('mlnx_ofed', None)
         self.__multi_thread = kwargs.get('multi_thread', False)
+        self.__ofedlabel = kwargs.get('ofedlabel', None)
         self.__oslabel = kwargs.get('oslabel', '') # Filled in by __distro()
         self.__ospackages = kwargs.get('ospackages', []) # Filled in by _distro()
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/hpcx')
-        self.__version = kwargs.get('version', '2.15')
+        self.__version = kwargs.get('version', '2.16')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
 
+        if not self.__buildlabel:
+            if StrictVersion(self.__version) >= StrictVersion('2.16'):
+                self.__buildlabel = 'cuda12-gdrcopy2-nccl2.18'
+            elif StrictVersion(self.__version) >= StrictVersion('2.15'):
+                self.__buildlabel = 'cuda12-gdrcopy2-nccl2.17'
+            elif StrictVersion(self.__version) >= StrictVersion('2.14'):
+                self.__buildlabel = 'cuda11-gdrcopy2-nccl2.16'
+            elif StrictVersion(self.__version) >= StrictVersion('2.12'):
+                self.__buildlabel = 'cuda11-gdrcopy2-nccl2.12'
+            elif StrictVersion(self.__version) >= StrictVersion('2.10'):
+                self.__buildlabel = 'cuda11-gdrcopy2-nccl2.11'
+
         if not self.__mlnx_ofed:
-            if StrictVersion(self.__version) >= StrictVersion('2.11'):
+            if StrictVersion(self.__version) >= StrictVersion('2.10'):
                 self.__mlnx_ofed = '5'
             else:
                 self.__mlnx_ofed = '5.2-2.2.0.0'
+
+        if not self.__ofedlabel:
+            if StrictVersion(self.__version) >= StrictVersion('2.16'):
+                self.__ofedlabel = 'gcc-mlnx_ofed'
+            else:
+                self.__ofedlabel = 'gcc-MLNX_OFED_LINUX-{}'.format(self.__mlnx_ofed)
 
         # Output toolchain
         self.toolchain = toolchain(CC='mpicc', CXX='mpicxx', F77='mpif77',
@@ -192,12 +219,12 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         elif hpccm.config.g_linux_distro == linux_distro.CENTOS:
             if not self.__oslabel:
                 if hpccm.config.g_linux_version >= StrictVersion('8.0'):
-                    if StrictVersion(self.__version) >= StrictVersion('2.11'):
+                    if StrictVersion(self.__version) >= StrictVersion('2.10'):
                         self.__oslabel = 'redhat8'
                     else:
                         self.__oslabel = 'redhat8.0'
                 else:
-                    if StrictVersion(self.__version) >= StrictVersion('2.11'):
+                    if StrictVersion(self.__version) >= StrictVersion('2.10'):
                         self.__oslabel = 'redhat7'
                     else:
                         self.__oslabel = 'redhat7.6'
@@ -227,7 +254,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         if self.__inbox:
             # Use inbox OFED
-            if StrictVersion(self.__version) >= StrictVersion('2.11'):
+            if StrictVersion(self.__version) >= StrictVersion('2.10'):
                 # Version 2.11 and later include an extra label
                 self.__label = 'hpcx-v{0}-gcc-inbox-{1}-{2}-{3}'.format(
                     self.__version, self.__oslabel, self.__buildlabel,
@@ -237,13 +264,13 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
                     self.__version, self.__oslabel, self.__arch)
         else:
             # Use MLNX OFED
-            if StrictVersion(self.__version) >= StrictVersion('2.11'):
-                # Version 2.11 and later include an extra label
-                self.__label = 'hpcx-v{0}-gcc-MLNX_OFED_LINUX-{1}-{2}-{3}-{4}'.format(
-                    self.__version, self.__mlnx_ofed, self.__oslabel, self.__buildlabel, self.__arch)
+            if StrictVersion(self.__version) >= StrictVersion('2.10'):
+                # Version 2.10 and later include an extra label
+                self.__label = 'hpcx-v{0}-{1}-{2}-{3}-{4}'.format(
+                    self.__version, self.__ofedlabel, self.__oslabel, self.__buildlabel, self.__arch)
             else:
-                self.__label = 'hpcx-v{0}-gcc-MLNX_OFED_LINUX-{1}-{2}-{3}'.format(
-                    self.__version, self.__mlnx_ofed, self.__oslabel, self.__arch)
+                self.__label = 'hpcx-v{0}-{1}-{2}-{3}'.format(
+                    self.__version, self.__ofedlabel, self.__oslabel, self.__arch)
 
         tarball = self.__label + '.tbz'
         url = '{0}/v{1}/{2}'.format(self.__baseurl, version_string, tarball)

--- a/test/test_hpcx.py
+++ b/test/test_hpcx.py
@@ -38,7 +38,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.15
+r'''# Mellanox HPC-X version 2.16
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -47,12 +47,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.15/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda12-gdrcopy2-nccl2.17-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.16/hpcx-v2.16-gcc-mlnx_ofed-ubuntu18.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu18.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu18.04-cuda12-gdrcopy2-nccl2.18-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu18.04-cuda12-gdrcopy2-nccl2.17-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu18.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu18.04-cuda12-gdrcopy2-nccl2.18-x86_64''')
 
     @x86_64
     @ubuntu20
@@ -61,7 +61,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.15
+r'''# Mellanox HPC-X version 2.16
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -70,12 +70,12 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.15/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda12-gdrcopy2-nccl2.17-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.16/hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu20.04-cuda12-gdrcopy2-nccl2.17-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu20.04-cuda12-gdrcopy2-nccl2.18-x86_64''')
 
     @x86_64
     @centos
@@ -84,7 +84,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default mlnx_ofed building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.15
+r'''# Mellanox HPC-X version 2.16
 RUN yum install -y \
         bzip2 \
         numactl-libs \
@@ -92,12 +92,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.15/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat7-cuda12-gdrcopy2-nccl2.17-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat7-cuda12-gdrcopy2-nccl2.17-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat7-cuda12-gdrcopy2-nccl2.17-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.16/hpcx-v2.16-gcc-mlnx_ofed-redhat7-cuda12-gdrcopy2-nccl2.18-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat7-cuda12-gdrcopy2-nccl2.18-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat7-cuda12-gdrcopy2-nccl2.18-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat7-cuda12-gdrcopy2-nccl2.17-x86_64.tbz /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat7-cuda12-gdrcopy2-nccl2.17-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat7-cuda12-gdrcopy2-nccl2.18-x86_64.tbz /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat7-cuda12-gdrcopy2-nccl2.18-x86_64''')
 
     @x86_64
     @centos8
@@ -106,7 +106,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Default mlnx_ofed building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.15
+r'''# Mellanox HPC-X version 2.16
 RUN yum install -y \
         bzip2 \
         numactl-libs \
@@ -114,12 +114,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.15/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.16/hpcx-v2.16-gcc-mlnx_ofed-redhat8-cuda12-gdrcopy2-nccl2.18-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat8-cuda12-gdrcopy2-nccl2.18-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat8-cuda12-gdrcopy2-nccl2.18-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64.tbz /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-redhat8-cuda12-gdrcopy2-nccl2.17-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat8-cuda12-gdrcopy2-nccl2.18-x86_64.tbz /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-redhat8-cuda12-gdrcopy2-nccl2.18-x86_64''')
 
     @x86_64
     @ubuntu
@@ -291,7 +291,7 @@ ENV CPATH=/usr/local/hpcx/hcoll/include:/usr/local/hpcx/ompi/include:/usr/local/
         h = hpcx()
         r = h.runtime()
         self.assertEqual(r,
-r'''# Mellanox HPC-X version 2.15
+r'''# Mellanox HPC-X version 2.16
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -300,9 +300,9 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.15/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu22.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu22.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu22.04-cuda12-gdrcopy2-nccl2.17-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.16/hpcx-v2.16-gcc-mlnx_ofed-ubuntu22.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu22.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu22.04-cuda12-gdrcopy2-nccl2.18-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu22.04-cuda12-gdrcopy2-nccl2.17-x86_64.tbz /var/tmp/hpcx-v2.15-gcc-MLNX_OFED_LINUX-5-ubuntu22.04-cuda12-gdrcopy2-nccl2.17-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu22.04-cuda12-gdrcopy2-nccl2.18-x86_64.tbz /var/tmp/hpcx-v2.16-gcc-mlnx_ofed-ubuntu22.04-cuda12-gdrcopy2-nccl2.18-x86_64''')


### PR DESCRIPTION
Bump default HPC-X version to 2.16

And adjust for another package naming change.

## Pull Request Description

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [ ] Passes all unit tests
