### PR TITLE
Add undocumented option to the doca_ofed building disable GPG checks for RPM-based distributions

### DIFF
--- a/docs/building_blocks.md
+++ b/docs/building_blocks.md
@@ -670,7 +670,7 @@ values are `libibumad`, `libibverbs`, `libibverbs-utils`,
 `librdmacm`, `rdma-core`, and `rdma-core-devel`.
 
 - __version__: The version of DOCA OFED to download.  The default value
-is `3.2.0`.
+is `3.3.0`.
 
 __Examples__
 

--- a/hpccm/building_blocks/doca_ofed.py
+++ b/hpccm/building_blocks/doca_ofed.py
@@ -64,7 +64,7 @@ class doca_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
     `librdmacm`, `rdma-core`, and `rdma-core-devel`.
 
     version: The version of DOCA OFED to download.  The default value
-    is `3.2.0`.
+    is `3.3.0`.
 
     # Examples
 
@@ -82,11 +82,12 @@ class doca_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
         self.__archlabel = kwargs.get('archlabel', '') # Filled in by __cpu_arch
         self.__extra_opts = []
         self.__key = 'https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub'
+        self.__nogpgcheck = kwargs.get('_nogpgcheck', False)
         self.__oslabel = kwargs.get('oslabel', '') # Filled in by __distro
         self.__ospackages = kwargs.get('ospackages',
                                        ['ca-certificates', 'gnupg', 'wget'])
         self.__packages = kwargs.get('packages', []) # Filled in by __distro
-        self.__version = kwargs.get('version', '3.2.0')
+        self.__version = kwargs.get('version', '3.3.0')
 
         # Add annotation
         self.add_annotation('version', self.__version)
