### PR TITLE
Fix Intel APT ONEAPI repository signature verification

### DIFF
--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -120,7 +120,7 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
         self += packages(
             _apt_key=True,
             apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
-            apt_repositories=['deb https://apt.repos.intel.com/mkl all main'],
+            apt_repositories=['deb [signed-by=/usr/share/keyrings/'+'GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.gpg'.format(self.__year+'] https://apt.repos.intel.com/mkl all main'],
             ospackages=['intel-mkl-64bit-{}'.format(self.__version)],
             yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             yum_repositories=['https://yum.repos.intel.com/mkl/setup/intel-mkl.repo'])

--- a/hpccm/building_blocks/mkl.py
+++ b/hpccm/building_blocks/mkl.py
@@ -120,7 +120,7 @@ class mkl(bb_base, hpccm.templates.envvars, hpccm.templates.wget):
         self += packages(
             _apt_key=True,
             apt_keys=['https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
-            apt_repositories=['deb [signed-by=/usr/share/keyrings/'+'GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.gpg'.format(self.__year+'] https://apt.repos.intel.com/mkl all main'],
+            apt_repositories=['deb [signed-by=/usr/share/keyrings/'+'GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.gpg'.format(self.__year)+'] https://apt.repos.intel.com/mkl all main'],
             ospackages=['intel-mkl-64bit-{}'.format(self.__version)],
             yum_keys=['https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-{}.PUB'.format(self.__year)],
             yum_repositories=['https://yum.repos.intel.com/mkl/setup/intel-mkl.repo'])

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2020.0-088 && \
@@ -90,7 +90,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2018.2-046 && \
@@ -112,7 +112,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2019.4-070 && \
@@ -138,7 +138,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2020.0-088 && \

--- a/test/test_mkl.py
+++ b/test/test_mkl.py
@@ -53,7 +53,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2020.0-088 && \
@@ -90,7 +90,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2018.2-046 && \
@@ -112,7 +112,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2019.4-070 && \
@@ -138,7 +138,7 @@ RUN apt-get update -y && \
         wget && \
     rm -rf /var/lib/apt/lists/*
 RUN wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | apt-key add - && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg] https://apt.repos.intel.com/mkl all main" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         intel-mkl-64bit-2020.0-088 && \


### PR DESCRIPTION
## Pull Request Description

We are receiving a signature verification issue when using the Intel APT OneAPI repository. The pull request fixes this issue by explicitly indicating the GPG Key used for the repository.

Signature verification issue:
```
#17 [12/26] RUN mkdir -p /usr/share/keyrings &&     rm -f /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | gpg --dearmor -o /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     echo "deb https://apt.repos.intel.com/oneapi all main" >> /etc/apt/sources.list.d/hpccm.list &&     apt-get update -y &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         intel-oneapi-mkl-devel-2021.4.0 &&     rm -rf /var/lib/apt/lists/*

#17 0.540 Get:1 https://apt.repos.intel.com/oneapi all InRelease [5680 B]

#17 0.696 Get:2 http://security.ubuntu.com/ubuntu noble-security InRelease [126 kB]

#17 0.751 Err:1 https://apt.repos.intel.com/oneapi all InRelease

#17 0.751   The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BAC6F0C353D04109

#17 0.928 Get:3 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]

#17 1.055 Get:4 http://security.ubuntu.com/ubuntu noble-security/main amd64 Packages [479 kB]

#17 1.354 Get:5 http://security.ubuntu.com/ubuntu noble-security/universe amd64 Packages [370 kB]

#17 1.614 Get:6 http://security.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [446 kB]

#17 1.803 Get:7 http://archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]

#17 1.834 Get:8 http://security.ubuntu.com/ubuntu noble-security/multiverse amd64 Packages [13.7 kB]

#17 2.521 Get:9 http://archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]

#17 3.562 Get:10 http://archive.ubuntu.com/ubuntu noble/main amd64 Packages [1808 kB]

#17 5.624 Get:11 http://archive.ubuntu.com/ubuntu noble/restricted amd64 Packages [117 kB]

#17 6.326 Get:12 http://archive.ubuntu.com/ubuntu noble/multiverse amd64 Packages [331 kB]

#17 7.501 Get:13 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]

#17 80.92 Ign:14 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages

#17 82.01 Get:15 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [682 kB]

#17 83.61 Get:16 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [512 kB]

#17 84.60 Get:17 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [446 kB]

#17 85.40 Get:18 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [11.8 kB]

#17 85.52 Get:14 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [17.8 kB]

#17 85.55 Reading package lists...

#17 86.21 W: GPG error: https://apt.repos.intel.com/oneapi all InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BAC6F0C353D04109

#17 86.21 E: The repository 'https://apt.repos.intel.com/oneapi all InRelease' is not signed.

#17 ERROR: process "/bin/sh -c mkdir -p /usr/share/keyrings &&     rm -f /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | gpg --dearmor -o /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     echo \"deb https://apt.repos.intel.com/oneapi all main\" >> /etc/apt/sources.list.d/hpccm.list &&     apt-get update -y &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         intel-oneapi-mkl-devel-2021.4.0 &&     rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100

------

 > [12/26] RUN mkdir -p /usr/share/keyrings &&     rm -f /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     wget -qO - https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB | gpg --dearmor -o /usr/share/keyrings/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.gpg &&     echo "deb https://apt.repos.intel.com/oneapi all main" >> /etc/apt/sources.list.d/hpccm.list &&     apt-get update -y &&     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         intel-oneapi-mkl-devel-2021.4.0 &&     rm -rf /var/lib/apt/lists/*:

7.501 Get:13 http://archive.ubuntu.com/ubuntu noble/universe amd64 Packages [19.3 MB]

80.92 Ign:14 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages

82.01 Get:15 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [682 kB]

83.61 Get:16 http://archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [512 kB]

84.60 Get:17 http://archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [446 kB]

85.40 Get:18 http://archive.ubuntu.com/ubuntu noble-backports/universe amd64 Packages [11.8 kB]

85.52 Get:14 http://archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Packages [17.8 kB]


86.21 W: GPG error: https://apt.repos.intel.com/oneapi all InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BAC6F0C353D04109

86.21 E: The repository 'https://apt.repos.intel.com/oneapi all InRelease' is not signed.
```


## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified -> not applicable
* [ ] Passes all unit tests
