### PR TITLE
The yum release_stream option should only apply to RHEL-based 8.x distos

### DIFF
--- a/hpccm/building_blocks/yum.py
+++ b/hpccm/building_blocks/yum.py
@@ -194,7 +194,8 @@ class yum(bb_base):
             self.__commands.append('yum-config-manager --set-enabled powertools')
 
         if (self.__release_stream and
-            hpccm.config.g_linux_version >= Version('8.0')):
+            hpccm.config.g_linux_version >= Version('8.0') and
+            hpccm.config.g_linux_version < Version('9.0')):
             # This needs to be a discrete, preliminary step so that
             # packages from release stream are available to be installed.
             self.__commands.append('yum install -y centos-release-stream')


### PR DESCRIPTION
## Pull Request Description

The yum building block documentation states that the `release_stream` option is only valid for RHEL-baesd 8.x distros.  However, it was incorrectly considered valid for 9.x and later distros.  Fix that.

The `centos-release-stream` repository is not valid for non-CentOS 8.x distros.  Further, CentOS no longer exists.  So this should ultimately be removed entirely, but deferring that for a larger removal of CentOS and pre 8.x support entirely.

Fix #513 

## Author Checklist
* [ ] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
