### PR TITLE
Update HPC-X building block

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -1574,15 +1574,16 @@ library directories. This value is ignored if `hpcxinit` is
 `True`. The default value is False.
 
 - __mlnx_ofed__: The version of Mellanox OFED that should be matched.
-This value is ignored if Inbox OFED is selected.  The default
-value is `5` for HPC-X version 2.10 and later, and `5.2-2.2.0.0`
-for earlier HPC-X versions.
+This value is ignored if Inbox OFED is selected, or for HPC-X 2.21
+and later.  The default value is `5` for HPC-X version 2.10 and
+later, and `5.2-2.2.0.0` for earlier HPC-X versions.
 
 - __multi_thread__: Boolean flag to specify whether the multi-threaded
 version of Mellanox HPC-X should be used.  The default is `False`.
 
 - __ofedlabel__: The Mellanox OFED label assigned by Mellanox to the
-tarball.  For version 2.16 and later, the default value is
+tarball.  For version 2.21 and later, the default value is
+`gcc-doca_ofed`.  For version 2.16 through 2.18, the default value is
 `gcc-mlnx_ofed`.  For earlier versions, the default value is
 `gcc-MLNX_OFED_LINUX-5`.  This value is ignored if `inbox` is `True`.
 
@@ -1606,7 +1607,7 @@ distributions the default values are `bzip2`, `numactl-libs`,
 `/usr/local/hpcx`.
 
 - __version__: The version of Mellanox HPC-X to install.  The default
-value is `2.19`.
+value is `2.22.1`.
 
 __Examples__
 

--- a/hpccm/building_blocks/hpcx.py
+++ b/hpccm/building_blocks/hpcx.py
@@ -86,15 +86,16 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     `True`. The default value is False.
 
     mlnx_ofed: The version of Mellanox OFED that should be matched.
-    This value is ignored if Inbox OFED is selected.  The default
-    value is `5` for HPC-X version 2.10 and later, and `5.2-2.2.0.0`
-    for earlier HPC-X versions.
+    This value is ignored if Inbox OFED is selected, or for HPC-X 2.21
+    and later.  The default value is `5` for HPC-X version 2.10 and
+    later, and `5.2-2.2.0.0` for earlier HPC-X versions.
 
     multi_thread: Boolean flag to specify whether the multi-threaded
     version of Mellanox HPC-X should be used.  The default is `False`.
 
     ofedlabel: The Mellanox OFED label assigned by Mellanox to the
-    tarball.  For version 2.16 and later, the default value is
+    tarball.  For version 2.21 and later, the default value is
+    `gcc-doca_ofed`.  For version 2.16 through 2.18, the default value is
     `gcc-mlnx_ofed`.  For earlier versions, the default value is
     `gcc-MLNX_OFED_LINUX-5`.  This value is ignored if `inbox` is `True`.
 
@@ -118,7 +119,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
     `/usr/local/hpcx`.
 
     version: The version of Mellanox HPC-X to install.  The default
-    value is `2.19`.
+    value is `2.22.1`.
 
     # Examples
 
@@ -147,7 +148,7 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
         self.__ospackages = kwargs.get('ospackages', []) # Filled in by _distro()
         self.__packages = kwargs.get('packages', [])
         self.__prefix = kwargs.get('prefix', '/usr/local/hpcx')
-        self.__version = kwargs.get('version', '2.19')
+        self.__version = kwargs.get('version', '2.22.1')
 
         self.__commands = [] # Filled in by __setup()
         self.__wd = kwargs.get('wd', hpccm.config.g_wd) # working directory
@@ -173,7 +174,9 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
                 self.__mlnx_ofed = '5.2-2.2.0.0'
 
         if not self.__ofedlabel:
-            if Version(self.__version) >= Version('2.16'):
+            if Version(self.__version) >= Version('2.21'):
+                self.__ofedlabel = 'gcc-doca_ofed'
+            elif Version(self.__version) >= Version('2.16'):
                 self.__ofedlabel = 'gcc-mlnx_ofed'
             else:
                 self.__ofedlabel = 'gcc-MLNX_OFED_LINUX-{}'.format(self.__mlnx_ofed)
