### PR TITLE
Bump default NVHPC version to 24.7

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -3196,7 +3196,7 @@ the default GNU toolchain.
 
 - __version__: The version of the HPC SDK to use.  Note when `package`
 is set the version is determined automatically from the package
-file name.  The default value is `23.11`.
+file name.  The default value is `24.7`.
 
 __Examples__
 

--- a/hpccm/building_blocks/nvhpc.py
+++ b/hpccm/building_blocks/nvhpc.py
@@ -117,7 +117,7 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
 
     version: The version of the HPC SDK to use.  Note when `package`
     is set the version is determined automatically from the package
-    file name.  The default value is `23.11`.
+    file name.  The default value is `24.7`.
 
     # Examples
 
@@ -175,14 +175,20 @@ class nvhpc(bb_base, hpccm.templates.downloader, hpccm.templates.envvars,
         self.__tarball = kwargs.get('tarball', False)
         self.__toolchain = kwargs.get('toolchain', None)
         self.__url = kwargs.get('url', None)
-        self.__version = kwargs.get('version', '23.11')
+        self.__version = kwargs.get('version', '24.7')
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
         self.__year = '' # Filled in by __get_version()
 
         self.toolchain = toolchain(CC='nvc', CXX='nvc++', F77='nvfortran',
                                    F90='nvfortran', FC='nvfortran')
 
-        if Version(self.__version) >= Version('23.7'):
+        if Version(self.__version) >= Version('24.7'):
+            self.__cuda_version_default = '12.5'
+        elif Version(self.__version) >= Version('24.5'):
+            self.__cuda_version_default = '12.4'
+        elif Version(self.__version) >= Version('23.11'):
+            self.__cuda_version_default = '12.3'
+        elif Version(self.__version) >= Version('23.7'):
             self.__cuda_version_default = '12.2'
         elif Version(self.__version) >= Version('23.5'):
             self.__cuda_version_default = '12.1'

--- a/test/test_nvhpc.py
+++ b/test/test_nvhpc.py
@@ -39,7 +39,7 @@ class Test_nvhpc(unittest.TestCase):
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertMultiLineEqual(str(n),
-r'''# NVIDIA HPC SDK version 23.11
+r'''# NVIDIA HPC SDK version 24.7
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -52,12 +52,12 @@ RUN mkdir -p /usr/share/keyrings && \
     echo "deb [signed-by=/usr/share/keyrings/DEB-GPG-KEY-NVIDIA-HPC-SDK.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        nvhpc-23-11-cuda-multi && \
+        nvhpc-24-7-cuda-multi && \
     rm -rf /var/lib/apt/lists/*
-ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/include:$CPATH \
-    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/cuda/lib64:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi/bin:$PATH''')
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/cuda/lib64:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -66,19 +66,19 @@ ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/include:/opt/
         """Default HPC SDK building block"""
         n = nvhpc(eula=True)
         self.assertMultiLineEqual(str(n),
-r'''# NVIDIA HPC SDK version 23.11
+r'''# NVIDIA HPC SDK version 24.7
 RUN yum install -y \
         ca-certificates && \
     rm -rf /var/cache/yum/*
 RUN yum install -y yum-utils && \
     yum-config-manager --add-repo https://developer.download.nvidia.com/hpc-sdk/rhel/nvhpc.repo && \
     yum install -y \
-        nvhpc-cuda-multi-23.11 && \
+        nvhpc-cuda-multi-24.7 && \
     rm -rf /var/cache/yum/*
-ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/include:$CPATH \
-    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/cuda/lib64:$LD_LIBRARY_PATH \
-    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/man:$MANPATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi/bin:$PATH''')
+ENV CPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/include:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/include:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/extras/qd/include/qd:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/include:$CPATH \
+    LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/lib64:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/cuda/lib64:$LD_LIBRARY_PATH \
+    MANPATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/man:$MANPATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nvshmem/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/nccl/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/profilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/cuda/bin:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -218,10 +218,10 @@ RUN apt-get update -y && \
         libnuma1 \
         openssh-client && \
     rm -rf /var/lib/apt/lists/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib:$LD_LIBRARY_PATH \
-    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/mpi/bin:$PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib:$LD_LIBRARY_PATH \
+    PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/mpi/bin:$PATH''')
 
     @x86_64
     @centos
@@ -241,11 +241,11 @@ RUN yum install -y \
         numactl-libs \
         openssh-clients && \
     rm -rf /var/cache/yum/*
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/REDIST/comm_libs/11.8/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/11.8/nccl/lib/libnccl.so
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib/
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/REDIST/math_libs/11.8/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/11.8/lib64/libcufft.so.10
-COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/REDIST/math_libs/11.8/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/11.8/lib64/libcublas.so.11
-ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/comm_libs/11.8/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/23.11/math_libs/11.8/lib64:$LD_LIBRARY_PATH''')
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/REDIST/comm_libs/11.8/nccl/lib/libnccl.so /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/11.8/nccl/lib/libnccl.so
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/REDIST/compilers/lib/* /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib/
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/REDIST/math_libs/11.8/lib64/libcufft.so.10 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/11.8/lib64/libcufft.so.10
+COPY --from=0 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/REDIST/math_libs/11.8/lib64/libcublas.so.11 /opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/11.8/lib64/libcublas.so.11
+ENV LD_LIBRARY_PATH=/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/comm_libs/11.8/nccl/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/compilers/lib:/opt/nvidia/hpc_sdk/Linux_x86_64/24.7/math_libs/11.8/lib64:$LD_LIBRARY_PATH''')
 
     @x86_64
     @ubuntu


### PR DESCRIPTION
## Pull Request Description

Bump default NVHPC version to 24.7

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
