### PR TITLE
Update the HDF5 and NetCDF building blocks

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1412,7 +1412,7 @@ non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of HDF5 source to download.  This value is
-ignored if `directory` is set.  The default value is `1.12.0`.
+ignored if `directory` is set.  The default value is `1.14.5`.
 
 - __with_PACKAGE[=ARG]__: Flags to control optional packages when
 configuring.  For instance, `with_foo=True` maps to `--with-foo`
@@ -2988,10 +2988,10 @@ directory. The default value is False.
 
 - __ospackages__: List of OS packages to install prior to configuring
 and building.  For Ubuntu, the default values are
-`ca-certificates`, `file`, `libcurl4-openssl-dev`, `m4`, `make`,
-`wget`, and `zlib1g-dev`.  For RHEL-based Linux distributions the
-default values are `ca-certificates`, `file`, `libcurl-devel`
-`m4`, `make`, `wget`, and `zlib-devel`.
+`ca-certificates`, `file`, `libcurl4-openssl-dev`, `libxml2-dev`, `m4`,
+`make`, `wget`, and `zlib1g-dev`.  For RHEL-based Linux distributions the
+default values are `ca-certificates`, `file`, `libcurl-devel`,
+`libxml2-devel`, `m4`, `make`, `wget`, and `zlib-devel`.
 
 - __prefix__: The top level install location.  The default location is
 `/usr/local/netcdf`.

--- a/test/test_hdf5.py
+++ b/test/test_hdf5.py
@@ -36,8 +36,8 @@ class Test_hdf5(unittest.TestCase):
     def test_defaults_ubuntu(self):
         """Default hdf5 building block"""
         h = hdf5()
-        self.assertEqual(str(h),
-r'''# HDF5 version 1.12.0
+        self.assertMultiLineEqual(str(h),
+r'''# HDF5 version 1.14.5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -46,12 +46,12 @@ RUN apt-get update -y && \
         wget \
         zlib1g-dev && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.12.0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.12.0 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/downloads/hdf5-1.14.5.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.14.5.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/hdf5-1.14.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.12.0 /var/tmp/hdf5-1.12.0.tar.bz2
+    rm -rf /var/tmp/hdf5-1.14.5 /var/tmp/hdf5-1.14.5.tar.gz
 ENV CPATH=/usr/local/hdf5/include:$CPATH \
     HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
@@ -63,8 +63,8 @@ ENV CPATH=/usr/local/hdf5/include:$CPATH \
     def test_defaults_centos(self):
         """Default hdf5 building block"""
         h = hdf5()
-        self.assertEqual(str(h),
-r'''# HDF5 version 1.12.0
+        self.assertMultiLineEqual(str(h),
+r'''# HDF5 version 1.14.5
 RUN yum install -y \
         bzip2 \
         file \
@@ -72,12 +72,12 @@ RUN yum install -y \
         wget \
         zlib-devel && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-1.12.0/src/hdf5-1.12.0.tar.bz2 && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.12.0.tar.bz2 -C /var/tmp -j && \
-    cd /var/tmp/hdf5-1.12.0 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://support.hdfgroup.org/releases/hdf5/v1_14/v1_14_5/downloads/hdf5-1.14.5.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hdf5-1.14.5.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/hdf5-1.14.5 &&   ./configure --prefix=/usr/local/hdf5 --enable-cxx --enable-fortran && \
     make -j$(nproc) && \
     make -j$(nproc) install && \
-    rm -rf /var/tmp/hdf5-1.12.0 /var/tmp/hdf5-1.12.0.tar.bz2
+    rm -rf /var/tmp/hdf5-1.14.5 /var/tmp/hdf5-1.14.5.tar.gz
 ENV CPATH=/usr/local/hdf5/include:$CPATH \
     HDF5_DIR=/usr/local/hdf5 \
     LD_LIBRARY_PATH=/usr/local/hdf5/lib:$LD_LIBRARY_PATH \
@@ -89,7 +89,7 @@ ENV CPATH=/usr/local/hdf5/include:$CPATH \
     def test_ldconfig(self):
         """ldconfig option"""
         h = hdf5(ldconfig=True, version='1.10.4')
-        self.assertEqual(str(h),
+        self.assertMultiLineEqual(str(h),
 r'''# HDF5 version 1.10.4
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -117,7 +117,7 @@ ENV CPATH=/usr/local/hdf5/include:$CPATH \
         """Runtime"""
         h = hdf5()
         r = h.runtime()
-        self.assertEqual(r,
+        self.assertMultiLineEqual(r,
 r'''# HDF5
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/test/test_netcdf.py
+++ b/test/test_netcdf.py
@@ -36,7 +36,7 @@ class Test_netcdf(unittest.TestCase):
     def test_defaults_ubuntu(self):
         """Default netcdf building block"""
         n = netcdf()
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NetCDF version 4.7.4, NetCDF C++ version 4.3.1, NetCDF Fortran
 # version 4.5.3
 RUN apt-get update -y && \
@@ -44,6 +44,7 @@ RUN apt-get update -y && \
         ca-certificates \
         file \
         libcurl4-openssl-dev \
+        libxml2-dev \
         m4 \
         make \
         wget \
@@ -77,13 +78,14 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     def test_defaults_centos(self):
         """Default netcdf building block"""
         n = netcdf()
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NetCDF version 4.7.4, NetCDF C++ version 4.3.1, NetCDF Fortran
 # version 4.5.3
 RUN yum install -y \
         ca-certificates \
         file \
         libcurl-devel \
+        libxml2-devel \
         m4 \
         make \
         wget \
@@ -118,7 +120,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """ldconfig option"""
         n = netcdf(ldconfig=True, version='4.6.1', version_cxx='4.3.0',
                    version_fortran='4.4.4')
-        self.assertEqual(str(n),
+        self.assertMultiLineEqual(str(n),
 r'''# NetCDF version 4.6.1, NetCDF C++ version 4.3.0, NetCDF Fortran
 # version 4.4.4
 RUN apt-get update -y && \
@@ -126,6 +128,7 @@ RUN apt-get update -y && \
         ca-certificates \
         file \
         libcurl4-openssl-dev \
+        libxml2-dev \
         m4 \
         make \
         wget \
@@ -162,7 +165,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         """Runtime"""
         n = netcdf()
         r = n.runtime()
-        self.assertEqual(r,
+        self.assertMultiLineEqual(r,
 r'''# NetCDF
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Pull Request Description

- Bump the default HDF5 version to 1.14.5
- Add required libxml2 dependency to NetCDF
- Workaround issue when building NetCDF Fortran with the NVIDIA HPC SDK

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
