### PR TITLE
Update gdrcopy building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -840,12 +840,15 @@ default values are `make` and `wget`.
 - __prefix__: The top level install location.  The default value is
 `/usr/local/gdrcopy`.
 
+- __targets__: List of make targets to build.  The default values are
+`lib` and `lib_install`.
+
 - __toolchain__: The toolchain object.  This should be used if
 non-default compilers or other toolchain options are needed.  The
 default is empty.
 
 - __version__: The version of gdrcopy source to download.  The default
-value is `2.2`.
+value is `2.4.4`.
 
 __Examples__
 

--- a/hpccm/building_blocks/gdrcopy.py
+++ b/hpccm/building_blocks/gdrcopy.py
@@ -59,12 +59,15 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
     prefix: The top level install location.  The default value is
     `/usr/local/gdrcopy`.
 
+    targets: List of make targets to build.  The default values are
+    `lib` and `lib_install`.
+
     toolchain: The toolchain object.  This should be used if
     non-default compilers or other toolchain options are needed.  The
     default is empty.
 
     version: The version of gdrcopy source to download.  The default
-    value is `2.2`.
+    value is `2.4.4`.
 
     # Examples
 
@@ -83,8 +86,9 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
         self.__baseurl = kwargs.pop('baseurl', 'https://github.com/NVIDIA/gdrcopy/archive')
         self.__ospackages = kwargs.pop('ospackages', ['make', 'wget'])
         self.__prefix = kwargs.pop('prefix', '/usr/local/gdrcopy')
+        self.__targets = kwargs.pop('targets', ['lib', 'lib_install'])
         self.__toolchain = kwargs.pop('toolchain', toolchain())
-        self.__version = kwargs.pop('version', '2.2')
+        self.__version = kwargs.pop('version', '2.4.4')
 
 
         # Since gdrcopy does not use autotools or CMake, the toolchain
@@ -122,7 +126,7 @@ class gdrcopy(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig):
             base_annotation=self.__class__.__name__,
             # Work around "install -D" issue on CentOS
             build=['mkdir -p {0}/include {0}/{1}'.format(self.__prefix, libdir),
-                   'make {} lib lib_install'.format(make_opts_str)],
+                   'make {0} {1}'.format(make_opts_str, ' '.join(self.__targets))],
             comment=False,
             devel_environment=self.environment_variables,
             directory='gdrcopy-{}'.format(self.__version),

--- a/test/test_gdrcopy.py
+++ b/test/test_gdrcopy.py
@@ -38,18 +38,18 @@ class Test_gdrcopy(unittest.TestCase):
         """Default gdrcopy building block"""
         g = gdrcopy()
         self.assertEqual(str(g),
-r'''# GDRCOPY version 2.2
+r'''# GDRCOPY version 2.4.4
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/gdrcopy-2.2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.4.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.4.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.4.4 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib && \
     make prefix=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/gdrcopy-2.2 /var/tmp/v2.2.tar.gz
+    rm -rf /var/tmp/gdrcopy-2.4.4 /var/tmp/v2.4.4.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib:$LIBRARY_PATH''')
@@ -60,17 +60,17 @@ ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
         """Default gdrcopy building block"""
         g = gdrcopy()
         self.assertEqual(str(g),
-r'''# GDRCOPY version 2.2
+r'''# GDRCOPY version 2.4.4
 RUN yum install -y \
         make \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/gdrcopy-2.2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.4.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.4.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.4.4 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib && \
     make prefix=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/gdrcopy-2.2 /var/tmp/v2.2.tar.gz
+    rm -rf /var/tmp/gdrcopy-2.4.4 /var/tmp/v2.4.4.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib:$LIBRARY_PATH''')        
@@ -170,18 +170,18 @@ ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
         tc = toolchain(CC='gcc', CFLAGS='-O2')
         g = gdrcopy(toolchain=tc)
         self.assertEqual(str(g),
-r'''# GDRCOPY version 2.2
+r'''# GDRCOPY version 2.4.4
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         make \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.2.tar.gz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.2.tar.gz -C /var/tmp -z && \
-    cd /var/tmp/gdrcopy-2.2 && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/NVIDIA/gdrcopy/archive/v2.4.4.tar.gz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/v2.4.4.tar.gz -C /var/tmp -z && \
+    cd /var/tmp/gdrcopy-2.4.4 && \
     mkdir -p /usr/local/gdrcopy/include /usr/local/gdrcopy/lib && \
     make CC=gcc COMMONCFLAGS=-O2 prefix=/usr/local/gdrcopy lib lib_install && \
-    rm -rf /var/tmp/gdrcopy-2.2 /var/tmp/v2.2.tar.gz
+    rm -rf /var/tmp/gdrcopy-2.4.4 /var/tmp/v2.4.4.tar.gz
 ENV CPATH=/usr/local/gdrcopy/include:$CPATH \
     LD_LIBRARY_PATH=/usr/local/gdrcopy/lib:$LD_LIBRARY_PATH \
     LIBRARY_PATH=/usr/local/gdrcopy/lib:$LIBRARY_PATH''')    


### PR DESCRIPTION
## Pull Request Description

Update gdrcopy building block
- Add targets option
- Bump default version to 2.4.4

Resolve #508 

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