@@ -153,14 +154,25 @@ class doca_ofed(bb_base, hpccm.templates.annotate, hpccm.templates.rm,
             if not self.__oslabel:
                 if hpccm.config.g_linux_version >= Version('10.0'):
                     self.__oslabel = 'rhel10'
-                    # The DOCA OFED GPG key is rejected by the Rockylinux 10
-                    # security policy as insecure.  Do not check the
-                    # package signatures.
-                    self.__key = None
-                    self.__extra_opts = ['--nogpgcheck']
+                    if self.__nogpgcheck:
+                        # The DOCA OFED GPG key is rejected by the Rockylinux 10
+                        # security policy as insecure.  Do not check the
+                        # package signatures.
+                        self.__key = None
+                        self.__extra_opts = ['--nogpgcheck']
                 elif hpccm.config.g_linux_version >= Version('9.0'):
                     self.__oslabel = 'rhel9'
+                    if self.__nogpgcheck and Version(self.__version) >= Version('3.2.2'):
+                        # The DOCA OFED GPG key is not recognized by
+                        # Rockylinux 9.  Do not check the package signatures.
+                        self.__key = None
+                        self.__extra_opts = ['--nogpgcheck']
                 else:
+                    if self.__nogpgcheck and Version(self.__version) >= Version('3.2.2'):
+                        # The DOCA OFED GPG key is not recognized by
+                        # Rockylinux 8.  Do not check the package signatures.
+                        self.__key = None
+                        self.__extra_opts = ['--nogpgcheck']
                     self.__oslabel = 'rhel8'
 
             if not self.__packages:

--- a/test/test_doca_ofed.py
+++ b/test/test_doca_ofed.py
@@ -31,38 +31,6 @@ class Test_doca_ofed(unittest.TestCase):
         """Disable logging output messages"""
         logging.disable(logging.ERROR)
 
-    @x86_64
-    @ubuntu20
-    @docker
-    def test_defaults_ubuntu20(self):
-        """Default doca_ofed building block"""
-        doca = doca_ofed()
-        self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
-RUN apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ca-certificates \
-        gnupg \
-        wget && \
-    rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /usr/share/keyrings && \
-    rm -f /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
-    wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor -o /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.gpg] https://linux.mellanox.com/public/repo/doca/3.2.0/ubuntu20.04/x86_64/ ./" >> /etc/apt/sources.list.d/hpccm.list && \
-    apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        ibverbs-providers \
-        ibverbs-utils \
-        libibmad-dev \
-        libibmad5 \
-        libibumad-dev \
-        libibumad3 \
-        libibverbs-dev \
-        libibverbs1 \
-        librdmacm-dev \
-        librdmacm1 && \
-    rm -rf /var/lib/apt/lists/*''')
-
     @aarch64
     @ubuntu22
     @docker
@@ -70,7 +38,7 @@ RUN mkdir -p /usr/share/keyrings && \
         """Default doca_ofed building block"""
         doca = doca_ofed()
         self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
+r'''# DOCA OFED version 3.3.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -80,7 +48,7 @@ RUN apt-get update -y && \
 RUN mkdir -p /usr/share/keyrings && \
     rm -f /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
     wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor -o /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.gpg] https://linux.mellanox.com/public/repo/doca/3.2.0/ubuntu22.04/arm64-sbsa/ ./" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.gpg] https://linux.mellanox.com/public/repo/doca/3.3.0/ubuntu22.04/arm64-sbsa/ ./" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-providers \
@@ -102,7 +70,7 @@ RUN mkdir -p /usr/share/keyrings && \
         """Default doca_ofed building block"""
         doca = doca_ofed()
         self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
+r'''# DOCA OFED version 3.3.0
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -112,7 +80,7 @@ RUN apt-get update -y && \
 RUN mkdir -p /usr/share/keyrings && \
     rm -f /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
     wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | gpg --dearmor -o /usr/share/keyrings/GPG-KEY-Mellanox.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.gpg] https://linux.mellanox.com/public/repo/doca/3.2.0/ubuntu24.04/x86_64/ ./" >> /etc/apt/sources.list.d/hpccm.list && \
+    echo "deb [signed-by=/usr/share/keyrings/GPG-KEY-Mellanox.gpg] https://linux.mellanox.com/public/repo/doca/3.3.0/ubuntu24.04/x86_64/ ./" >> /etc/apt/sources.list.d/hpccm.list && \
     apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-providers \
@@ -132,18 +100,17 @@ RUN mkdir -p /usr/share/keyrings && \
     @docker
     def test_defaults_rockylinux9(self):
         """Default doca_ofed building block"""
-        doca = doca_ofed()
+        doca = doca_ofed(_nogpgcheck=True)
         self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
+r'''# DOCA OFED version 3.3.0
 RUN yum install -y \
         ca-certificates \
         gnupg \
         wget && \
     rm -rf /var/cache/yum/*
-RUN rpm --import https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub && \
-    yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.2.0/rhel9/x86_64 && \
-    yum install -y \
+RUN yum install -y dnf-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.3.0/rhel9/x86_64 && \
+    yum install -y --nogpgcheck \
         libibumad \
         libibverbs \
         libibverbs-utils \
@@ -157,16 +124,16 @@ RUN rpm --import https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pu
     @docker
     def test_defaults_rockylinux10(self):
         """Default doca_ofed building block"""
-        doca = doca_ofed()
+        doca = doca_ofed(_nogpgcheck=True)
         self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
+r'''# DOCA OFED version 3.3.0
 RUN yum install -y \
         ca-certificates \
         gnupg \
         wget && \
     rm -rf /var/cache/yum/*
 RUN yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.2.0/rhel10/x86_64 && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.3.0/rhel10/x86_64 && \
     yum install -y --nogpgcheck \
         libibumad \
         libibverbs \
@@ -181,18 +148,17 @@ RUN yum install -y dnf-utils && \
     @docker
     def test_defaults_rockylinux8(self):
         """Default doca_ofed building block"""
-        doca = doca_ofed()
+        doca = doca_ofed(_nogpgcheck=True)
         self.assertMultiLineEqual(str(doca),
-r'''# DOCA OFED version 3.2.0
+r'''# DOCA OFED version 3.3.0
 RUN yum install -y \
         ca-certificates \
         gnupg \
         wget && \
     rm -rf /var/cache/yum/*
-RUN rpm --import https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub && \
-    yum install -y dnf-utils && \
-    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.2.0/rhel8/x86_64 && \
-    yum install -y \
+RUN yum install -y dnf-utils && \
+    yum-config-manager --add-repo https://linux.mellanox.com/public/repo/doca/3.3.0/rhel8/x86_64 && \
+    yum install -y --nogpgcheck \
         libibumad \
         libibverbs \
         libibverbs-utils \


### PR DESCRIPTION
## Pull Request Description

Add undocumented option to the doca_ofed building disable GPG checks for RPM-based distributions

Also bump default the default version to 3.3.0

## Author Checklist
* [x] Updated documentation (`pydocmd generate`) if any docstrings have been modified
* [x] Passes all unit tests