@@ -205,7 +208,9 @@ class hpcx(bb_base, hpccm.templates.envvars, hpccm.templates.ldconfig,
 
         if hpccm.config.g_linux_distro == linux_distro.UBUNTU:
             if not self.__oslabel:
-                if hpccm.config.g_linux_version >= Version('22.0'):
+                if hpccm.config.g_linux_version >= Version('24.0'):
+                    self.__oslabel = 'ubuntu24.04'
+                elif hpccm.config.g_linux_version >= Version('22.0'):
                     self.__oslabel = 'ubuntu22.04'
                 elif hpccm.config.g_linux_version >= Version('20.0'):
                     self.__oslabel = 'ubuntu20.04'

--- a/test/test_hpcx.py
+++ b/test/test_hpcx.py
@@ -22,11 +22,11 @@ from __future__ import print_function
 import logging # pylint: disable=unused-import
 import unittest
 
-from helpers import aarch64, centos, centos8, docker, ppc64le, ubuntu, ubuntu18, ubuntu20, ubuntu22, x86_64
+from helpers import aarch64, centos, centos8, docker, ppc64le, ubuntu, ubuntu18, ubuntu20, ubuntu22, ubuntu24, x86_64
 
 from hpccm.building_blocks.hpcx import hpcx
 
-class Test_mlnx_ofed(unittest.TestCase):
+class Test_hpcx(unittest.TestCase):
     def setUp(self):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
@@ -38,7 +38,7 @@ class Test_mlnx_ofed(unittest.TestCase):
         """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.19
+r'''# Mellanox HPC-X version 2.22.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -47,19 +47,42 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.19/hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.22.1/hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64.tbz /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu20.04-cuda12-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12-x86_64.tbz /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu20.04-cuda12-x86_64''')
+
+    @x86_64
+    @ubuntu24
+    @docker
+    def test_defaults_ubuntu24(self):
+        """Default hpcx building block"""
+        h = hpcx()
+        self.assertEqual(str(h),
+r'''# Mellanox HPC-X version 2.22.1
+RUN apt-get update -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bzip2 \
+        libnuma1 \
+        openssh-client \
+        tar \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.22.1/hpcx-v2.22.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64 /usr/local/hpcx && \
+    echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
+    echo "hpcx_load" >> /etc/bash.bashrc && \
+    rm -rf /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64.tbz /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu24.04-cuda12-x86_64''')
 
     @x86_64
     @centos
     @docker
     def test_defaults_centos7(self):
-        """Default mlnx_ofed building block"""
-        h = hpcx()
+        """Default hpcx building block"""
+        h = hpcx(version='2.19')
         self.assertEqual(str(h),
 r'''# Mellanox HPC-X version 2.19
 RUN yum install -y \
@@ -80,10 +103,10 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
     @centos8
     @docker
     def test_defaults_centos8(self):
-        """Default mlnx_ofed building block"""
+        """Default hpcx building block"""
         h = hpcx()
         self.assertEqual(str(h),
-r'''# Mellanox HPC-X version 2.19
+r'''# Mellanox HPC-X version 2.22.1
 RUN yum install -y \
         bzip2 \
         numactl-libs \
@@ -91,12 +114,12 @@ RUN yum install -y \
         tar \
         wget && \
     rm -rf /var/cache/yum/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.19/hpcx-v2.19-gcc-mlnx_ofed-redhat8-cuda12-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-redhat8-cuda12-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-redhat8-cuda12-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.22.1/hpcx-v2.22.1-gcc-doca_ofed-redhat8-cuda12-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-redhat8-cuda12-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-redhat8-cuda12-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bashrc && \
     echo "hpcx_load" >> /etc/bashrc && \
-    rm -rf /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-redhat8-cuda12-x86_64.tbz /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-redhat8-cuda12-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-redhat8-cuda12-x86_64.tbz /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-redhat8-cuda12-x86_64''')
 
     @x86_64
     @ubuntu
@@ -291,7 +314,7 @@ RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://
         h = hpcx()
         r = h.runtime()
         self.assertEqual(r,
-r'''# Mellanox HPC-X version 2.19
+r'''# Mellanox HPC-X version 2.22.1
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         bzip2 \
@@ -300,9 +323,9 @@ RUN apt-get update -y && \
         tar \
         wget && \
     rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.19/hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz && \
-    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz -C /var/tmp -j && \
-    cp -a /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64 /usr/local/hpcx && \
+RUN mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://content.mellanox.com/hpc/hpc-x/v2.22.1/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz && \
+    mkdir -p /var/tmp && tar -x -f /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz -C /var/tmp -j && \
+    cp -a /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64 /usr/local/hpcx && \
     echo "source /usr/local/hpcx/hpcx-init-ompi.sh" >> /etc/bash.bashrc && \
     echo "hpcx_load" >> /etc/bash.bashrc && \
-    rm -rf /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64.tbz /var/tmp/hpcx-v2.19-gcc-mlnx_ofed-ubuntu22.04-cuda12-x86_64''')
+    rm -rf /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64.tbz /var/tmp/hpcx-v2.22.1-gcc-doca_ofed-ubuntu22.04-cuda12-x86_64''')


### PR DESCRIPTION
## Pull Request Description

Update HPC-X building block
- Reflect change to DOCA OFED
- Bump default to version 2.22.1

Resolve #509 

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
